### PR TITLE
Implement stock tab loader in menu builder

### DIFF
--- a/__tests__/StockTab.test.tsx
+++ b/__tests__/StockTab.test.tsx
@@ -3,7 +3,7 @@ import StockTab from '../components/StockTab';
 
 describe('StockTab', () => {
   it('renders title and buttons', () => {
-    render(<StockTab categories={[]} />);
+    render(<StockTab categories={[]} addons={[]} />);
     expect(screen.getByText(/Live Stock Control/)).toBeInTheDocument();
     expect(screen.getByText('⬇ Expand All')).toBeInTheDocument();
     expect(screen.getByText('⬆ Collapse All')).toBeInTheDocument();

--- a/components/StockTab.tsx
+++ b/components/StockTab.tsx
@@ -13,6 +13,12 @@ export interface StockTabProps {
       stock_return_date: string | null;
     }[];
   }[];
+  addons: {
+    id: string;
+    name: string;
+    stock_status: 'in_stock' | 'scheduled' | 'out';
+    stock_return_date: string | null;
+  }[];
 }
 
 function StockStatusBadge({ status, returnDate }: { status: 'in_stock' | 'scheduled' | 'out'; returnDate: string | null }) {
@@ -31,7 +37,7 @@ function StockStatusBadge({ status, returnDate }: { status: 'in_stock' | 'schedu
   return <span className={`text-xs px-2 py-1 rounded ${color}`}>{label}</span>;
 }
 
-export default function StockTab({ categories }: StockTabProps) {
+export default function StockTab({ categories, addons }: StockTabProps) {
   const [expanded, setExpanded] = useState<Set<string>>(new Set(categories.map((c) => c.id)));
 
   const expandAll = () => setExpanded(new Set(categories.map((c) => c.id)));
@@ -101,6 +107,25 @@ export default function StockTab({ categories }: StockTabProps) {
           );
         })}
       </div>
+      {addons.length > 0 && (
+        <div className="mt-8">
+          <h3 className="text-xl font-semibold mb-2">Add-ons</h3>
+          <ul className="space-y-2">
+            {addons.map((addon) => (
+              <li
+                key={addon.id}
+                className="flex justify-between items-center bg-white rounded-lg shadow px-4 py-2"
+              >
+                <span>{addon.name}</span>
+                <StockStatusBadge
+                  status={addon.stock_status}
+                  returnDate={addon.stock_return_date}
+                />
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- extend `StockTab` component to show addon items and update interface
- adapt StockTab tests for new `addons` prop
- fetch categories/items and addon options for stock tab in menu-builder page
- render `StockTab` with spinner when loading

## Testing
- `npm run test:ci` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68704366af208325ba1da3b4cae437db