### PR TITLE
Add MultiSelectDropdown for categories

### DIFF
--- a/__tests__/AddItemModal.test.tsx
+++ b/__tests__/AddItemModal.test.tsx
@@ -1,6 +1,26 @@
 import { render, screen } from '@testing-library/react'
 import AddItemModal from '../components/AddItemModal'
 
+// Mock supabase client to avoid ESM import issues during tests
+jest.mock('../utils/supabaseClient', () => ({
+  supabase: {
+    from: jest.fn(() => ({
+      select: jest.fn(),
+      update: jest.fn(),
+      insert: jest.fn(),
+      delete: jest.fn(),
+      eq: jest.fn(),
+      single: jest.fn(),
+    })),
+    storage: {
+      from: jest.fn(() => ({
+        upload: jest.fn(),
+        getPublicUrl: jest.fn(() => ({ publicUrl: '' })),
+      })),
+    },
+  },
+}))
+
 describe('AddItemModal', () => {
   const categories = [
     { id: 1, name: 'Breakfast' },
@@ -12,6 +32,7 @@ describe('AddItemModal', () => {
       <AddItemModal
         showModal={true}
         onClose={() => {}}
+        onCreated={() => {}}
         categories={categories}
       />
     )
@@ -23,6 +44,7 @@ describe('AddItemModal', () => {
       <AddItemModal
         showModal={false}
         onClose={() => {}}
+        onCreated={() => {}}
         categories={categories}
       />
     )

--- a/__tests__/AddItemModal.test.tsx
+++ b/__tests__/AddItemModal.test.tsx
@@ -2,13 +2,30 @@ import { render, screen } from '@testing-library/react'
 import AddItemModal from '../components/AddItemModal'
 
 describe('AddItemModal', () => {
+  const categories = [
+    { id: 1, name: 'Breakfast' },
+    { id: 2, name: 'Lunch' },
+  ]
+
   it('renders when showModal is true', () => {
-    render(<AddItemModal showModal={true} onClose={() => {}} />)
+    render(
+      <AddItemModal
+        showModal={true}
+        onClose={() => {}}
+        categories={categories}
+      />
+    )
     expect(screen.getByText('Edit Item')).toBeInTheDocument()
   })
 
   it('does not render when showModal is false', () => {
-    const { container } = render(<AddItemModal showModal={false} onClose={() => {}} />)
+    const { container } = render(
+      <AddItemModal
+        showModal={false}
+        onClose={() => {}}
+        categories={categories}
+      />
+    )
     expect(container.firstChild).toBeNull()
   })
 })

--- a/components/AddItemModal.tsx
+++ b/components/AddItemModal.tsx
@@ -1,14 +1,29 @@
 import { useEffect, useRef, useState } from 'react';
+import MultiSelectDropdown from './MultiSelectDropdown';
 import Cropper, { Area } from 'react-easy-crop';
 import { CloudArrowUpIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import { Trash2 } from 'lucide-react';
 
+interface Category {
+  id: number;
+  name: string;
+}
+
 interface AddItemModalProps {
   showModal: boolean;
   onClose: () => void;
+  /** list of categories to choose from */
+  categories?: Category[];
+  /** optionally preselect a single category */
+  defaultCategoryId?: number;
 }
 
-export default function AddItemModal({ showModal, onClose }: AddItemModalProps) {
+export default function AddItemModal({
+  showModal,
+  onClose,
+  categories = [],
+  defaultCategoryId,
+}: AddItemModalProps) {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [imageUrl, setImageUrl] = useState<string | null>(null);
@@ -19,6 +34,7 @@ export default function AddItemModal({ showModal, onClose }: AddItemModalProps) 
   const [crop, setCrop] = useState({ x: 0, y: 0 });
   const [zoom, setZoom] = useState(1);
   const croppedAreaPixels = useRef<Area | null>(null);
+  const [selectedCategories, setSelectedCategories] = useState<number[]>([]);
 
   const createImage = (url: string): Promise<HTMLImageElement> => {
     return new Promise((resolve, reject) => {
@@ -62,6 +78,12 @@ export default function AddItemModal({ showModal, onClose }: AddItemModalProps) 
     }
   }, [showModal]);
 
+  useEffect(() => {
+    if (showModal && defaultCategoryId) {
+      setSelectedCategories([defaultCategoryId]);
+    }
+  }, [showModal, defaultCategoryId]);
+
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
@@ -82,6 +104,10 @@ export default function AddItemModal({ showModal, onClose }: AddItemModalProps) 
     }
     setCropping(false);
     setTempImage(null);
+  };
+
+  const handleCategoryChange = (values: number[]) => {
+    setSelectedCategories(values);
   };
 
   const handleRemoveImage = (e: React.MouseEvent) => {
@@ -155,19 +181,27 @@ export default function AddItemModal({ showModal, onClose }: AddItemModalProps) 
                 <CloudArrowUpIcon className="w-8 h-8 text-gray-400" />
               )}
             </div>
-            <input
-              type="file"
-              accept="image/*"
-              ref={fileRef}
-              onChange={handleFileChange}
-              className="hidden"
-            />
-          </div>
-          <div className="text-right mt-6 space-x-2">
-            <button
-              type="button"
-              onClick={onClose}
-              className="px-4 py-2 border border-[#b91c1c] text-[#b91c1c] rounded hover:bg-[#b91c1c]/10"
+          <input
+            type="file"
+            accept="image/*"
+            ref={fileRef}
+            onChange={handleFileChange}
+            className="hidden"
+          />
+        </div>
+        {categories && categories.length > 0 && (
+          <MultiSelectDropdown
+            options={categories}
+            selected={selectedCategories}
+            onChange={handleCategoryChange}
+            placeholder="Select categories"
+          />
+        )}
+        <div className="text-right mt-6 space-x-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 border border-[#b91c1c] text-[#b91c1c] rounded hover:bg-[#b91c1c]/10"
             >
               Cancel
             </button>

--- a/components/MultiSelectDropdown.tsx
+++ b/components/MultiSelectDropdown.tsx
@@ -1,0 +1,75 @@
+import { useState, useRef, useEffect } from 'react';
+
+interface Option {
+  id: number;
+  name: string;
+}
+
+interface MultiSelectDropdownProps {
+  options: Option[];
+  selected: number[];
+  onChange: (selected: number[]) => void;
+  placeholder?: string;
+}
+
+export default function MultiSelectDropdown({
+  options,
+  selected,
+  onChange,
+  placeholder = 'Select categories',
+}: MultiSelectDropdownProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    if (open) {
+      document.addEventListener('mousedown', handleClick);
+    }
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  const toggle = (id: number) => {
+    if (selected.includes(id)) {
+      onChange(selected.filter((s) => s !== id));
+    } else {
+      onChange([...selected, id]);
+    }
+  };
+
+  const label = selected
+    .map((id) => options.find((o) => o.id === id)?.name)
+    .filter(Boolean)
+    .join(', ');
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="w-full border border-gray-300 rounded p-2 text-left"
+      >
+        {label || placeholder}
+      </button>
+      {open && (
+        <div className="absolute z-10 mt-1 w-full bg-white border border-gray-300 rounded shadow">
+          {options.map((opt) => (
+            <label key={opt.id} className="flex items-center px-2 py-1 space-x-2 hover:bg-gray-50">
+              <input
+                type="checkbox"
+                className="form-checkbox"
+                checked={selected.includes(opt.id)}
+                onChange={() => toggle(opt.id)}
+              />
+              <span>{opt.name}</span>
+            </label>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/MultiSelectDropdown.tsx
+++ b/components/MultiSelectDropdown.tsx
@@ -1,5 +1,8 @@
 import { useState, useRef, useEffect } from 'react';
 
+// Simple dropdown that allows selecting multiple options via checkboxes.
+// The parent component controls the selected ids via the `selected` prop.
+
 interface Option {
   id: number;
   name: string;

--- a/pages/dashboard/menu-builder.tsx
+++ b/pages/dashboard/menu-builder.tsx
@@ -258,6 +258,8 @@ export default function MenuBuilder() {
           setShowAddModal(false);
           setEditItem(null);
         }}
+        categories={categories}
+        defaultCategoryId={defaultCategoryId || undefined}
       />
       {showAddCatModal && (
         <AddCategoryModal

--- a/pages/dashboard/menu-builder.tsx
+++ b/pages/dashboard/menu-builder.tsx
@@ -258,6 +258,8 @@ export default function MenuBuilder() {
           setShowAddModal(false);
           setEditItem(null);
         }}
+        onCreated={() => restaurantId && fetchData(restaurantId!)}
+        item={editItem || undefined}
         categories={categories}
         defaultCategoryId={defaultCategoryId || undefined}
       />


### PR DESCRIPTION
## Summary
- implement `MultiSelectDropdown` component
- allow selecting multiple categories when adding an item
- wire dropdown into `AddItemModal`
- pass categories to the modal from menu builder
- update tests for new props

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686eb9f6c8cc8325badc79d10ea87b88