### PR TITLE
Fix root domain handling in middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -15,13 +15,20 @@ export function middleware(request: NextRequest) {
 
   const host = request.headers.get('host') || '';
   const hostname = host.split(':')[0];
-  const subdomain = hostname.split('.')[0];
+
+  const ROOT_DOMAIN = 'orderfast.vercel.app';
+
+  if (hostname === ROOT_DOMAIN) {
+    return NextResponse.next();
+  }
+
+  const subdomain = hostname.replace(`.${ROOT_DOMAIN}`, '');
 
   if (
+    hostname.endsWith(`.${ROOT_DOMAIN}`) &&
     subdomain &&
     subdomain !== 'www' &&
-    subdomain !== 'whatsthatorder' &&
-    hostname.split('.').length > 2
+    subdomain !== 'whatsthatorder'
   ) {
     const url = request.nextUrl.clone();
     url.pathname = '/restaurant';


### PR DESCRIPTION
## Summary
- avoid applying restaurant subdomain rewrite when host equals `orderfast.vercel.app`
- only rewrite when the hostname ends with `.orderfast.vercel.app`

## Testing
- `npm run test:ci` *(fails: findUp.sync is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68768e373bac8325b11ff8668cf79090