### PR TITLE
Fix menu item save with missing tasks

### DIFF
--- a/components/AddItemModal.tsx
+++ b/components/AddItemModal.tsx
@@ -138,6 +138,9 @@ export default function AddItemModal({
       uploadedUrl = urlData.publicUrl;
     }
 
+    // Default tasks array if not provided
+    const tasks = item?.tasks ?? [];
+
     // Decide whether to insert a new item or update an existing one
     const { data, error } = await (item
       ? supabase
@@ -151,6 +154,7 @@ export default function AddItemModal({
             vegetarian,
             image_url: uploadedUrl,
             category_id: selectedCategories[0] || null,
+            tasks,
           })
           .eq('id', item.id)
           .select()
@@ -167,6 +171,7 @@ export default function AddItemModal({
               vegetarian,
               image_url: uploadedUrl,
               category_id: selectedCategories[0] || null,
+              tasks,
             },
           ])
           .select()


### PR DESCRIPTION
## Summary
- handle undefined `tasks` when inserting or updating menu items

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d66bbbd5483258ac464b750bacc01