### PR TITLE
Fix handling for missing restaurant subdomain

### DIFF
--- a/pages/restaurant/index.tsx
+++ b/pages/restaurant/index.tsx
@@ -17,7 +17,13 @@ export default function RestaurantPage() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    if (!router.isReady || !subdomain) return;
+    if (!router.isReady) return;
+
+    if (!subdomain) {
+      setLoading(false);
+      return;
+    }
+
     const load = async () => {
       const { data, error } = await supabase
         .from('restaurants')
@@ -33,6 +39,10 @@ export default function RestaurantPage() {
 
   if (loading) {
     return <div className="p-6 text-center">Loading...</div>;
+  }
+
+  if (!subdomain) {
+    return <div className="p-6 text-center">No restaurant specified</div>;
   }
 
   if (!restaurant) {


### PR DESCRIPTION
## Summary
- handle the case when no restaurant subdomain is provided

## Testing
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68768c38788c8325b26cdbe5e7e5fdca