### PR TITLE
Fix menu preview link

### DIFF
--- a/pages/dashboard/website/preview.tsx
+++ b/pages/dashboard/website/preview.tsx
@@ -65,7 +65,10 @@ export default function WebsitePreview() {
             {restaurant.website_description}
           </p>
         )}
-        <Link href="/restaurant/menu" className="px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-700">
+        <Link
+          href={`/restaurant/menu?restaurant_id=${restaurant.id}`}
+          className="px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-700"
+        >
           View Menu
         </Link>
       </div>


### PR DESCRIPTION
## Summary
- ensure the website preview menu button passes the restaurant id

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_6876a07466008325aa342bbffa634277