### PR TITLE
Fix item-addon upserts

### DIFF
--- a/utils/saveItemAddonLinks.ts
+++ b/utils/saveItemAddonLinks.ts
@@ -38,7 +38,9 @@ export async function saveItemAddonLinks(items: ItemLinkData[]) {
     );
 
     if (rows.length) {
-      const { error } = await supabase.from('item_addon_links').insert(rows);
+      const { error } = await supabase
+        .from('item_addon_links')
+        .upsert(rows, { onConflict: 'item_id,group_id' });
       if (error) throw error;
     }
   } catch (err) {

--- a/utils/updateItemAddonLinks.ts
+++ b/utils/updateItemAddonLinks.ts
@@ -5,13 +5,25 @@ import { supabase } from './supabaseClient';
  */
 export async function updateItemAddonLinks(itemId: string, selectedAddonGroupIds: string[]) {
   // Remove existing links for the item
-  await supabase.from('item_addon_links').delete().eq('item_id', itemId);
+  try {
+    const { error: deleteError } = await supabase
+      .from('item_addon_links')
+      .delete()
+      .eq('item_id', itemId);
+    if (deleteError) throw deleteError;
 
-  if (selectedAddonGroupIds.length > 0) {
-    const rows = selectedAddonGroupIds.map((groupId) => ({
-      item_id: itemId,
-      group_id: groupId,
-    }));
-    await supabase.from('item_addon_links').insert(rows);
+    if (selectedAddonGroupIds.length > 0) {
+      const rows = selectedAddonGroupIds.map((groupId) => ({
+        item_id: itemId,
+        group_id: groupId,
+      }));
+      const { error: upsertError } = await supabase
+        .from('item_addon_links')
+        .upsert(rows, { onConflict: 'item_id,group_id' });
+      if (upsertError) throw upsertError;
+    }
+  } catch (err) {
+    console.error('Failed to update item addon links', err);
+    throw err;
   }
 }


### PR DESCRIPTION
## Summary
- use comma-separated string for `onConflict` in upsert calls

## Testing
- `npm run test:ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877f3eb02688325a171557d09afd5c7