### PR TITLE
Fix add-on link insertion during menu publish

### DIFF
--- a/pages/dashboard/menu-builder.tsx
+++ b/pages/dashboard/menu-builder.tsx
@@ -564,7 +564,9 @@ export default function MenuBuilder() {
           }
 
           if (linksToInsert.length) {
-            await supabase.from('item_addon_links').insert(linksToInsert);
+            await supabase
+              .from('item_addon_links')
+              .upsert(linksToInsert, { onConflict: 'item_id,group_id' });
           }
 
           setToastMessage('Menu published');


### PR DESCRIPTION
## Summary
- ensure add-on group links are inserted without duplicates when publishing the menu

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876bef0dcf88325b1b9be8385fdaa36