### PR TITLE
Fix AddonGroup type mismatch

### DIFF
--- a/components/AddItemModal.tsx
+++ b/components/AddItemModal.tsx
@@ -15,7 +15,7 @@ interface AddItemModalProps {
   item?: any;
   onSaved?: () => void;
   categoriesProp?: any[];
-  onSaveData?: (data: any, categories: number[], addons: number[]) => Promise<void>;
+  onSaveData?: (data: any, categories: number[], addons: string[]) => Promise<void>;
   onDeleteData?: (id: number) => Promise<void> | void;
   onDeleted?: () => void;
 }
@@ -41,7 +41,7 @@ export default function AddItemModal({
   const [categories, setCategories] = useState<any[]>([]);
   const [selectedCategories, setSelectedCategories] = useState<number[]>([]);
   const [addonGroups, setAddonGroups] = useState<any[]>([]);
-  const [selectedAddons, setSelectedAddons] = useState<number[]>([]);
+  const [selectedAddons, setSelectedAddons] = useState<string[]>([]);
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const fileRef = useRef<HTMLInputElement | null>(null);
   const overlayRef = useRef<HTMLDivElement | null>(null);
@@ -143,7 +143,7 @@ export default function AddItemModal({
           .select('addon_group_id')
           .eq('item_id', item.id);
         if (addonLinks?.length) {
-          setSelectedAddons(addonLinks.map((l) => l.addon_group_id));
+          setSelectedAddons(addonLinks.map((l) => String(l.addon_group_id)));
         } else {
           setSelectedAddons([]);
         }
@@ -175,7 +175,7 @@ export default function AddItemModal({
   };
 
   const handleCategoryChange = (ids: number[]) => setSelectedCategories(ids);
-  const handleAddonChange = (ids: number[]) => setSelectedAddons(ids);
+  const handleAddonChange = (ids: string[]) => setSelectedAddons(ids);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -234,7 +234,7 @@ export default function AddItemModal({
           selectedCategories.map((cid) => ({ item_id: data.id, category_id: cid }))
         );
       }
-      await updateItemAddonLinks(String(data.id), selectedAddons.map(String));
+      await updateItemAddonLinks(String(data.id), selectedAddons);
     }
 
     onSaved?.();

--- a/components/AddonMultiSelect.tsx
+++ b/components/AddonMultiSelect.tsx
@@ -1,14 +1,10 @@
 import Select from 'react-select';
-
-interface AddonGroup {
-  id: number;
-  name: string;
-}
+import type { AddonGroup } from '../utils/types';
 
 interface AddonMultiSelectProps {
   options: AddonGroup[];
-  selectedIds: number[];
-  onChange: (ids: number[]) => void;
+  selectedIds: string[];
+  onChange: (ids: string[]) => void;
 }
 
 export default function AddonMultiSelect({ options, selectedIds, onChange }: AddonMultiSelectProps) {

--- a/components/MenuItemCard.tsx
+++ b/components/MenuItemCard.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { getAddonsForItem } from '../utils/getAddonsForItem';
+import type { AddonGroup } from '../utils/types';
 
 interface MenuItem {
   id: number;
@@ -12,18 +13,6 @@ interface MenuItem {
   stock_status?: 'in_stock' | 'scheduled' | 'out' | null;
 }
 
-interface AddonOption {
-  id: number;
-  name: string;
-  price: number | null;
-}
-
-interface AddonGroup {
-  id: string;
-  name: string;
-  required: boolean | null;
-  addon_options: AddonOption[];
-}
 
 export default function MenuItemCard({ item }: { item: MenuItem }) {
   const [showModal, setShowModal] = useState(false);

--- a/components/__tests__/AddonMultiSelect.test.tsx
+++ b/components/__tests__/AddonMultiSelect.test.tsx
@@ -7,13 +7,13 @@ import AddonMultiSelect from '../AddonMultiSelect';
 describe('AddonMultiSelect', () => {
   it('shows selected add-on names', () => {
     const addons = [
-      { id: 1, name: 'Cheese' },
-      { id: 2, name: 'Bacon' },
+      { id: '1', name: 'Cheese' },
+      { id: '2', name: 'Bacon' },
     ];
     render(
       <AddonMultiSelect
         options={addons}
-        selectedIds={[1, 2]}
+        selectedIds={['1', '2']}
         onChange={() => {}}
       />
     );

--- a/pages/dashboard/menu-builder.tsx
+++ b/pages/dashboard/menu-builder.tsx
@@ -544,14 +544,14 @@ export default function MenuBuilder() {
             itemMap.set(bi.id, inserted.id);
           }
 
-          const addonData: { id: number; selectedAddonGroupIds: number[] }[] = [];
+          const addonData: { id: number; selectedAddonGroupIds: string[] }[] = [];
           for (const bi of buildItems) {
             const newId = itemMap.get(bi.id);
             if (!newId) continue;
             addonData.push({
               id: newId,
               selectedAddonGroupIds: Array.isArray(bi.addons)
-                ? bi.addons.map(Number)
+                ? bi.addons.map(String)
                 : [],
             });
           }

--- a/utils/getAddonsForItem.ts
+++ b/utils/getAddonsForItem.ts
@@ -1,24 +1,13 @@
 import { supabase } from './supabaseClient';
-
-export interface AddonOption {
-  id: number | string;
-  name: string;
-  price: number | null;
-}
-
-export interface AddonGroup {
-  id: number | string;
-  name: string;
-  required: boolean;
-  multiple_choice: boolean;
-  addon_options: AddonOption[];
-}
+import type { AddonGroup, AddonOption } from './types';
 
 /**
  * Fetch addon groups and options for a menu item using the view `view_addons_for_item`.
  * The view returns one row per option so we group the records by addon_group_id.
  */
-export async function getAddonsForItem(itemId: number | string): Promise<AddonGroup[]> {
+export async function getAddonsForItem(
+  itemId: number | string
+): Promise<AddonGroup[]> {
   const { data, error } = await supabase
     .from('view_addons_for_item')
     .select('*')
@@ -26,12 +15,13 @@ export async function getAddonsForItem(itemId: number | string): Promise<AddonGr
 
   if (error) throw error;
 
-  const map: Record<string | number, AddonGroup> = {};
+  const map: Record<string, AddonGroup> = {};
 
   for (const row of data || []) {
-    if (!map[row.addon_group_id]) {
-      map[row.addon_group_id] = {
-        id: row.addon_group_id,
+    const gId = String(row.addon_group_id);
+    if (!map[gId]) {
+      map[gId] = {
+        id: gId,
         name: row.addon_group_name,
         required: row.required,
         multiple_choice: row.multiple_choice,
@@ -39,8 +29,8 @@ export async function getAddonsForItem(itemId: number | string): Promise<AddonGr
       };
     }
     if (row.addon_option_id) {
-      map[row.addon_group_id].addon_options.push({
-        id: row.addon_option_id,
+      map[gId].addon_options.push({
+        id: String(row.addon_option_id),
         name: row.addon_option_name,
         price: row.price,
       });

--- a/utils/saveItemAddonLinks.ts
+++ b/utils/saveItemAddonLinks.ts
@@ -1,8 +1,8 @@
 import { supabase } from './supabaseClient';
 
 interface ItemLinkData {
-  id: string | number;
-  selectedAddonGroupIds: (string | number)[];
+  id: string;
+  selectedAddonGroupIds: string[];
 }
 
 /**

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -1,0 +1,13 @@
+export interface AddonOption {
+  id: string;
+  name: string;
+  price: number | null;
+}
+
+export interface AddonGroup {
+  id: string;
+  name: string;
+  required: boolean | null;
+  multiple_choice?: boolean | null;
+  addon_options: AddonOption[];
+}


### PR DESCRIPTION
## Summary
- centralize AddonGroup/AddonOption definitions
- enforce AddonGroup ids as strings across project
- update getAddonsForItem to return new types
- adjust MenuItemCard, AddonMultiSelect, AddItemModal and tests
- update menu builder save logic

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_6877dea949588325bf7cfff4afa8ebcb