### PR TITLE
Add success overlay to DraftCategoryModal

### DIFF
--- a/components/DraftCategoryModal.tsx
+++ b/components/DraftCategoryModal.tsx
@@ -10,6 +10,8 @@ interface DraftCategoryModalProps {
 export default function DraftCategoryModal({ show, onClose, category, onSave }: DraftCategoryModalProps) {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [showSuccess, setShowSuccess] = useState(false);
 
   useEffect(() => {
     if (show) {
@@ -19,18 +21,62 @@ export default function DraftCategoryModal({ show, onClose, category, onSave }: 
   }, [show, category]);
 
   if (!show) return null;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (saving) return;
+    setSaving(true);
+    onSave({ id: category?.id, name, description });
+    setShowSuccess(true);
+    setTimeout(() => {
+      onClose();
+      setShowSuccess(false);
+      setSaving(false);
+    }, 800);
+  };
+
   return (
-    <div onClick={(e) => e.target === e.currentTarget && onClose()} className="fixed inset-0 bg-black/40 flex items-center justify-center p-4 z-[1000]">
-      <div onClick={(e) => e.stopPropagation()} className="bg-white rounded-xl p-6 max-w-md w-full">
+    <div
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+      className="fixed inset-0 bg-black/40 flex items-center justify-center p-4 z-[1000]"
+    >
+      <div onClick={(e) => e.stopPropagation()} className="bg-white rounded-xl p-6 max-w-md w-full relative">
         <h3 className="text-xl font-semibold mb-4">{category ? 'Edit Category' : 'Add Category'}</h3>
-        <form onSubmit={(e) => {e.preventDefault(); onSave({ id: category?.id, name, description });}}>
-          <input value={name} onChange={(e) => setName(e.target.value)} placeholder="Name" className="w-full border border-gray-300 rounded p-2 mb-3" />
-          <textarea value={description} onChange={(e) => setDescription(e.target.value)} placeholder="Description" className="w-full border border-gray-300 rounded p-2 mb-4" />
+        <form onSubmit={handleSubmit}>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Name"
+            className="w-full border border-gray-300 rounded p-2 mb-3"
+          />
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Description"
+            className="w-full border border-gray-300 rounded p-2 mb-4"
+          />
           <div className="text-right space-x-2">
-            <button type="button" onClick={onClose} className="px-4 py-2 border border-teal-600 text-teal-600 rounded hover:bg-teal-50">Cancel</button>
-            <button type="submit" className="px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-700">Save</button>
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 border border-teal-600 text-teal-600 rounded hover:bg-teal-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-700 disabled:opacity-50"
+            >
+              {saving ? 'Saving...' : 'Save'}
+            </button>
           </div>
         </form>
+        {showSuccess && (
+          <div className="absolute inset-0 flex items-center justify-center bg-white/80 rounded-xl">
+            <div className="text-green-600 text-5xl animate-bounce">✓</div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/pages/dashboard/menu-builder.tsx
+++ b/pages/dashboard/menu-builder.tsx
@@ -910,6 +910,7 @@ export default function MenuBuilder() {
             setShowDraftCategoryModal(false);
             setDraftCategory(null);
           }}
+          // DraftCategoryModal will close itself after showing a success overlay
           onSave={(cat) => {
             if (draftCategory) {
               setBuildCategories((prev) =>
@@ -919,7 +920,12 @@ export default function MenuBuilder() {
               const id = Date.now() + Math.random();
               setBuildCategories((prev) => [
                 ...prev,
-                { id, name: cat.name, description: cat.description, sort_order: prev.length },
+                {
+                  id,
+                  name: cat.name,
+                  description: cat.description,
+                  sort_order: prev.length,
+                },
               ]);
             }
           }}


### PR DESCRIPTION
## Summary
- show saving and success states when editing draft categories
- clarify draft category save handler in menu builder

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_68702785c07883258e720f499471171f