### PR TITLE
Improve modal responsiveness

### DIFF
--- a/components/AddCategoryModal.tsx
+++ b/components/AddCategoryModal.tsx
@@ -56,6 +56,7 @@ export default function AddCategoryModal({ onClose, onCreated, category, sortOrd
         justifyContent: 'center',
         alignItems: 'center',
         padding: '1rem',
+        // Keep the overlay locked vertically with no horizontal scroll
         overflowX: 'hidden',
         overflowY: 'auto',
         zIndex: 1000,
@@ -66,7 +67,8 @@ export default function AddCategoryModal({ onClose, onCreated, category, sortOrd
           background: 'white',
           padding: '2rem',
           width: '100%',
-          maxWidth: '500px',
+          // Cap width to the viewport so content never forces horizontal scroll
+          maxWidth: 'min(500px, 100vw)',
           position: 'relative',
           overflowX: 'hidden',
           boxSizing: 'border-box',

--- a/components/AddItemModal.tsx
+++ b/components/AddItemModal.tsx
@@ -203,6 +203,7 @@ export default function AddItemModal({
         justifyContent: 'center',
         alignItems: 'center',
         padding: '1rem',
+        // Disable any side-to-side scrolling of the overlay itself
         overflowX: 'hidden',
         overflowY: 'auto',
         zIndex: 1000,
@@ -213,7 +214,8 @@ export default function AddItemModal({
           background: 'white',
           padding: '2rem',
           width: '100%',
-          maxWidth: '500px',
+          // Prevent the modal from ever exceeding the viewport width
+          maxWidth: 'min(500px, 100vw)',
           position: 'relative',
           overflowX: 'hidden',
           boxSizing: 'border-box',
@@ -295,6 +297,7 @@ export default function AddItemModal({
                 setImageFile(file);
                 setImagePreview(file ? URL.createObjectURL(file) : null);
               }}
+              style={{ width: '100%' }}
             />
             <small>Images should be square for best results.</small>
             {imagePreview && (
@@ -302,7 +305,7 @@ export default function AddItemModal({
                 <img
                   src={imagePreview}
                   alt="Preview"
-                  style={{ height: '100px', objectFit: 'cover' }}
+                  style={{ height: '100px', width: '100%', objectFit: 'cover' }}
                 />
                 <div>
                   <button


### PR DESCRIPTION
## Summary
- prevent horizontal scrolling in AddItemModal and AddCategoryModal
- make images and fields responsive

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d40fe73a88325bcc826c998bc1957