### PR TITLE
Add custom page management

### DIFF
--- a/components/CustomPagesSection.tsx
+++ b/components/CustomPagesSection.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from 'react';
+import {
+  PencilSquareIcon,
+  TrashIcon,
+  PlusCircleIcon,
+} from '@heroicons/react/24/outline';
+import { supabase } from '../utils/supabaseClient';
+import PageModal, { Page } from './PageModal';
+import ConfirmModal from './ConfirmModal';
+import Toast from './Toast';
+
+export default function CustomPagesSection({
+  restaurantId,
+}: {
+  restaurantId: number;
+}) {
+  const [pages, setPages] = useState<Page[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showModal, setShowModal] = useState(false);
+  const [editing, setEditing] = useState<Page | null>(null);
+  const [confirmDel, setConfirmDel] = useState<Page | null>(null);
+  const [toastMessage, setToastMessage] = useState('');
+
+  const loadPages = async () => {
+    const { data, error } = await supabase
+      .from('restaurant_pages')
+      .select('*')
+      .eq('restaurant_id', restaurantId)
+      .order('id');
+    if (error) {
+      console.error(error);
+      setToastMessage('Failed to load pages');
+    } else {
+      setPages((data as Page[]) || []);
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    if (restaurantId) loadPages();
+  }, [restaurantId]);
+
+  const handleSaved = () => {
+    setShowModal(false);
+    setEditing(null);
+    loadPages();
+    setToastMessage('Page saved');
+  };
+
+  const handleDelete = async () => {
+    if (!confirmDel) return;
+    const { error } = await supabase
+      .from('restaurant_pages')
+      .delete()
+      .eq('id', confirmDel.id);
+    if (error) {
+      setToastMessage('Failed to delete page');
+    } else {
+      setPages((prev) => prev.filter((p) => p.id !== confirmDel.id));
+      setToastMessage('Page deleted');
+    }
+    setConfirmDel(null);
+  };
+
+  const togglePublished = async (p: Page, val: boolean) => {
+    setPages((prev) => prev.map((pg) => (pg.id === p.id ? { ...pg, published: val } : pg)));
+    const { error } = await supabase
+      .from('restaurant_pages')
+      .update({ published: val })
+      .eq('id', p.id);
+    if (error) {
+      setToastMessage('Failed to update');
+    }
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto mt-12">
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-2xl font-bold">Custom Pages</h2>
+        <button
+          onClick={() => {
+            setEditing(null);
+            setShowModal(true);
+          }}
+          className="flex items-center bg-teal-600 text-white px-3 py-2 rounded-lg hover:bg-teal-700"
+        >
+          <PlusCircleIcon className="w-5 h-5 mr-1" /> New Page
+        </button>
+      </div>
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <div className="bg-white rounded-xl shadow divide-y">
+          {pages.map((p) => (
+            <div key={p.id} className="p-4 flex items-center justify-between">
+              <div>
+                <p className="font-semibold">{p.title}</p>
+                <p className="text-sm text-gray-500">{p.slug}</p>
+              </div>
+              <div className="flex items-center space-x-4">
+                <label className="flex items-center space-x-1 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={p.published}
+                    onChange={(e) => togglePublished(p, e.target.checked)}
+                  />
+                  <span>Published</span>
+                </label>
+                <button
+                  onClick={() => {
+                    setEditing(p);
+                    setShowModal(true);
+                  }}
+                  className="p-2 rounded hover:bg-gray-100"
+                  aria-label="Edit"
+                >
+                  <PencilSquareIcon className="w-5 h-5" />
+                </button>
+                <button
+                  onClick={() => setConfirmDel(p)}
+                  className="p-2 rounded hover:bg-gray-100"
+                  aria-label="Delete"
+                >
+                  <TrashIcon className="w-5 h-5 text-red-600" />
+                </button>
+              </div>
+            </div>
+          ))}
+          {!pages.length && (
+            <p className="p-4 text-gray-500 text-sm">No pages yet.</p>
+          )}
+        </div>
+      )}
+      {showModal && (
+        <PageModal
+          restaurantId={restaurantId}
+          page={editing || undefined}
+          onClose={() => {
+            setShowModal(false);
+            setEditing(null);
+          }}
+          onSaved={handleSaved}
+        />
+      )}
+      {confirmDel && (
+        <ConfirmModal
+          show={true}
+          title="Delete Page?"
+          message={`Are you sure you want to delete \"${confirmDel.title}\"?`}
+          onConfirm={handleDelete}
+          onCancel={() => setConfirmDel(null)}
+        />
+      )}
+      <Toast message={toastMessage} onClose={() => setToastMessage('')} />
+    </div>
+  );
+}

