### PR TITLE
Fix StockTab props usage

### DIFF
--- a/components/StockTabLoader.tsx
+++ b/components/StockTabLoader.tsx
@@ -13,6 +13,7 @@ interface Row {
 
 export default function StockTabLoader() {
   const [categories, setCategories] = useState<StockTabProps['categories']>([]);
+  const addons: StockTabProps['addons'] = [];
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -59,5 +60,5 @@ JOIN menu_items i ON i.category_id = c.id;`;
   if (loading) return <div className="p-4">Loading...</div>;
   if (error) return <div className="p-4 text-red-500">Error: {error}</div>;
 
-  return <StockTab categories={categories} />;
+  return <StockTab categories={categories} addons={addons} />;
 }

--- a/pages/stock.tsx
+++ b/pages/stock.tsx
@@ -46,9 +46,30 @@ export default function StockPage() {
     },
   ];
 
+  const addons = [
+    {
+      id: 'a1',
+      name: 'Cheese',
+      stock_status: 'in_stock' as const,
+      stock_return_date: null,
+    },
+    {
+      id: 'a2',
+      name: 'Bacon',
+      stock_status: 'out' as const,
+      stock_return_date: null,
+    },
+    {
+      id: 'a3',
+      name: 'Avocado',
+      stock_status: 'scheduled' as const,
+      stock_return_date: new Date().toISOString(),
+    },
+  ];
+
   return (
     <div className="p-4">
-      <StockTab categories={categories} />
+      <StockTab categories={categories} addons={addons} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- pass `addons` prop in `StockTabLoader` and `stock` page
- add a placeholder empty addons array in `StockTabLoader`
- add sample addons data for `stock` page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870466bc4348325993cba39523c362c