### PR TITLE
Fix overlay colors

### DIFF
--- a/components/AddCategoryModal.tsx
+++ b/components/AddCategoryModal.tsx
@@ -53,22 +53,7 @@ export default function AddCategoryModal({
 
   return (
     <div
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        backgroundColor: 'rgba(0,0,0,0.5)',
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        padding: '1rem',
-        // Keep the overlay locked vertically with no horizontal scroll
-        overflowX: 'hidden',
-        overflowY: 'auto',
-        zIndex: 1000,
-      }}
+      className="fixed inset-0 bg-black bg-opacity-40 flex justify-center items-center p-4 overflow-x-hidden overflow-y-auto z-[1000]"
     >
       <div
         style={{

--- a/components/AddItemModal.tsx
+++ b/components/AddItemModal.tsx
@@ -38,21 +38,7 @@ export default function AddItemModal({ showModal, onClose }: AddItemModalProps) 
           onClose();
         }
       }}
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        backgroundColor: 'rgba(0,0,0,0.5)',
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        padding: '1rem',
-        overflowX: 'hidden',
-        overflowY: 'auto',
-        zIndex: 1000,
-      }}
+      className="fixed inset-0 bg-black bg-opacity-40 flex justify-center items-center p-4 overflow-x-hidden overflow-y-auto z-[1000]"
     >
       <div
         onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
## Summary
- use semi-transparent black for AddItemModal overlay
- use semi-transparent black for AddCategoryModal overlay

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686e890c8c908325ba96f6b92ac59e10