### PR TITLE
Add item modal fields and supabase sync

### DIFF
--- a/__tests__/AddItemModal.test.tsx
+++ b/__tests__/AddItemModal.test.tsx
@@ -1,14 +1,34 @@
 import { render, screen } from '@testing-library/react'
 import AddItemModal from '../components/AddItemModal'
 
+process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost'
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'key'
+
+jest.mock('../utils/supabaseClient', () => {
+  const chain = {
+    select: jest.fn(() => chain),
+    eq: jest.fn(() => chain),
+    order: jest.fn(async () => ({ data: [], error: null })),
+    insert: jest.fn(() => chain),
+    update: jest.fn(() => chain),
+    delete: jest.fn(() => chain),
+    single: jest.fn(async () => ({ data: {}, error: null })),
+  };
+  return { supabase: { from: jest.fn(() => chain) } };
+});
+
 describe('AddItemModal', () => {
   it('renders when showModal is true', () => {
-    render(<AddItemModal showModal={true} onClose={() => {}} />)
+    render(
+      <AddItemModal showModal={true} onClose={() => {}} restaurantId={1} />
+    )
     expect(screen.getByText('Edit Item')).toBeInTheDocument()
   })
 
   it('does not render when showModal is false', () => {
-    const { container } = render(<AddItemModal showModal={false} onClose={() => {}} />)
+    const { container } = render(
+      <AddItemModal showModal={false} onClose={() => {}} restaurantId={1} />
+    )
     expect(container.firstChild).toBeNull()
   })
 })

--- a/pages/dashboard/menu-builder.tsx
+++ b/pages/dashboard/menu-builder.tsx
@@ -254,6 +254,10 @@ export default function MenuBuilder() {
       </div>
       <AddItemModal
         showModal={showAddModal}
+        restaurantId={restaurantId!}
+        defaultCategoryId={defaultCategoryId || undefined}
+        item={editItem || undefined}
+        onSaved={() => restaurantId && fetchData(restaurantId)}
         onClose={() => {
           setShowAddModal(false);
           setEditItem(null);


### PR DESCRIPTION
## Summary
- update AddItemModal to load categories from Supabase and include price and dietary flags
- send all item fields to Supabase on save
- pass new props from menu-builder
- adjust modal tests for new props and mock Supabase

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686eb4bdae6c8325af534eef7a0b1da8