### PR TITLE
Sync addon link updates on publish

### DIFF
--- a/components/AddItemModal.tsx
+++ b/components/AddItemModal.tsx
@@ -3,6 +3,7 @@ import Cropper, { Area } from 'react-easy-crop';
 import { CloudArrowUpIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import { Trash2 } from 'lucide-react';
 import { supabase } from '../utils/supabaseClient';
+import { updateItemAddonLinks } from '../utils/updateItemAddonLinks';
 import CategoryMultiSelect from './CategoryMultiSelect';
 import AddonMultiSelect from './AddonMultiSelect';
 
@@ -227,18 +228,13 @@ export default function AddItemModal({
     if (data?.id) {
       if (item) {
         await supabase.from('menu_item_categories').delete().eq('item_id', data.id);
-        await supabase.from('item_addon_links').delete().eq('item_id', data.id);
       }
       if (selectedCategories.length) {
         await supabase.from('menu_item_categories').insert(
           selectedCategories.map((cid) => ({ item_id: data.id, category_id: cid }))
         );
       }
-      if (selectedAddons.length) {
-        await supabase.from('item_addon_links').insert(
-          selectedAddons.map((aid) => ({ item_id: data.id, group_id: aid }))
-        );
-      }
+      await updateItemAddonLinks(String(data.id), selectedAddons.map(String));
     }
 
     onSaved?.();

--- a/utils/updateItemAddonLinks.ts
+++ b/utils/updateItemAddonLinks.ts
@@ -1,0 +1,17 @@
+import { supabase } from './supabaseClient';
+
+/**
+ * Replace the addon links for a menu item with the given group IDs.
+ */
+export async function updateItemAddonLinks(itemId: string, selectedAddonGroupIds: string[]) {
+  // Remove existing links for the item
+  await supabase.from('item_addon_links').delete().eq('item_id', itemId);
+
+  if (selectedAddonGroupIds.length > 0) {
+    const rows = selectedAddonGroupIds.map((groupId) => ({
+      item_id: itemId,
+      group_id: groupId,
+    }));
+    await supabase.from('item_addon_links').insert(rows);
+  }
+}


### PR DESCRIPTION
## Summary
- expose helper `updateItemAddonLinks` for replacing addon links
- use new helper when saving a menu item so assigned addon groups publish correctly

## Testing
- `npm install`
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_6877cbd30f388325b859a5e34bbc19a1