### PR TITLE
Implement addon management UI

### DIFF
--- a/components/AddonGroupModal.tsx
+++ b/components/AddonGroupModal.tsx
@@ -1,0 +1,224 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../utils/supabaseClient';
+
+interface AddonGroupModalProps {
+  show: boolean;
+  restaurantId: number;
+  group?: any;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+export default function AddonGroupModal({
+  show,
+  restaurantId,
+  group,
+  onClose,
+  onSaved,
+}: AddonGroupModalProps) {
+  const [name, setName] = useState(group?.name || '');
+  const [multipleChoice, setMultipleChoice] = useState<boolean>(!!group?.multiple_choice);
+  const [required, setRequired] = useState<boolean>(!!group?.required);
+  const [categories, setCategories] = useState<any[]>([]);
+  const [items, setItems] = useState<any[]>([]);
+  const [selectedCats, setSelectedCats] = useState<number[]>([]);
+  const [selectedItems, setSelectedItems] = useState<number[]>([]);
+  const [search, setSearch] = useState('');
+
+  useEffect(() => {
+    if (!show) return;
+    const load = async () => {
+      const { data: catData } = await supabase
+        .from('menu_categories')
+        .select('*')
+        .eq('restaurant_id', restaurantId)
+        .order('sort_order', { ascending: true });
+      setCategories(catData || []);
+      const { data: itemData } = await supabase
+        .from('menu_items')
+        .select('*')
+        .eq('restaurant_id', restaurantId);
+      setItems(itemData || []);
+      if (group) {
+        setName(group.name || '');
+        setMultipleChoice(!!group.multiple_choice);
+        setRequired(!!group.required);
+        const { data: links } = await supabase
+          .from('menu_item_addon_groups')
+          .select('item_id')
+          .eq('addon_group_id', group.id);
+        const itemIds = links?.map((l: any) => l.item_id) || [];
+        setSelectedItems(itemIds);
+        const catIds = Array.from(
+          new Set(
+            itemData
+              ?.filter((it: any) => itemIds.includes(it.id))
+              .map((it: any) => it.category_id)
+              .filter((v: any) => v)
+          )
+        );
+        setSelectedCats(catIds);
+      } else {
+        setName('');
+        setMultipleChoice(false);
+        setRequired(false);
+        setSelectedCats([]);
+        setSelectedItems([]);
+      }
+    };
+    load();
+  }, [show, restaurantId, group]);
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name) {
+      alert('Name is required');
+      return;
+    }
+    let groupId = group?.id;
+    if (group) {
+      const { error } = await supabase
+        .from('addon_groups')
+        .update({ name, multiple_choice: multipleChoice, required })
+        .eq('id', group.id);
+      if (error) {
+        alert('Failed to save: ' + error.message);
+        return;
+      }
+    } else {
+      const { data, error } = await supabase
+        .from('addon_groups')
+        .insert([{ name, multiple_choice: multipleChoice, required, restaurant_id: restaurantId }])
+        .select()
+        .single();
+      if (error) {
+        alert('Failed to save: ' + error.message);
+        return;
+      }
+      groupId = data?.id;
+    }
+
+    if (!groupId) return;
+
+    const catItemIds = items
+      .filter((it) => selectedCats.includes(it.category_id))
+      .map((it) => it.id);
+    const itemIds = Array.from(new Set([...selectedItems, ...catItemIds]));
+    await supabase.from('menu_item_addon_groups').delete().eq('addon_group_id', groupId);
+    if (itemIds.length) {
+      await supabase.from('menu_item_addon_groups').insert(
+        itemIds.map((id) => ({ item_id: id, addon_group_id: groupId }))
+      );
+    }
+    onSaved();
+    onClose();
+  };
+
+  if (!show) return null;
+
+  const filteredItems = items.filter((it) =>
+    it.name.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/40 flex items-center justify-center z-[1000]"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div className="bg-white rounded-xl p-6 max-w-lg w-full max-h-[90vh] overflow-y-auto">
+        <h3 className="text-xl font-semibold mb-4">{group ? 'Edit Add-on Category' : 'Add Add-on Category'}</h3>
+        <form onSubmit={handleSave} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">Name</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full border border-gray-300 rounded p-2"
+            />
+          </div>
+          <label className="flex items-center space-x-2 text-sm">
+            <input
+              type="checkbox"
+              checked={multipleChoice}
+              onChange={(e) => setMultipleChoice(e.target.checked)}
+            />
+            <span>Multiple Choice</span>
+          </label>
+          <label className="flex items-center space-x-2 text-sm">
+            <input
+              type="checkbox"
+              checked={required}
+              onChange={(e) => setRequired(e.target.checked)}
+            />
+            <span>Required</span>
+          </label>
+          <div>
+            <p className="font-semibold mb-1 text-sm">Assign to Categories</p>
+            <div className="space-y-1 max-h-32 overflow-y-auto border p-2 rounded">
+              {categories.map((c) => (
+                <label key={c.id} className="flex items-center space-x-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={selectedCats.includes(c.id)}
+                    onChange={(e) => {
+                      if (e.target.checked) {
+                        setSelectedCats((prev) => [...prev, c.id]);
+                      } else {
+                        setSelectedCats((prev) => prev.filter((id) => id !== c.id));
+                      }
+                    }}
+                  />
+                  <span>{c.name}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+          <div>
+            <p className="font-semibold mb-1 text-sm">Assign to Items</p>
+            <input
+              type="text"
+              placeholder="Search items"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="w-full border border-gray-300 rounded p-1 mb-2"
+            />
+            <div className="space-y-1 max-h-32 overflow-y-auto border p-2 rounded">
+              {filteredItems.map((it) => (
+                <label key={it.id} className="flex items-center space-x-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={selectedItems.includes(it.id)}
+                    onChange={(e) => {
+                      if (e.target.checked) {
+                        setSelectedItems((prev) => [...prev, it.id]);
+                      } else {
+                        setSelectedItems((prev) => prev.filter((id) => id !== it.id));
+                      }
+                    }}
+                  />
+                  <span>{it.name}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+          {selectedCats.length === 0 && selectedItems.length === 0 && (
+            <p className="text-xs text-red-500">This group is not assigned to any items.</p>
+          )}
+          <div className="flex justify-end space-x-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 border border-teal-600 text-teal-600 rounded hover:bg-teal-50"
+            >
+              Cancel
+            </button>
+            <button type="submit" className="px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-700">
+              Save
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/components/AddonsTab.tsx
+++ b/components/AddonsTab.tsx
@@ -1,0 +1,211 @@
+import { useEffect, useState } from 'react';
+import { DndContext, PointerSensor, useSensor, useSensors, closestCenter, DragEndEvent } from '@dnd-kit/core';
+import { SortableContext, useSortable, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { TrashIcon, PencilSquareIcon, DocumentDuplicateIcon, PlusCircleIcon } from '@heroicons/react/24/outline';
+import { supabase } from '../utils/supabaseClient';
+import ConfirmModal from './ConfirmModal';
+import AddonGroupModal from './AddonGroupModal';
+
+function SortableOption({ id, children }: { id: number; children: React.ReactNode }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.6 : undefined,
+    background: isDragging ? '#f0f0f0' : undefined,
+    cursor: 'grab',
+  } as React.CSSProperties;
+  return (
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+      {children}
+    </div>
+  );
+}
+
+export default function AddonsTab({ restaurantId }: { restaurantId: number }) {
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
+  const [groups, setGroups] = useState<any[]>([]);
+  const [options, setOptions] = useState<Record<number, any[]>>({});
+  const [showModal, setShowModal] = useState(false);
+  const [editingGroup, setEditingGroup] = useState<any | null>(null);
+  const [confirmDel, setConfirmDel] = useState<any | null>(null);
+
+  const load = async () => {
+    const { data: grp } = await supabase
+      .from('addon_groups')
+      .select('*')
+      .eq('restaurant_id', restaurantId)
+      .order('id');
+    setGroups(grp || []);
+    if (grp && grp.length) {
+      const { data: opts } = await supabase
+        .from('addon_options')
+        .select('*')
+        .in('group_id', grp.map((g) => g.id));
+      const map: Record<number, any[]> = {};
+      grp.forEach((g) => (map[g.id] = []));
+      opts?.forEach((o) => {
+        if (!map[o.group_id]) map[o.group_id] = [];
+        map[o.group_id].push(o);
+      });
+      setOptions(map);
+    } else {
+      setOptions({});
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, [restaurantId]);
+
+  const addOption = async (gid: number) => {
+    const { data } = await supabase
+      .from('addon_options')
+      .insert([{ name: '', price: 0, available: true, group_id: gid }])
+      .select()
+      .single();
+    if (data) {
+      setOptions((prev) => ({ ...prev, [gid]: [...(prev[gid] || []), data] }));
+    }
+  };
+
+  const updateOption = async (gid: number, id: number, fields: any) => {
+    await supabase.from('addon_options').update(fields).eq('id', id);
+    setOptions((prev) => ({
+      ...prev,
+      [gid]: prev[gid].map((o) => (o.id === id ? { ...o, ...fields } : o)),
+    }));
+  };
+
+  const deleteOption = async (gid: number, id: number) => {
+    await supabase.from('addon_options').delete().eq('id', id);
+    setOptions((prev) => ({ ...prev, [gid]: prev[gid].filter((o) => o.id !== id) }));
+  };
+
+  const handleDragEnd = (gid: number) => ({ active, over }: DragEndEvent) => {
+    if (!over || active.id === over.id) return;
+    setOptions((prev) => {
+      const arr = prev[gid];
+      const oldIndex = arr.findIndex((o) => o.id === active.id);
+      const newIndex = arr.findIndex((o) => o.id === over.id);
+      return { ...prev, [gid]: arrayMove(arr, oldIndex, newIndex) };
+    });
+  };
+
+  const duplicateGroup = async (g: any) => {
+    const { data: newGroup } = await supabase
+      .from('addon_groups')
+      .insert([{ name: `${g.name} - copy`, multiple_choice: g.multiple_choice, required: g.required, restaurant_id: restaurantId }])
+      .select()
+      .single();
+    if (newGroup) {
+      const groupOpts = options[g.id] || [];
+      if (groupOpts.length) {
+        await supabase.from('addon_options').insert(
+          groupOpts.map((o) => ({ name: o.name, price: o.price, available: o.available, group_id: newGroup.id }))
+        );
+      }
+      load();
+    }
+  };
+
+  const deleteGroup = async (g: any) => {
+    await supabase.from('addon_options').delete().eq('group_id', g.id);
+    await supabase.from('menu_item_addon_groups').delete().eq('addon_group_id', g.id);
+    await supabase.from('addon_groups').delete().eq('id', g.id);
+    load();
+  };
+
+  return (
+    <div>
+      <div className="flex justify-between mb-4">
+        <h2 className="text-2xl font-bold">Add-on Categories</h2>
+        <button
+          onClick={() => {
+            setEditingGroup(null);
+            setShowModal(true);
+          }}
+          className="flex items-center bg-teal-600 text-white px-3 py-2 rounded-lg hover:bg-teal-700"
+        >
+          <PlusCircleIcon className="w-5 h-5 mr-1" /> Add Category
+        </button>
+      </div>
+      {groups.map((g) => (
+        <div key={g.id} className="bg-white rounded-xl shadow mb-4">
+          <div className="flex justify-between p-4">
+            <div>
+              <h3 className="font-semibold">{g.name}</h3>
+              <p className="text-xs text-gray-500">
+                {g.multiple_choice ? 'Multiple Choice' : 'Single Choice'}
+                {g.required ? ' · Required' : ''}
+              </p>
+            </div>
+            <div className="flex space-x-2">
+              <button onClick={() => { setEditingGroup(g); setShowModal(true); }} className="p-2 rounded hover:bg-gray-100" aria-label="Edit">
+                <PencilSquareIcon className="w-5 h-5" />
+              </button>
+              <button onClick={() => duplicateGroup(g)} className="p-2 rounded hover:bg-gray-100" aria-label="Duplicate">
+                <DocumentDuplicateIcon className="w-5 h-5" />
+              </button>
+              <button onClick={() => setConfirmDel(g)} className="p-2 rounded hover:bg-gray-100" aria-label="Delete">
+                <TrashIcon className="w-5 h-5" />
+              </button>
+            </div>
+          </div>
+          <div className="p-4 pt-0">
+            <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd(g.id)}>
+              <SortableContext items={(options[g.id] || []).map((o) => o.id)} strategy={verticalListSortingStrategy}>
+                {(options[g.id] || []).map((o) => (
+                  <SortableOption key={o.id} id={o.id}>
+                    <div className="flex items-center space-x-2 border-b py-1">
+                      <input
+                        type="text"
+                        value={o.name}
+                        onChange={(e) => updateOption(g.id, o.id, { name: e.target.value })}
+                        className="flex-1 border border-gray-300 rounded p-1 text-sm"
+                      />
+                      <input
+                        type="number"
+                        value={o.price}
+                        onChange={(e) => updateOption(g.id, o.id, { price: parseFloat(e.target.value) || 0 })}
+                        className="w-20 border border-gray-300 rounded p-1 text-sm"
+                      />
+                      <button onClick={() => deleteOption(g.id, o.id)} className="p-1 rounded hover:bg-red-100" aria-label="Delete option">
+                        <TrashIcon className="w-4 h-4 text-red-600" />
+                      </button>
+                    </div>
+                  </SortableOption>
+                ))}
+              </SortableContext>
+            </DndContext>
+            <button onClick={() => addOption(g.id)} className="mt-2 flex items-center text-sm text-teal-600 hover:underline">
+              <PlusCircleIcon className="w-4 h-4 mr-1" /> Add Item
+            </button>
+          </div>
+        </div>
+      ))}
+      {showModal && (
+        <AddonGroupModal
+          show={showModal}
+          restaurantId={restaurantId}
+          group={editingGroup || undefined}
+          onClose={() => setShowModal(false)}
+          onSaved={load}
+        />
+      )}
+      {confirmDel && (
+        <ConfirmModal
+          show={true}
+          title="Delete category?"
+          message="This will remove all addon items and assignments."
+          onConfirm={() => {
+            deleteGroup(confirmDel);
+            setConfirmDel(null);
+          }}
+          onCancel={() => setConfirmDel(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/pages/dashboard/menu-builder.tsx
+++ b/pages/dashboard/menu-builder.tsx
@@ -23,6 +23,7 @@ import ConfirmModal from '../../components/ConfirmModal';
 import DraftCategoryModal from '../../components/DraftCategoryModal';
 import ViewItemModal from '../../components/ViewItemModal';
 import DashboardLayout from '../../components/DashboardLayout';
+import AddonsTab from '../../components/AddonsTab';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   ChevronDownIcon,
@@ -663,6 +664,17 @@ export default function MenuBuilder() {
           </SortableContext>
         </DndContext>
             )}
+          </motion.div>
+        )}
+        {activeTab === 'addons' && (
+          <motion.div
+            key="addons"
+            initial={{ x: 20, opacity: 0 }}
+            animate={{ x: 0, opacity: 1 }}
+            exit={{ x: -20, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+          >
+            {restaurantId && <AddonsTab restaurantId={restaurantId} />}
           </motion.div>
         )}
         {activeTab === 'build' && (


### PR DESCRIPTION
## Summary
- create `AddonsTab` component for managing add‑on groups and options
- create `AddonGroupModal` for editing add‑on category details and assignments
- integrate the new tab into the menu builder page
- ensure Jest tests run with new components

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_686fe967bfbc8325aa75aa7d1f93b724