### PR TITLE
Restore AddItemModal form

### DIFF
--- a/components/AddItemModal.tsx
+++ b/components/AddItemModal.tsx
@@ -6,7 +6,6 @@ interface AddItemModalProps {
 }
 
 export default function AddItemModal({ showModal, onClose }: AddItemModalProps) {
-  const DEBUG_MODAL = true; // temporary debug flag
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [imageUrl, setImageUrl] = useState<string | null>(null);
@@ -31,30 +30,6 @@ export default function AddItemModal({ showModal, onClose }: AddItemModalProps) 
   };
 
   if (!showModal) return null;
-
-  if (DEBUG_MODAL) {
-    return (
-      <div
-        style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          right: 0,
-          bottom: 0,
-          background: 'rgba(255,0,0,0.5)',
-          zIndex: 9999,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          color: '#fff',
-          fontSize: '2rem',
-        }}
-      >
-        TEST MODAL
-      </div>
-    );
-  }
-
   return (
     <div
       ref={overlayRef}
@@ -63,7 +38,21 @@ export default function AddItemModal({ showModal, onClose }: AddItemModalProps) 
           onClose();
         }
       }}
-      className="fixed inset-0 bg-black bg-opacity-40 z-50 flex items-center justify-center"
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: 'rgba(0,0,0,0.5)',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        padding: '1rem',
+        overflowX: 'hidden',
+        overflowY: 'auto',
+        zIndex: 1000,
+      }}
     >
       <div
         onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
## Summary
- bring back AddItemModal form now that overlay works

## Testing
- `npm install`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_686e8780afa083258882b13d2887d917