### PR TITLE
Fix addonData id type for saveItemAddonLinks

### DIFF
--- a/pages/dashboard/menu-builder.tsx
+++ b/pages/dashboard/menu-builder.tsx
@@ -544,12 +544,12 @@ export default function MenuBuilder() {
             itemMap.set(bi.id, inserted.id);
           }
 
-          const addonData: { id: number; selectedAddonGroupIds: string[] }[] = [];
+          const addonData: { id: string; selectedAddonGroupIds: string[] }[] = [];
           for (const bi of buildItems) {
             const newId = itemMap.get(bi.id);
             if (!newId) continue;
             addonData.push({
-              id: newId,
+              id: String(newId),
               selectedAddonGroupIds: Array.isArray(bi.addons)
                 ? bi.addons.map(String)
                 : [],


### PR DESCRIPTION
## Summary
- ensure addon IDs are strings before calling `saveItemAddonLinks`

## Testing
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_6877e4aad24483258dbe8a91e59f7dca