### PR TITLE
Fix AddonGroup id type mismatch

### DIFF
--- a/components/MenuItemCard.tsx
+++ b/components/MenuItemCard.tsx
@@ -19,7 +19,7 @@ interface AddonOption {
 }
 
 interface AddonGroup {
-  id: number;
+  id: string;
   name: string;
   required: boolean | null;
   addon_options: AddonOption[];


### PR DESCRIPTION
## Summary
- update `MenuItemCard` to accept addon groups with string IDs

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_6877db8059dc8325b936c674b345233e