### PR TITLE
Add Website dropdown with preview page

### DIFF
--- a/components/DashboardLayout.tsx
+++ b/components/DashboardLayout.tsx
@@ -34,7 +34,14 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
     { href: null, label: 'POS', icon: ComputerDesktopIcon },
     { href: null, label: 'KOD', icon: CpuChipIcon },
     { href: null, label: 'Kiosk', icon: DeviceTabletIcon },
-    { href: '/dashboard/website', label: 'Website', icon: GlobeAltIcon },
+    {
+      label: 'Website',
+      icon: GlobeAltIcon,
+      children: [
+        { href: '/dashboard/website/settings', label: 'Settings' },
+        { href: '/dashboard/website/preview', label: 'Preview' },
+      ],
+    },
     { href: null, label: 'Team', icon: UserGroupIcon },
     { href: null, label: 'Transactions', icon: ArrowsRightLeftIcon },
     { href: null, label: 'Sales', icon: ChartBarIcon },
@@ -45,6 +52,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   const router = useRouter();
   const [open, setOpen] = useState(false); // mobile open state
   const [collapsed, setCollapsed] = useState(false); // desktop collapse state
+  const [dropdownOpen, setDropdownOpen] = useState<Record<string, boolean>>({});
 
   const highlight = 'text-teal-600';
 
@@ -85,17 +93,65 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
         </div>
         <nav className="flex-1 px-2 space-y-1">
           {nav.map((n) => {
-            const active = !!n.href && router.pathname === n.href;
+            const hasChildren = Array.isArray(n.children);
+            const active =
+              (!!n.href && router.pathname === n.href) ||
+              (hasChildren && n.children!.some((c) => router.pathname === c.href));
             const base = `flex items-center px-4 py-2 rounded hover:bg-gray-50 focus:outline-none ${active ? 'bg-gray-50 border-l-4 border-teal-600' : ''}`;
             const labelClass = `${active ? highlight : 'text-gray-700'} ${collapsed ? 'hidden' : 'ml-3'}`;
             const iconClass = `w-6 h-6 ${active ? highlight : 'text-gray-400'}`;
+
+            if (hasChildren) {
+              const openDrop = dropdownOpen[n.label];
+              return (
+                <div key={n.label}>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setDropdownOpen((prev) => ({ ...prev, [n.label]: !openDrop }))
+                    }
+                    className={base}
+                    aria-label={n.label}
+                  >
+                    <n.icon className={iconClass} aria-hidden="true" />
+                    <span className={labelClass}>{n.label}</span>
+                  </button>
+                  {openDrop && !collapsed && (
+                    <div className="mt-1 ml-8 space-y-1">
+                      {n.children!.map((c) => {
+                        const childActive = router.pathname === c.href;
+                        return (
+                          <Link
+                            key={c.label}
+                            href={c.href}
+                            className={`block px-4 py-2 rounded hover:bg-gray-50 ${
+                              childActive ? 'bg-gray-50 border-l-4 border-teal-600' : ''
+                            }`}
+                          >
+                            <span className={childActive ? highlight : 'text-gray-700'}>
+                              {c.label}
+                            </span>
+                          </Link>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              );
+            }
+
             return n.href ? (
               <Link key={n.label} href={n.href} className={base} aria-label={n.label}>
                 <n.icon className={iconClass} aria-hidden="true" />
                 <span className={labelClass}>{n.label}</span>
               </Link>
             ) : (
-              <span key={n.label} className={`${base} text-gray-400 cursor-not-allowed`} title="Coming soon" aria-label={n.label}>
+              <span
+                key={n.label}
+                className={`${base} text-gray-400 cursor-not-allowed`}
+                title="Coming soon"
+                aria-label={n.label}
+              >
                 <n.icon className="w-6 h-6 text-gray-400" aria-hidden="true" />
                 <span className={labelClass}>{n.label}</span>
               </span>

--- a/pages/dashboard/website/preview.tsx
+++ b/pages/dashboard/website/preview.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import DashboardLayout from '../../../components/DashboardLayout';
+import { supabase } from '../../../utils/supabaseClient';
+
+interface Restaurant {
+  id: number;
+  name: string;
+  logo_url: string | null;
+  website_description: string | null;
+}
+
+export default function WebsitePreview() {
+  const router = useRouter();
+  const [restaurant, setRestaurant] = useState<Restaurant | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (!session) {
+        router.push('/login');
+        return;
+      }
+      const { data: ru } = await supabase
+        .from('restaurant_users')
+        .select('restaurant_id')
+        .eq('user_id', session.user.id)
+        .maybeSingle();
+      if (ru) {
+        const { data } = await supabase
+          .from('restaurants')
+          .select('*')
+          .eq('id', ru.restaurant_id)
+          .maybeSingle();
+        setRestaurant(data);
+      }
+      setLoading(false);
+    };
+    load();
+  }, [router]);
+
+  if (loading) return <DashboardLayout>Loading...</DashboardLayout>;
+
+  if (!restaurant) {
+    return <DashboardLayout>No restaurant found</DashboardLayout>;
+  }
+
+  return (
+    <DashboardLayout>
+      <div className="min-h-screen flex flex-col items-center justify-center p-6 bg-gray-50">
+        {restaurant.logo_url && (
+          <img
+            src={restaurant.logo_url}
+            alt={`${restaurant.name} logo`}
+            className="h-24 mb-4 object-contain"
+          />
+        )}
+        <h1 className="text-3xl font-bold mb-2 text-center">{restaurant.name}</h1>
+        {restaurant.website_description && (
+          <p className="text-gray-600 text-center mb-6 max-w-xl">
+            {restaurant.website_description}
+          </p>
+        )}
+        <Link href="/menu" className="px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-700">
+          View Menu
+        </Link>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/pages/dashboard/website/settings.tsx
+++ b/pages/dashboard/website/settings.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import DashboardLayout from '../../components/DashboardLayout';
-import Toast from '../../components/Toast';
-import CustomPagesSection from '../../components/CustomPagesSection';
-import { supabase } from '../../utils/supabaseClient';
+import DashboardLayout from '../../../components/DashboardLayout';
+import Toast from '../../../components/Toast';
+import CustomPagesSection from '../../../components/CustomPagesSection';
+import { supabase } from '../../../utils/supabaseClient';
 
 export default function WebsitePage() {
   const router = useRouter();


### PR DESCRIPTION
## Summary
- move website settings page into a `website` folder
- add new preview page for viewing the public site
- update DashboardLayout navigation to use a dropdown for Website with Settings and Preview

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687691ef49a48325851015e0052d5f52