### PR TITLE
Add debug modal styles and state logging

### DIFF
--- a/components/AddCategoryModal.tsx
+++ b/components/AddCategoryModal.tsx
@@ -58,7 +58,7 @@ export default function AddCategoryModal({
           onClose();
         }
       }}
-      className="fixed inset-0 bg-black bg-opacity-40 flex justify-center items-center p-4 overflow-x-hidden overflow-y-auto z-[1000] font-sans"
+      className="fixed inset-0 bg-black bg-opacity-40 flex justify-center items-center p-4 overflow-x-hidden overflow-y-auto z-[1000] font-sans debug-modal"
     >
       <div
         onClick={(e) => e.stopPropagation()}

--- a/components/AddItemModal.tsx
+++ b/components/AddItemModal.tsx
@@ -101,7 +101,7 @@ export default function AddItemModal({ showModal, onClose }: AddItemModalProps) 
           onClose();
         }
       }}
-      className="fixed inset-0 bg-black bg-opacity-40 flex justify-center items-center p-4 overflow-x-hidden overflow-y-auto z-[1000] font-sans"
+      className="fixed inset-0 bg-black bg-opacity-40 flex justify-center items-center p-4 overflow-x-hidden overflow-y-auto z-[1000] font-sans debug-modal"
     >
       <div
         onClick={(e) => e.stopPropagation()}

--- a/pages/dashboard/menu-builder.tsx
+++ b/pages/dashboard/menu-builder.tsx
@@ -147,6 +147,7 @@ export default function MenuBuilder() {
         onClick={() => {
           setEditCategory(null);
           setShowAddCatModal(true);
+          console.log('showAddCatModal after click:', showAddCatModal);
         }}
         style={{ margin: '1rem 0' }}
       >
@@ -172,6 +173,7 @@ export default function MenuBuilder() {
                     onClick={() => {
                       setEditCategory(cat);
                       setShowAddCatModal(true);
+                      console.log('showAddCatModal after click:', showAddCatModal);
                     }}
                     onPointerDown={(e) => e.stopPropagation()}
                     style={{ marginBottom: '0.5rem', cursor: 'pointer' }}
@@ -180,9 +182,10 @@ export default function MenuBuilder() {
                   </button>
                   <button
                     onClick={() => {
-                      setDefaultCategoryId(cat.id);
-                      setEditItem(null);
-                      setShowAddModal(true);
+                     setDefaultCategoryId(cat.id);
+                     setEditItem(null);
+                     setShowAddModal(true);
+                      console.log('showAddModal after click:', showAddModal);
                     }}
                     onPointerDown={(e) => e.stopPropagation()}
                     style={{ marginBottom: '1rem', cursor: 'pointer' }}
@@ -213,6 +216,7 @@ export default function MenuBuilder() {
                                   setEditItem(item);
                                   setDefaultCategoryId(null);
                                   setShowAddModal(true);
+                                  console.log('showAddModal after click:', showAddModal);
                                 }}
                                 onPointerDown={(e) => e.stopPropagation()}
                                 style={{ cursor: 'grab', padding: '0.25rem 0' }}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -6,3 +6,11 @@
 body {
   font-family: 'Inter', sans-serif;
 }
+
+/* Debug modal overlay styles */
+.debug-modal {
+  z-index: 9999 !important;
+  position: fixed !important;
+  inset: 0 !important;
+  opacity: 1 !important;
+  display: flex !important;}


### PR DESCRIPTION
## Summary
- ensure modals have a `debug-modal` CSS class for easier troubleshooting
- log modal visibility state when buttons are clicked in the menu builder

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686eb0943d048325a559cae28a9369a5