### PR TITLE
Fix Supabase conflict options

### DIFF
--- a/components/AddonGroupModal.tsx
+++ b/components/AddonGroupModal.tsx
@@ -177,8 +177,7 @@ export default function AddonGroupModal({
         .from('item_addon_links')
         .upsert(
           itemIds.map((id) => ({ item_id: id, group_id: groupId })),
-{ onConflict: ['item_id', 'group_id'] }
-
+          { onConflict: 'item_id,group_id' }
         );
       if (upsertError) {
         alert('Failed to update item links: ' + upsertError.message);

--- a/utils/saveItemAddonLinks.ts
+++ b/utils/saveItemAddonLinks.ts
@@ -40,7 +40,7 @@ export async function saveItemAddonLinks(items: ItemLinkData[]) {
     if (rows.length) {
       const { error } = await supabase
         .from('item_addon_links')
-        .upsert(rows, { onConflict: ['item_id', 'group_id'] });
+        .upsert(rows, { onConflict: 'item_id,group_id' });
 
       if (error) throw error;
     }

--- a/utils/updateItemAddonLinks.ts
+++ b/utils/updateItemAddonLinks.ts
@@ -19,7 +19,7 @@ export async function updateItemAddonLinks(itemId: string, selectedAddonGroupIds
       }));
       const { error: upsertError } = await supabase
         .from('item_addon_links')
-        .upsert(rows, { onConflict: ['item_id', 'group_id'] });
+        .upsert(rows, { onConflict: 'item_id,group_id' });
 
       if (upsertError) throw upsertError;
     }


### PR DESCRIPTION
## Summary
- update the Supabase `upsert` calls to use string syntax for `onConflict`

## Testing
- `npm ci`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_6877fa0c2c8c83259a5882b26f47cf76