### PR TITLE
Fix addon group loading in AddItemModal

### DIFF
--- a/components/AddItemModal.tsx
+++ b/components/AddItemModal.tsx
@@ -113,7 +113,7 @@ export default function AddItemModal({
         .from('addon_groups')
         .select('*')
         .eq('restaurant_id', restaurantId)
-        .order('sort_order', { ascending: true });
+        .order('id');
       setAddonGroups(addonData || []);
 
       if (item) {


### PR DESCRIPTION
## Summary
- ensure AddItemModal fetches addon groups ordered by id

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877e9db110483258b9e420da0b179c4