### PR TITLE
Fix edit item modal trigger

### DIFF
--- a/pages/dashboard/menu-builder.tsx
+++ b/pages/dashboard/menu-builder.tsx
@@ -199,6 +199,7 @@ export default function MenuBuilder() {
                                   setDefaultCategoryId(null);
                                   setShowAddModal(true);
                                 }}
+                                onPointerDown={(e) => e.stopPropagation()}
                                 style={{ cursor: 'grab', padding: '0.25rem 0' }}
                               >
                                 <strong>{item.name}</strong> – ${item.price.toFixed(2)}<br />


### PR DESCRIPTION
## Summary
- prevent drag events from blocking item click in menu builder

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d5a4e2d08832598383627487d9da4