### PR TITLE
Refactor StockTab header toggle

### DIFF
--- a/__tests__/StockTab.test.tsx
+++ b/__tests__/StockTab.test.tsx
@@ -2,10 +2,9 @@ import { render, screen } from '@testing-library/react';
 import StockTab from '../components/StockTab';
 
 describe('StockTab', () => {
-  it('renders title and buttons', () => {
+  it('renders title and toggle button', () => {
     render(<StockTab categories={[]} addons={[]} />);
     expect(screen.getByText(/Live Stock Control/)).toBeInTheDocument();
-    expect(screen.getByText('⬇ Expand All')).toBeInTheDocument();
-    expect(screen.getByText('⬆ Collapse All')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Collapse all/i)).toBeInTheDocument();
   });
 });

--- a/components/StockTab.tsx
+++ b/components/StockTab.tsx
@@ -125,22 +125,19 @@ export default function StockTab({ categories, addons }: StockTabProps) {
             Quickly mark your items, add-ons, or full categories as out of stock — whether it's just for today or until further notice.
           </p>
         </div>
-        <div className="shrink-0 flex items-center space-x-2">
+        <div className="shrink-0 flex items-center justify-end">
           <button
-            onClick={expandAll}
-            className="p-2 rounded hover:bg-gray-200 flex items-center gap-1"
-            aria-label="Expand all"
+            onClick={() => {
+              const allOpen = expanded.size === data.length;
+              if (allOpen) collapseAll();
+              else expandAll();
+            }}
+            className="p-2 rounded hover:bg-gray-200 transition-transform hover:opacity-80"
+            aria-label={expanded.size === data.length ? 'Collapse all' : 'Expand all'}
           >
-            <ChevronDownIcon className="w-5 h-5" />
-            <span>⬇ Expand All</span>
-          </button>
-          <button
-            onClick={collapseAll}
-            className="p-2 rounded hover:bg-gray-200 flex items-center gap-1"
-            aria-label="Collapse all"
-          >
-            <ChevronUpIcon className="w-5 h-5" />
-            <span>⬆ Collapse All</span>
+            <ChevronDownIcon
+              className={`w-5 h-5 transition-transform ${expanded.size === data.length ? 'rotate-180' : ''}`}
+            />
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- replace "Expand/Collapse All" buttons with one chevron toggle in **StockTab**
- update unit test for new toggle

## Testing
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_687054c384508325b47273f4bd2479a0