### PR TITLE
Add quantity controls to addon options

### DIFF
--- a/components/AddonGroups.tsx
+++ b/components/AddonGroups.tsx
@@ -2,22 +2,26 @@ import { useState } from 'react';
 import type { AddonGroup } from '../utils/types';
 
 export default function AddonGroups({ addons }: { addons: AddonGroup[] }) {
-  const [selectedAddons, setSelectedAddons] = useState<Record<string, string[]>>({});
+  const [selectedQuantities, setSelectedQuantities] = useState<Record<string, Record<string, number>>>({});
 
-  const handleSelect = (groupId: string, optionId: string, multiple?: boolean | null) => {
-    setSelectedAddons(prev => {
-      const current = prev[groupId] || [];
+  const updateQuantity = (
+    groupId: string,
+    optionId: string,
+    delta: number,
+    max: number
+  ) => {
+    setSelectedQuantities(prev => {
+      const group = prev[groupId] || {};
+      const current = group[optionId] || 0;
+      const updatedQty = Math.max(0, Math.min(current + delta, max));
 
-      if (multiple) {
-        return {
-          ...prev,
-          [groupId]: current.includes(optionId)
-            ? current.filter(id => id !== optionId)
-            : [...current, optionId],
-        };
-      }
-
-      return { ...prev, [groupId]: [optionId] };
+      return {
+        ...prev,
+        [groupId]: {
+          ...group,
+          [optionId]: updatedQty,
+        },
+      };
     });
   };
 
@@ -42,16 +46,15 @@ export default function AddonGroups({ addons }: { addons: AddonGroup[] }) {
           </div>
 
           <div className="flex gap-3 overflow-x-auto pb-1">
-            {group.addon_options.map(option => {
-              const isSelected = selectedAddons[group.id]?.includes(option.id) || false;
+            {group.addon_options.map((option) => {
+              const quantity = selectedQuantities[group.id]?.[option.id] || 0;
+              const showQtyControls = !!group.max_option_quantity && group.max_option_quantity > 1;
 
               return (
                 <div
                   key={option.id}
-                  onClick={() =>
-                    handleSelect(group.id, option.id, group.multiple_choice)}
-                  className={`min-w-[140px] max-w-[160px] cursor-pointer border rounded-lg p-3 text-center flex-shrink-0 transition ${
-                    isSelected
+                  className={`min-w-[160px] max-w-[180px] border rounded-lg p-3 text-center flex-shrink-0 transition ${
+                    quantity > 0
                       ? 'border-green-500 bg-green-50 shadow-sm'
                       : 'border-gray-300 bg-white hover:bg-gray-50'
                   }`}
@@ -63,11 +66,62 @@ export default function AddonGroups({ addons }: { addons: AddonGroup[] }) {
                       className="w-full h-20 object-cover rounded mb-2"
                     />
                   )}
+
                   <div className="font-medium">{option.name}</div>
                   {option.price && option.price > 0 && (
                     <div className="text-sm text-gray-500">
                       +£{(option.price / 100).toFixed(2)}
                     </div>
+                  )}
+
+                  {showQtyControls ? (
+                    <div className="flex items-center justify-center gap-2 mt-3">
+                      <button
+                        onClick={() =>
+                          updateQuantity(
+                            group.id,
+                            option.id,
+                            -1,
+                            group.max_option_quantity!
+                          )
+                        }
+                        className="w-8 h-8 rounded-full border border-gray-300 hover:bg-gray-100"
+                      >
+                        –
+                      </button>
+                      <div className="w-6 text-center">{quantity}</div>
+                      <button
+                        onClick={() =>
+                          updateQuantity(
+                            group.id,
+                            option.id,
+                            1,
+                            group.max_option_quantity!
+                          )
+                        }
+                        className="w-8 h-8 rounded-full border border-gray-300 hover:bg-gray-100"
+                      >
+                        +
+                      </button>
+                    </div>
+                  ) : (
+                    <button
+                      onClick={() =>
+                        updateQuantity(
+                          group.id,
+                          option.id,
+                          quantity === 0 ? 1 : -1,
+                          1
+                        )
+                      }
+                      className={`mt-3 w-full text-sm py-1.5 rounded ${
+                        quantity > 0
+                          ? 'bg-green-600 text-white'
+                          : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                      }`}
+                    >
+                      {quantity > 0 ? 'Selected' : 'Select'}
+                    </button>
                   )}
                 </div>
               );

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -11,5 +11,6 @@ export interface AddonGroup {
   required: boolean | null;
   multiple_choice?: boolean | null;
   max_group_select?: number | null;
+  max_option_quantity?: number | null;
   addon_options: AddonOption[];
 }


### PR DESCRIPTION
## Summary
- add max_option_quantity field to AddonGroup type
- track quantities in AddonGroups component
- render +/- buttons and single-select button logic

## Testing
- `npm run test:ci`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6878287e85f88325b2e460a2329555c3