### PR TITLE
Refactor AddItemModal image upload UI

### DIFF
--- a/components/AddItemModal.tsx
+++ b/components/AddItemModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useRef, useMemo } from 'react';
+import { UploadCloud, Trash2 } from 'lucide-react';
 import Cropper from 'react-easy-crop';
 import type { Area } from 'react-easy-crop';
 import { supabase } from '../utils/supabaseClient';
@@ -74,6 +75,7 @@ export default function AddItemModal({
 
   const nameInputRef = useRef<HTMLInputElement | null>(null);
   const overlayRef = useRef<HTMLDivElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const filteredCategories = useMemo(
     () => categories.filter((c) => c.restaurant_id === restaurantId),
@@ -432,66 +434,82 @@ export default function AddItemModal({
           {/* Image upload field */}
           <div style={{ marginBottom: '1rem' }}>
             <div
+              role="button"
+              tabIndex={0}
+              aria-label={imagePreview ? 'Change image' : 'Upload image'}
+              onClick={() => fileInputRef.current?.click()}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  fileInputRef.current?.click();
+                }
+              }}
               style={{
+                marginTop: '0.5rem',
+                width: '40vw',
+                height: '40vw',
+                maxWidth: '200px',
+                maxHeight: '200px',
+                overflow: 'hidden',
                 display: 'flex',
                 alignItems: 'center',
-                gap: '0.5rem',
-                marginBottom: '0.5rem',
-                flexWrap: 'wrap',
+                justifyContent: 'center',
+                marginLeft: 'auto',
+                marginRight: 'auto',
+                borderRadius: '0.5rem',
+                position: 'relative',
+                cursor: 'pointer',
+                background: '#f9f9f9',
+                border: '1px dashed #ccc',
               }}
             >
-              <label htmlFor="image-input" style={{ whiteSpace: 'nowrap' }}>
-                Select Image
-              </label>
-              <input
-                id="image-input"
-                type="file"
-                accept="image/*"
-                onChange={handleFileChange}
-              />
-              {imagePreview && (
-                <button
-                  type="button"
-                  onClick={() => {
-                    setImageFile(null);
-                    setImagePreview(null);
-                  }}
-                  style={{ whiteSpace: 'nowrap' }}
-                >
-                  Remove image
-                </button>
+              {imagePreview ? (
+                <>
+                  <img
+                    src={imagePreview}
+                    alt="Preview"
+                    style={{
+                      width: '100%',
+                      height: '100%',
+                      objectFit: 'cover',
+                      borderRadius: '0.5rem',
+                    }}
+                  />
+                  <button
+                    type="button"
+                    aria-label="Remove image"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setImageFile(null);
+                      setImagePreview(null);
+                    }}
+                    style={{
+                      position: 'absolute',
+                      top: '4px',
+                      right: '4px',
+                      background: 'rgba(255,255,255,0.8)',
+                      border: 'none',
+                      borderRadius: '50%',
+                      padding: '2px',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    <Trash2 size={16} />
+                  </button>
+                </>
+              ) : (
+                <UploadCloud size={32} aria-hidden="true" />
               )}
             </div>
+            <input
+              ref={fileInputRef}
+              id="image-input"
+              type="file"
+              accept="image/*"
+              onChange={handleFileChange}
+              style={{ display: 'none' }}
+            />
             <small>Images should be square for best results.</small>
-            {imagePreview && (
-              <div
-                style={{
-                  marginTop: '0.5rem',
-                  width: '40vw',
-                  height: '40vw',
-                  maxWidth: '200px',
-                  maxHeight: '200px',
-                  overflow: 'hidden',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  marginLeft: 'auto',
-                  marginRight: 'auto',
-                  borderRadius: '0.5rem',
-                }}
-              >
-                <img
-                  src={imagePreview}
-                  alt="Preview"
-                  style={{
-                    width: '100%',
-                    height: '100%',
-                    objectFit: 'cover',
-                    borderRadius: '0.5rem',
-                  }}
-                />
-              </div>
-            )}
           </div>
           <div style={{ marginBottom: '0.5rem' }}>
             <label>

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@supabase/auth-helpers-react": "^0.3.0",
         "@supabase/supabase-js": "^2.0.0",
         "axios": "^1.4.0",
+        "lucide-react": "^0.274.0",
         "next": "13.4.12",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -1320,6 +1321,15 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
+    },
+    "node_modules/lucide-react": {
+      "version": "0.274.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.274.0.tgz",
+      "integrity": "sha512-qiWcojRXEwDiSimMX1+arnxha+ROJzZjJaVvCC0rsG6a9pUPjZePXSq7em4ZKMp0NDm1hyzPNkM7UaWC3LU2AA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "next": "13.4.12",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-easy-crop": "^4.4.0"
+    "react-easy-crop": "^4.4.0",
+    "lucide-react": "^0.274.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.10",


### PR DESCRIPTION
## Summary
- simplify AddItemModal image picker
- show an upload icon when no image selected
- overlay a trash icon to remove the image
- add lucide-react icon package

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686dafbd1a308325b6f28c93994dfc1d