### PR TITLE
Add Stock page example

### DIFF
--- a/pages/stock.tsx
+++ b/pages/stock.tsx
@@ -1,0 +1,55 @@
+import StockTab from '@/components/StockTab';
+
+export default function StockPage() {
+  const categories = [
+    {
+      id: '1',
+      name: 'Burgers',
+      items: [
+        {
+          id: 'b1',
+          name: 'Cheeseburger',
+          stock_status: 'in_stock' as const,
+          stock_return_date: null,
+        },
+        {
+          id: 'b2',
+          name: 'Veggie Burger',
+          stock_status: 'scheduled' as const,
+          stock_return_date: new Date().toISOString(),
+        },
+      ],
+    },
+    {
+      id: '2',
+      name: 'Drinks',
+      items: [
+        {
+          id: 'd1',
+          name: 'Cola',
+          stock_status: 'out' as const,
+          stock_return_date: null,
+        },
+        {
+          id: 'd2',
+          name: 'Lemonade',
+          stock_status: 'in_stock' as const,
+          stock_return_date: null,
+        },
+        {
+          id: 'd3',
+          name: 'Iced Tea',
+          stock_status: 'scheduled' as const,
+          stock_return_date: new Date().toISOString(),
+        },
+      ],
+    },
+  ];
+
+  return (
+    <div className="p-4">
+      <StockTab categories={categories} />
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add stock page with hardcoded data for StockTab

## Testing
- `npm run test:ci` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68703e9526a48325b30df57970d292b6