### PR TITLE
Fix item-addon link insert conflicts

### DIFF
--- a/components/AddonGroupModal.tsx
+++ b/components/AddonGroupModal.tsx
@@ -163,11 +163,26 @@ export default function AddonGroupModal({
       .filter((it) => selectedCats.includes(it.category_id))
       .map((it) => it.id);
     const itemIds = Array.from(new Set([...selectedItems, ...catItemIds]));
-    await supabase.from('item_addon_links').delete().eq('group_id', groupId);
+    const { error: deleteError } = await supabase
+      .from('item_addon_links')
+      .delete()
+      .eq('group_id', groupId);
+    if (deleteError) {
+      alert('Failed to update item links: ' + deleteError.message);
+      return;
+    }
+
     if (itemIds.length) {
-      await supabase.from('item_addon_links').insert(
-        itemIds.map((id) => ({ item_id: id, group_id: groupId }))
-      );
+      const { error: upsertError } = await supabase
+        .from('item_addon_links')
+        .upsert(
+          itemIds.map((id) => ({ item_id: id, group_id: groupId })),
+          { onConflict: ['item_id', 'group_id'] }
+        );
+      if (upsertError) {
+        alert('Failed to update item links: ' + upsertError.message);
+        return;
+      }
     }
     onSaved();
     onClose();

--- a/utils/saveItemAddonLinks.ts
+++ b/utils/saveItemAddonLinks.ts
@@ -38,7 +38,9 @@ export async function saveItemAddonLinks(items: ItemLinkData[]) {
     );
 
     if (rows.length) {
-      const { error } = await supabase.from('item_addon_links').insert(rows);
+      const { error } = await supabase
+        .from('item_addon_links')
+        .upsert(rows, { onConflict: ['item_id', 'group_id'] });
       if (error) throw error;
     }
   } catch (err) {

--- a/utils/updateItemAddonLinks.ts
+++ b/utils/updateItemAddonLinks.ts
@@ -5,13 +5,25 @@ import { supabase } from './supabaseClient';
  */
 export async function updateItemAddonLinks(itemId: string, selectedAddonGroupIds: string[]) {
   // Remove existing links for the item
-  await supabase.from('item_addon_links').delete().eq('item_id', itemId);
+  try {
+    const { error: deleteError } = await supabase
+      .from('item_addon_links')
+      .delete()
+      .eq('item_id', itemId);
+    if (deleteError) throw deleteError;
 
-  if (selectedAddonGroupIds.length > 0) {
-    const rows = selectedAddonGroupIds.map((groupId) => ({
-      item_id: itemId,
-      group_id: groupId,
-    }));
-    await supabase.from('item_addon_links').insert(rows);
+    if (selectedAddonGroupIds.length > 0) {
+      const rows = selectedAddonGroupIds.map((groupId) => ({
+        item_id: itemId,
+        group_id: groupId,
+      }));
+      const { error: upsertError } = await supabase
+        .from('item_addon_links')
+        .upsert(rows, { onConflict: ['item_id', 'group_id'] });
+      if (upsertError) throw upsertError;
+    }
+  } catch (err) {
+    console.error('Failed to update item addon links', err);
+    throw err;
   }
 }


### PR DESCRIPTION
## Summary
- ensure addon group item links use `upsert`
- add error handling around Supabase operations

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_6877f3eb02688325a171557d09afd5c7