### PR TITLE
Add AddonGroups component

### DIFF
--- a/components/AddonGroups.tsx
+++ b/components/AddonGroups.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+// Render Add-On Groups with basic UI styling
+// Assumes props: addons = array of groups, each with options
+
+// Example of expected `addons` structure (from view_addons_for_item):
+// [
+//   {
+//     group_id: 'uuid',
+//     group_name: 'Size',
+//     required: true,
+//     multiple_choice: false,
+//     max_group_select: 1,
+//     max_option_quantity: 1,
+//     options: [
+//       { id: 'uuid', name: 'Small', price: 0 },
+//       { id: 'uuid', name: 'Large', price: 1.5 }
+//     ]
+//   },
+//   ...
+// ]
+
+export interface AddonOption {
+  id: string;
+  name: string;
+  price: number;
+}
+
+export interface AddonGroup {
+  group_id: string;
+  group_name: string;
+  required?: boolean;
+  multiple_choice?: boolean;
+  max_group_select?: number;
+  max_option_quantity?: number;
+  options: AddonOption[];
+}
+
+export default function AddonGroups({ addons }: { addons: AddonGroup[] }) {
+  return (
+    <div className="space-y-6">
+      {addons.map((group) => (
+        <div key={group.group_id} className="border rounded-xl p-4 shadow-sm">
+          <div className="flex items-center justify-between mb-2">
+            <h3 className="text-lg font-semibold">
+              {group.group_name}{' '}
+              {group.required && (
+                <span className="text-red-500 text-sm ml-2">(Required)</span>
+              )}
+            </h3>
+            <p className="text-sm text-gray-500">
+              {group.multiple_choice
+                ? `Pick up to ${group.max_group_select}`
+                : 'Pick one'}
+            </p>
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            {group.options.map((option) => (
+              <div
+                key={option.id}
+                className="border px-4 py-2 rounded-full text-sm cursor-pointer bg-white hover:bg-gray-100 transition"
+              >
+                {option.name}{' '}
+                {option.price > 0 && (
+                  <span className="text-gray-500">+£{option.price.toFixed(2)}</span>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/__tests__/AddonGroups.test.tsx
+++ b/components/__tests__/AddonGroups.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import AddonGroups, { AddonGroup } from '../AddonGroups';
+
+describe('AddonGroups', () => {
+  it('renders group and option names', () => {
+    const addons: AddonGroup[] = [
+      {
+        group_id: '1',
+        group_name: 'Size',
+        required: true,
+        multiple_choice: false,
+        max_group_select: 1,
+        max_option_quantity: 1,
+        options: [
+          { id: 'a', name: 'Small', price: 0 },
+          { id: 'b', name: 'Large', price: 1.5 },
+        ],
+      },
+    ];
+
+    render(<AddonGroups addons={addons} />);
+
+    expect(screen.getByText('Size')).toBeInTheDocument();
+    expect(screen.getByText('Small')).toBeInTheDocument();
+    expect(screen.getByText('Large')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add `AddonGroups` component to display groups of add-ons
- create a basic test for `AddonGroups`

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_687807447d088325b675b7cc9425ab6e