### PR TITLE
Use placeholder image for missing menu item photos

### DIFF
--- a/pages/restaurant/menu.tsx
+++ b/pages/restaurant/menu.tsx
@@ -112,7 +112,10 @@ export default function RestaurantMenuPage() {
                     className="flex gap-4 p-4 border rounded-lg shadow-sm bg-white"
                   >
                     <img
-                      src={item.image_url || 'https://via.placeholder.com/120'}
+                      src={
+                        item.image_url ||
+                        "https://placehold.co/120x120?text=No+Image"
+                      }
                       alt={item.name}
                       className="w-24 h-24 object-cover rounded"
                     />


### PR DESCRIPTION
## Summary
- replace via.placeholder.com with placehold.co/120x120?text=No+Image for menu item image fallback

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6876a9c19a3883258ac10ea0ad5699c8