### PR TITLE
Update menu builder

### DIFF
--- a/components/AddCategoryModal.tsx
+++ b/components/AddCategoryModal.tsx
@@ -21,6 +21,8 @@ export default function AddCategoryModal({
 }: AddCategoryModalProps) {
   const [name, setName] = useState(category?.name || '');
   const [description, setDescription] = useState(category?.description || '');
+  const [saving, setSaving] = useState(false);
+  const [showSuccess, setShowSuccess] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -29,6 +31,8 @@ export default function AddCategoryModal({
       return;
     }
 
+    if (saving) return;
+    setSaving(true);
     let err;
     if (category) {
       const { error } = await supabase
@@ -45,10 +49,16 @@ export default function AddCategoryModal({
 
     if (err) {
       alert('Failed to save category: ' + err.message);
+      setSaving(false);
       return;
     }
-    onCreated();
-    onClose();
+    setShowSuccess(true);
+    setTimeout(() => {
+      onCreated();
+      onClose();
+      setShowSuccess(false);
+      setSaving(false);
+    }, 800);
   };
 
   return (
@@ -94,11 +104,16 @@ export default function AddCategoryModal({
             <button type="button" onClick={onClose} className="px-4 py-2 border border-teal-600 text-teal-600 rounded hover:bg-teal-50">
               Cancel
             </button>
-            <button type="submit" className="px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-700">
-              Save
+            <button type="submit" disabled={saving} className="px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-700 disabled:opacity-50">
+              {saving ? 'Saving...' : 'Save'}
             </button>
           </div>
         </form>
+        {showSuccess && (
+          <div className="absolute inset-0 flex items-center justify-center bg-white/80 rounded-xl">
+            <div className="text-green-600 text-5xl animate-bounce">✓</div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/components/AddItemModal.tsx
+++ b/components/AddItemModal.tsx
@@ -174,6 +174,10 @@ export default function AddItemModal({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (selectedCategories.length === 0) {
+      alert('Please select at least one category');
+      return;
+    }
     const categoryId = selectedCategories[0] ?? null;
     const itemData = {
       restaurant_id: restaurantId,

--- a/pages/dashboard/menu-builder.tsx
+++ b/pages/dashboard/menu-builder.tsx
@@ -317,6 +317,16 @@ export default function MenuBuilder() {
     setItems((prev) => prev.filter((i) => i.id !== id));
   };
 
+  const handleDeleteDraftCategory = (id: number) => {
+    const hasItems = buildItems.some((i) => i.category_id === id);
+    const msg = hasItems
+      ? 'Delete this category and all items in it?'
+      : 'Delete this category?';
+    if (!window.confirm(msg)) return;
+    setBuildCategories((prev) => prev.filter((c) => c.id !== id));
+    setBuildItems((prev) => prev.filter((i) => i.category_id !== id));
+  };
+
   // Duplicate live menu into the draft state
   const duplicateLiveMenu = () => {
     const doIt = () => {
@@ -526,7 +536,7 @@ export default function MenuBuilder() {
         </div>
       )}
 
-      {activeTab !== 'addons' && (
+      {activeTab === 'build' && (
         <div className="mb-6 flex items-center justify-between">
           <div className="flex items-center text-sm text-gray-500 space-x-2">
             <ArrowsUpDownIcon className="w-4 h-4" />
@@ -539,17 +549,15 @@ export default function MenuBuilder() {
             <button onClick={collapseAll} className="p-2 rounded hover:bg-gray-200" aria-label="Collapse all">
               <ChevronUpIcon className="w-5 h-5" />
             </button>
-            {activeTab === 'menu' && (
-              <button
-                onClick={() => {
-                  setEditCategory(null);
-                  setShowAddCatModal(true);
-                }}
-                className="flex items-center bg-teal-600 text-white px-3 py-2 rounded-lg hover:bg-teal-700"
-              >
-                <PlusCircleIcon className="w-5 h-5 mr-1" /> Add Category
-              </button>
-            )}
+            <button
+              onClick={() => {
+                setDraftCategory(null);
+                setShowDraftCategoryModal(true);
+              }}
+              className="flex items-center bg-teal-600 text-white px-3 py-2 rounded-lg hover:bg-teal-700"
+            >
+              <PlusCircleIcon className="w-5 h-5 mr-1" /> Add Category
+            </button>
             {/* Publish button hidden on Menu tab */}
           </div>
         </div>
@@ -565,9 +573,19 @@ export default function MenuBuilder() {
             transition={{ duration: 0.2 }}
           >
             <div className="mb-6">
-              <h2 className="text-2xl font-bold flex items-center gap-2">
-                <span role="img" aria-label="plates">🍽️</span> Live Menu
-              </h2>
+              <div className="flex items-center justify-between">
+                <h2 className="text-2xl font-bold flex items-center gap-2">
+                  <span role="img" aria-label="plates">🍽️</span> Live Menu
+                </h2>
+                <div className="flex items-center space-x-3">
+                  <button onClick={expandAll} className="p-2 rounded hover:bg-gray-200" aria-label="Expand all">
+                    <ChevronDownIcon className="w-5 h-5" />
+                  </button>
+                  <button onClick={collapseAll} className="p-2 rounded hover:bg-gray-200" aria-label="Collapse all">
+                    <ChevronUpIcon className="w-5 h-5" />
+                  </button>
+                </div>
+              </div>
               <p className="text-sm text-gray-600">
                 This is what your customers see right now. All published items appear here. Changes go live instantly!
               </p>
@@ -763,6 +781,14 @@ export default function MenuBuilder() {
                             >
                               <PlusCircleIcon className="w-5 h-5" />
                             </button>
+                            <button
+                              onClick={() => handleDeleteDraftCategory(cat.id)}
+                              onPointerDown={(e) => e.stopPropagation()}
+                              className="p-2 rounded hover:bg-red-100"
+                              aria-label="Delete category"
+                            >
+                              <TrashIcon className="w-5 h-5 text-red-600" />
+                            </button>
                           </div>
                         </div>
                         {!collapsedCats.has(cat.id) && (
@@ -843,7 +869,10 @@ export default function MenuBuilder() {
             setShowAddCatModal(false);
             setEditCategory(null);
           }}
-          onCreated={() => restaurantId && fetchData(restaurantId)}
+          onCreated={() => {
+            restaurantId && fetchData(restaurantId);
+            setToastMessage('Category saved');
+          }}
         />
       )}
  <AddItemModal


### PR DESCRIPTION
## Summary
- tweak AddCategoryModal with success animation and disabled button
- require a category when saving an item
- adjust menu builder layout and controls
- add ability to delete build menu categories

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_6870215b3a848325a4d7fe332b19fb09