### PR TITLE
Fix Build Menu addon link saves

### DIFF
--- a/components/AddItemModal.tsx
+++ b/components/AddItemModal.tsx
@@ -211,9 +211,7 @@ export default function AddItemModal({
 
     if (onSaveData) {
       await onSaveData(itemData, selectedCategories, selectedAddons);
-      if (item?.id) {
-        await updateItemAddonLinks(String(item.id), selectedAddons);
-      }
+      // Draft items are not persisted yet, so skip saving addon links
       onSaved?.();
       onClose();
       return;

--- a/utils/saveItemAddonLinks.ts
+++ b/utils/saveItemAddonLinks.ts
@@ -15,6 +15,9 @@ export async function saveItemAddonLinks(items: ItemLinkData[]) {
 
   // Filter out items without a valid id (unsaved drafts)
   const validItems = items.filter((i) => i.id);
+  if (validItems.length !== items.length) {
+    console.warn('saveItemAddonLinks received items with missing ids');
+  }
   if (!validItems.length) return;
 
   const itemIds = validItems.map((i) => i.id);

--- a/utils/updateItemAddonLinks.ts
+++ b/utils/updateItemAddonLinks.ts
@@ -4,6 +4,11 @@ import { supabase } from './supabaseClient';
  * Replace the addon links for a menu item with the given group IDs.
  */
 export async function updateItemAddonLinks(itemId: string, selectedAddonGroupIds: string[]) {
+  if (!itemId) {
+    const msg = 'updateItemAddonLinks called with invalid itemId';
+    console.error(msg, itemId);
+    throw new Error(msg);
+  }
   // Remove existing links for the item
   try {
     const { error: deleteError } = await supabase


### PR DESCRIPTION
## Summary
- stop saving addon links when editing draft items
- warn when item ids are missing during bulk addon save
- validate itemId in updateItemAddonLinks

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_6877ffc7da9c832582f7f838c879d171