### PR TITLE
Fix addon group interface

### DIFF
--- a/components/AddonGroups.tsx
+++ b/components/AddonGroups.tsx
@@ -41,11 +41,9 @@ export default function AddonGroups({ addons }: { addons: AddonGroup[] }) {
             {group.multiple_choice !== undefined && (
               <p className="text-sm text-gray-500">
                 {group.multiple_choice
-{group.multiple_choice
-  ? group.max_group_select != null
-    ? `Pick up to ${group.max_group_select}`
-    : 'Multiple Choice'
-  : 'Pick one'}
+                  ? group.max_group_select != null
+                    ? `Multiple Choice (up to ${group.max_group_select})`
+                    : 'Multiple Choice'
                   : 'Pick one'}
               </p>
             )}


### PR DESCRIPTION
## Summary
- handle displaying multiple choice addon limit

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_687814105dbc8325b7a3ba237e4f9d48