### PR TITLE
Implement read-only Main Menu with view modal

### DIFF
--- a/components/ViewItemModal.tsx
+++ b/components/ViewItemModal.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from 'react';
+import { XMarkIcon } from '@heroicons/react/24/outline';
+
+interface ViewItemModalProps {
+  showModal: boolean;
+  onClose: () => void;
+  item: {
+    name: string;
+    description?: string;
+    price: number;
+    image_url?: string | null;
+  } | null;
+}
+
+export default function ViewItemModal({ showModal, onClose, item }: ViewItemModalProps) {
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (showModal) {
+      const original = document.body.style.overflow;
+      document.body.style.overflow = 'hidden';
+      return () => {
+        document.body.style.overflow = original;
+      };
+    }
+  }, [showModal]);
+
+  if (!showModal || !item) return null;
+
+  return (
+    <div
+      ref={overlayRef}
+      onClick={(e) => {
+        if (e.target === overlayRef.current) onClose();
+      }}
+      className="fixed inset-0 bg-black bg-opacity-40 flex justify-center items-center p-4 overflow-x-hidden overflow-y-auto z-[1000] font-sans"
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="bg-white rounded-xl shadow-lg p-6 sm:p-8 max-w-md w-full relative max-h-[90vh] overflow-y-auto"
+      >
+        <button
+          type="button"
+          aria-label="Close"
+          onClick={onClose}
+          className="absolute right-2 top-2 text-gray-500 hover:text-gray-700"
+        >
+          <XMarkIcon className="w-5 h-5" />
+        </button>
+        <div className="space-y-4">
+          {item.image_url && (
+            <img src={item.image_url} alt={item.name} className="w-full h-48 object-cover rounded" />
+          )}
+          <h2 className="text-2xl font-bold">{item.name}</h2>
+          {item.description && <p className="text-gray-700">{item.description}</p>}
+          <p className="text-lg font-semibold">${item.price.toFixed(2)}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/pages/dashboard/menu-builder.tsx
+++ b/pages/dashboard/menu-builder.tsx
@@ -21,6 +21,7 @@ import AddCategoryModal from '../../components/AddCategoryModal';
 import Toast from '../../components/Toast';
 import ConfirmModal from '../../components/ConfirmModal';
 import DraftCategoryModal from '../../components/DraftCategoryModal';
+import ViewItemModal from '../../components/ViewItemModal';
 import DashboardLayout from '../../components/DashboardLayout';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
@@ -99,6 +100,8 @@ export default function MenuBuilder() {
   const [draftItem, setDraftItem] = useState<any | null>(null);
   const [showDraftCategoryModal, setShowDraftCategoryModal] = useState(false);
   const [draftCategory, setDraftCategory] = useState<any | null>(null);
+  const [showViewModal, setShowViewModal] = useState(false);
+  const [viewItem, setViewItem] = useState<any | null>(null);
   const [confirmState, setConfirmState] = useState<
     | { title: string; message: string; action: () => void }
     | null
@@ -520,7 +523,7 @@ export default function MenuBuilder() {
         <button onClick={collapseAll} className="p-2 rounded hover:bg-gray-200" aria-label="Collapse all">
           <ChevronUpIcon className="w-5 h-5" />
         </button>
-        {activeTab !== 'build' && (
+        {activeTab !== 'build' && activeTab !== 'menu' && (
           <button
             onClick={() => {
               setEditCategory(null);
@@ -531,15 +534,7 @@ export default function MenuBuilder() {
             <PlusCircleIcon className="w-5 h-5 mr-1" /> Add Category
           </button>
         )}
-        {activeTab === 'menu' && (
-          <button
-            onClick={publishLiveMenu}
-            disabled={!hasMenuChanges}
-            className="flex items-center bg-teal-600 text-white px-3 py-2 rounded-lg hover:bg-teal-700 disabled:opacity-50"
-          >
-            Publish Changes
-          </button>
-        )}
+        {/* Publish button hidden on Menu tab */}
       </div>
     </div>
 
@@ -599,29 +594,7 @@ export default function MenuBuilder() {
                           <ChevronUpIcon className="w-5 h-5" />
                         )}
                       </button>
-                      <button
-                        onClick={() => {
-                          setEditCategory(cat);
-                          setShowAddCatModal(true);
-                        }}
-                        onPointerDown={(e) => e.stopPropagation()}
-                        className="p-2 rounded hover:bg-gray-100"
-                        aria-label="Edit category"
-                      >
-                        <PencilSquareIcon className="w-5 h-5" />
-                      </button>
-                      <button
-                        onClick={() => {
-                          setDefaultCategoryId(cat.id);
-                          setEditItem(null);
-                          setShowAddModal(true);
-                        }}
-                        onPointerDown={(e) => e.stopPropagation()}
-                        className="p-2 rounded hover:bg-gray-100"
-                        aria-label="Add item"
-                      >
-                        <PlusCircleIcon className="w-5 h-5" />
-                      </button>
+                      {/* actions removed in read-only menu */}
                     </div>
                   </div>
                   {!collapsedCats.has(cat.id) && (
@@ -646,9 +619,8 @@ export default function MenuBuilder() {
                                 <SortableWrapper key={item.id} id={item.id}>
                                   <div
                                     onClick={() => {
-                                      setEditItem(item);
-                                      setDefaultCategoryId(null);
-                                      setShowAddModal(true);
+                                      setViewItem(item);
+                                      setShowViewModal(true);
                                     }}
                                     className="cursor-grab bg-gray-50 rounded-lg p-3 flex items-start justify-between"
                                   >
@@ -915,6 +887,14 @@ export default function MenuBuilder() {
         />
       )}
       <Toast message={toastMessage} onClose={() => setToastMessage('')} />
+      <ViewItemModal
+        showModal={showViewModal}
+        item={viewItem}
+        onClose={() => {
+          setShowViewModal(false);
+          setViewItem(null);
+        }}
+      />
     </DashboardLayout>
   );
 }


### PR DESCRIPTION
## Summary
- add `ViewItemModal` for read-only item display
- prevent editing actions on Main Menu
- show view modal when clicking items in Main Menu
- hide Add Category and Publish buttons on Main Menu
- fix build menu item modal state

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fdcc8f86c83258f3c19987ee01b6e