### PR TITLE
Fix image persistence in menu publishing

### DIFF
--- a/pages/dashboard/menu-builder.tsx
+++ b/pages/dashboard/menu-builder.tsx
@@ -488,6 +488,7 @@ export default function MenuBuilder() {
                 name: bi.name,
                 description: bi.description,
                 price: bi.price,
+                image_url: bi.image_url,
                 sort_order: bi.sort_order || 0,
               },
             ]);


### PR DESCRIPTION
## Summary
- include `image_url` when publishing draft menu items

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_6876b1f021708325adecc2a9d9c542c6