### PR TITLE
Fix menu builder tasks

### DIFF
--- a/components/AddCategoryModal.tsx
+++ b/components/AddCategoryModal.tsx
@@ -8,9 +8,17 @@ interface AddCategoryModalProps {
   category?: any;
   /** number of categories to set sort order for new ones */
   sortOrder?: number;
+  /** restaurant the category belongs to */
+  restaurantId: number;
 }
 
-export default function AddCategoryModal({ onClose, onCreated, category, sortOrder = 0 }: AddCategoryModalProps) {
+export default function AddCategoryModal({
+  onClose,
+  onCreated,
+  category,
+  sortOrder = 0,
+  restaurantId,
+}: AddCategoryModalProps) {
   const [name, setName] = useState(category?.name || '');
   const [description, setDescription] = useState(category?.description || '');
 
@@ -30,7 +38,7 @@ export default function AddCategoryModal({ onClose, onCreated, category, sortOrd
       err = error;
     } else {
       const { error } = await supabase.from('menu_categories').insert([
-        { name, description, sort_order: sortOrder },
+        { name, description, sort_order: sortOrder, restaurant_id: restaurantId },
       ]);
       err = error;
     }

--- a/components/AddItemModal.tsx
+++ b/components/AddItemModal.tsx
@@ -176,6 +176,7 @@ export default function AddItemModal({
     const categoryId =
       rawCat && typeof rawCat === 'object' ? (rawCat as any).id : rawCat ?? null;
     const itemData = {
+      restaurant_id: restaurantId,
       name,
       description,
       price: parseFloat(price),

--- a/pages/dashboard/menu-builder.tsx
+++ b/pages/dashboard/menu-builder.tsx
@@ -129,8 +129,8 @@ export default function MenuBuilder() {
     if (catError || itemsError) {
       console.error('Error fetching data:', catError || itemsError);
     } else {
-      setCategories(categoriesData);
-      setItems(itemsData);
+      setCategories(categoriesData || []);
+      setItems(itemsData || []);
     }
 
     setLoading(false);
@@ -155,6 +155,8 @@ export default function MenuBuilder() {
 
       {loading ? (
         <p>Loading...</p>
+      ) : categories.length === 0 ? (
+        <p>No menu categories found. Use "Add New Category" to get started.</p>
       ) : (
         <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleCategoryDragEnd}>
           <SortableContext items={categories.map((c) => c.id)} strategy={verticalListSortingStrategy}>
@@ -263,6 +265,7 @@ export default function MenuBuilder() {
         <AddCategoryModal
           category={editCategory || undefined}
           sortOrder={categories.length}
+          restaurantId={restaurantId!}
           onClose={() => {
             setShowAddCatModal(false);
             setEditCategory(null);


### PR DESCRIPTION
## Summary
- add `restaurantId` prop to category modal
- attach `restaurant_id` when adding menu categories/items
- show a friendly message when a restaurant has no categories

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: next not found)*
- `npx tsc --noEmit` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686d7c485060832580bee2024af00efb