### PR TITLE
Add view for item add-ons and use new util

### DIFF
--- a/components/MenuItemCard.tsx
+++ b/components/MenuItemCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { supabase } from '../utils/supabaseClient';
+import { getAddonsForItem } from '../utils/getAddonsForItem';
 
 interface MenuItem {
   id: number;
@@ -32,22 +32,15 @@ export default function MenuItemCard({ item }: { item: MenuItem }) {
 
   const loadAddons = async () => {
     setLoading(true);
-    const { data: links } = await supabase
-      .from('item_addon_links')
-      .select('group_id')
-      .eq('item_id', item.id);
-    const groupIds = links?.map((l: any) => l.group_id) || [];
-    if (groupIds.length > 0) {
-      const { data } = await supabase
-        .from('addon_groups')
-        .select('id,name,required,addon_options(id,name,price)')
-        .in('id', groupIds)
-        .order('sort_order');
-      setGroups(data || []);
-    } else {
+    try {
+      const data = await getAddonsForItem(item.id);
+      setGroups(data);
+    } catch (err) {
+      console.error('Failed to load addons', err);
       setGroups([]);
+    } finally {
+      setLoading(false);
     }
-    setLoading(false);
   };
 
   const handleClick = () => {

--- a/supabase/migrations/20250711000000_create_view_addons_for_item.sql
+++ b/supabase/migrations/20250711000000_create_view_addons_for_item.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE VIEW view_addons_for_item AS
+SELECT
+  ial.item_id,
+  ag.id AS addon_group_id,
+  ag.name AS addon_group_name,
+  ag.required,
+  ag.multiple_choice,
+  ao.id AS addon_option_id,
+  ao.name AS addon_option_name,
+  ao.price
+FROM item_addon_links ial
+JOIN addon_groups ag ON ag.id = ial.group_id
+LEFT JOIN addon_options ao ON ao.group_id = ag.id AND ao.available = true;


### PR DESCRIPTION
## Summary
- add migration creating `view_addons_for_item`
- load menu item add-ons via `getAddonsForItem` instead of nested selects

## Testing
- `npm install`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_6877d6add4d88325a45f346a65c3f46f