### PR TITLE
Fix login redirect issue and check supabase config

### DIFF
--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -13,7 +13,7 @@ export default function Dashboard() {
       } = await supabase.auth.getSession();
 
       if (!session) {
-        router.push('/login');
+        router.replace('/login');
         return;
       }
 
@@ -25,7 +25,7 @@ export default function Dashboard() {
 
   const handleSignOut = async () => {
     await supabase.auth.signOut();
-    router.push('/login');
+    router.replace('/login');
   };
 
   return (

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -10,17 +10,18 @@ export default function Login() {
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    const { error } = await supabase.auth.signInWithPassword({
+    const { data, error } = await supabase.auth.signInWithPassword({
       email,
       password,
     });
 
-    if (error) {
-      alert('Login failed: ' + error.message);
-    } else {
-      alert('Login successful!');
-      router.push('/dashboard');
+    if (error || !data.session) {
+      alert('Login failed: ' + (error?.message || 'No session returned'));
+      return;
     }
+
+    alert('Login successful!');
+    await router.push('/dashboard');
   };
 
   return (

--- a/utils/supabaseClient.ts
+++ b/utils/supabaseClient.ts
@@ -1,6 +1,11 @@
 import { createClient } from '@supabase/supabase-js';
 
-export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  console.error('Supabase environment variables are missing.');
+  throw new Error('Supabase is not configured');
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- redirect back to login using router.replace to avoid navigation history buildup
- validate Supabase environment variables and throw a clear error if missing
- handle missing session on login and await dashboard navigation

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d301195fc8325b24af4eb296d2b8c