### PR TITLE
Fix modal overlay close behavior

### DIFF
--- a/components/AddCategoryModal.tsx
+++ b/components/AddCategoryModal.tsx
@@ -53,9 +53,15 @@ export default function AddCategoryModal({
 
   return (
     <div
+      onClick={(e) => {
+        if (e.target === e.currentTarget) {
+          onClose();
+        }
+      }}
       className="fixed inset-0 bg-black bg-opacity-40 flex justify-center items-center p-4 overflow-x-hidden overflow-y-auto z-[1000]"
     >
       <div
+        onClick={(e) => e.stopPropagation()}
         style={{
           background: 'white',
           padding: '2rem',


### PR DESCRIPTION
## Summary
- allow AddCategoryModal to close when clicking the overlay

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e8bcf04588325ab60181193698b50