--- a/components/PageModal.tsx
+++ b/components/PageModal.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../utils/supabaseClient';
+
+export interface Page {
+  id: number;
+  title: string;
+  slug: string;
+  content: string;
+  published: boolean;
+}
+
+interface PageModalProps {
+  restaurantId: number;
+  page?: Page;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+const slugify = (str: string) =>
+  str
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)+/g, '');
+
+export default function PageModal({
+  restaurantId,
+  page,
+  onClose,
+  onSaved,
+}: PageModalProps) {
+  const [title, setTitle] = useState(page?.title || '');
+  const [slug, setSlug] = useState(page?.slug || '');
+  const [content, setContent] = useState(page?.content || '');
+  const [published, setPublished] = useState(page?.published ?? true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!page) {
+      setSlug(slugify(title));
+    }
+  }, [title, page]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (saving) return;
+    setSaving(true);
+    let error;
+    if (page) {
+      ({ error } = await supabase
+        .from('restaurant_pages')
+        .update({ title, slug, content, published })
+        .eq('id', page.id));
+    } else {
+      ({ error } = await supabase.from('restaurant_pages').insert([
+        { restaurant_id: restaurantId, title, slug, content, published },
+      ]));
+    }
+    if (error) {
+      alert('Failed to save page: ' + error.message);
+      setSaving(false);
+      return;
+    }
+    onSaved();
+    onClose();
+    setSaving(false);
+  };
+
+  if (!restaurantId) return null;
+  return (
+    <div
+      className="fixed inset-0 bg-black/40 flex items-center justify-center z-[1000]"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div
+        className="bg-white rounded-xl p-6 max-w-lg w-full max-h-[90vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="text-xl font-semibold mb-4">
+          {page ? 'Edit Page' : 'New Page'}
+        </h3>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">Title</label>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="w-full border border-gray-300 rounded p-2"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Slug</label>
+            <input
+              type="text"
+              value={slug}
+              onChange={(e) => setSlug(e.target.value)}
+              className="w-full border border-gray-300 rounded p-2"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Content</label>
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              className="w-full border border-gray-300 rounded p-2 min-h-[150px]"
+            />
+          </div>
+          <label className="flex items-center space-x-2 text-sm">
+            <input
+              type="checkbox"
+              checked={published}
+              onChange={(e) => setPublished(e.target.checked)}
+            />
+            <span>Published</span>
+          </label>
+          <div className="flex justify-end space-x-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 border border-teal-600 text-teal-600 rounded hover:bg-teal-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-700"
+              disabled={saving}
+            >
+              {saving ? 'Saving...' : 'Save'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/pages/dashboard/website.tsx
+++ b/pages/dashboard/website.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import DashboardLayout from '../../components/DashboardLayout';
 import Toast from '../../components/Toast';
+import CustomPagesSection from '../../components/CustomPagesSection';
 import { supabase } from '../../utils/supabaseClient';
 
 export default function WebsitePage() {
@@ -216,6 +217,7 @@ export default function WebsitePage() {
           </form>
         </div>
       </div>
+      {restaurantId && <CustomPagesSection restaurantId={restaurantId} />}
       <Toast message={toastMessage} onClose={() => setToastMessage('')} />
     </DashboardLayout>
   );


### PR DESCRIPTION
## Summary
- manage restaurant pages in dashboard
- add modal for creating/editing a page
- list existing pages with edit, delete and published toggle

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_687653f2b6a88325b37224f341c2ae10