### PR TITLE
Use AddonGroups component in menu item modal

### DIFF
--- a/components/AddonGroups.tsx
+++ b/components/AddonGroups.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { AddonGroup } from '../utils/types';
 
 // Render Add-On Groups with basic UI styling
 // Assumes props: addons = array of groups, each with options
@@ -20,50 +21,41 @@ import React from 'react';
 //   ...
 // ]
 
-export interface AddonOption {
-  id: string;
-  name: string;
-  price: number;
-}
-
-export interface AddonGroup {
-  group_id: string;
-  group_name: string;
-  required?: boolean;
-  multiple_choice?: boolean;
-  max_group_select?: number;
-  max_option_quantity?: number;
-  options: AddonOption[];
-}
+// Previously this component defined its own AddonGroup interface, but we now
+// reuse the shared type from `utils/types` which exposes a slightly different
+// shape (e.g. `id`/`name` and `addon_options`). To keep the UI the same we map
+// those fields when rendering.
 
 export default function AddonGroups({ addons }: { addons: AddonGroup[] }) {
   return (
     <div className="space-y-6">
       {addons.map((group) => (
-        <div key={group.group_id} className="border rounded-xl p-4 shadow-sm">
+        <div key={group.id} className="border rounded-xl p-4 shadow-sm">
           <div className="flex items-center justify-between mb-2">
             <h3 className="text-lg font-semibold">
-              {group.group_name}{' '}
+              {group.name}{' '}
               {group.required && (
                 <span className="text-red-500 text-sm ml-2">(Required)</span>
               )}
             </h3>
-            <p className="text-sm text-gray-500">
-              {group.multiple_choice
-                ? `Pick up to ${group.max_group_select}`
-                : 'Pick one'}
-            </p>
+            {group.multiple_choice !== undefined && (
+              <p className="text-sm text-gray-500">
+                {group.multiple_choice
+                  ? `Pick up to ${group.max_group_select}`
+                  : 'Pick one'}
+              </p>
+            )}
           </div>
 
           <div className="flex flex-wrap gap-3">
-            {group.options.map((option) => (
+            {group.addon_options.map((option) => (
               <div
                 key={option.id}
                 className="border px-4 py-2 rounded-full text-sm cursor-pointer bg-white hover:bg-gray-100 transition"
               >
                 {option.name}{' '}
-                {option.price > 0 && (
-                  <span className="text-gray-500">+£{option.price.toFixed(2)}</span>
+                {(option.price ?? 0) > 0 && (
+                  <span className="text-gray-500">+£{(option.price! / 100).toFixed(2)}</span>
                 )}
               </div>
             ))}

--- a/components/MenuItemCard.tsx
+++ b/components/MenuItemCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { getAddonsForItem } from '../utils/getAddonsForItem';
 import type { AddonGroup } from '../utils/types';
+import AddonGroups from './AddonGroups';
 
 interface MenuItem {
   id: number;
@@ -85,24 +86,7 @@ export default function MenuItemCard({ item }: { item: MenuItem }) {
             ) : groups.length === 0 ? (
               <p className="text-center text-gray-500">No add-ons available</p>
             ) : (
-              <div className="space-y-4">
-                {groups.map((g) => (
-                  <div key={g.id} className="space-y-1">
-                    <h4 className="font-semibold">
-                      {g.name}{' '}
-                      {g.required ? <span className="text-xs">(Required)</span> : null}
-                    </h4>
-                    <ul className="pl-4 list-disc text-sm">
-                      {g.addon_options.map((o) => (
-                        <li key={o.id} className="flex justify-between">
-                          <span>{o.name}</span>
-                          <span>${((o.price || 0) / 100).toFixed(2)}</span>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                ))}
-              </div>
+              <AddonGroups addons={groups} />
             )}
             <div className="mt-6 flex justify-end">
               <button

--- a/components/__tests__/AddonGroups.test.tsx
+++ b/components/__tests__/AddonGroups.test.tsx
@@ -1,19 +1,18 @@
 import { render, screen } from '@testing-library/react';
-import AddonGroups, { AddonGroup } from '../AddonGroups';
+import AddonGroups from '../AddonGroups';
+import type { AddonGroup } from '../../utils/types';
 
 describe('AddonGroups', () => {
   it('renders group and option names', () => {
     const addons: AddonGroup[] = [
       {
-        group_id: '1',
-        group_name: 'Size',
+        id: '1',
+        name: 'Size',
         required: true,
         multiple_choice: false,
-        max_group_select: 1,
-        max_option_quantity: 1,
-        options: [
+        addon_options: [
           { id: 'a', name: 'Small', price: 0 },
-          { id: 'b', name: 'Large', price: 1.5 },
+          { id: 'b', name: 'Large', price: 150 },
         ],
       },
     ];


### PR DESCRIPTION
## Summary
- update `AddonGroups` to accept shared `AddonGroup` type
- refactor `MenuItemCard` modal to render `<AddonGroups />`
- adjust `AddonGroups` tests for new prop shape

## Testing
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68780aae74d48325ba4902abf9746f42