### PR TITLE
Update addon link logic when saving items

### DIFF
--- a/components/AddItemModal.tsx
+++ b/components/AddItemModal.tsx
@@ -140,10 +140,10 @@ export default function AddItemModal({
 
         const { data: addonLinks } = await supabase
           .from('item_addon_links')
-          .select('addon_group_id')
+          .select('group_id')
           .eq('item_id', item.id);
         if (addonLinks?.length) {
-          setSelectedAddons(addonLinks.map((l) => String(l.addon_group_id)));
+          setSelectedAddons(addonLinks.map((l) => String(l.group_id)));
         } else {
           setSelectedAddons([]);
         }
@@ -211,6 +211,9 @@ export default function AddItemModal({
 
     if (onSaveData) {
       await onSaveData(itemData, selectedCategories, selectedAddons);
+      if (item?.id) {
+        await updateItemAddonLinks(String(item.id), selectedAddons);
+      }
       onSaved?.();
       onClose();
       return;


### PR DESCRIPTION
## Summary
- fix AddItemModal query for addon groups
- update addon link saving when `onSaveData` handler is used

## Testing
- `npm install`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_6877ecbfd8c08325a8ddc49aeee392a1