### PR TITLE
Update AddonGroups quantity control

### DIFF
--- a/components/AddonGroups.tsx
+++ b/components/AddonGroups.tsx
@@ -2,7 +2,8 @@ import { useState } from 'react';
 import type { AddonGroup } from '../utils/types';
 
 export default function AddonGroups({ addons }: { addons: AddonGroup[] }) {
-  const [selectedQuantities, setSelectedQuantities] = useState<Record<string, Record<string, number>>>({});
+  const [selectedQuantities, setSelectedQuantities] =
+    useState<Record<string, Record<string, number>>>({});
 
   const updateQuantity = (
     groupId: string,
@@ -48,12 +49,15 @@ export default function AddonGroups({ addons }: { addons: AddonGroup[] }) {
           <div className="flex gap-3 overflow-x-auto pb-1">
             {group.addon_options.map((option) => {
               const quantity = selectedQuantities[group.id]?.[option.id] || 0;
-              const showQtyControls = !!group.max_option_quantity && group.max_option_quantity > 1;
+              const maxQty = group.max_option_quantity || 1;
 
               return (
                 <div
                   key={option.id}
-                  className={`min-w-[160px] max-w-[180px] border rounded-lg p-3 text-center flex-shrink-0 transition ${
+                  onClick={() =>
+                    updateQuantity(group.id, option.id, 1, maxQty)
+                  }
+                  className={`min-w-[160px] max-w-[180px] border rounded-lg p-3 flex-shrink-0 transition cursor-pointer text-center ${
                     quantity > 0
                       ? 'border-green-500 bg-green-50 shadow-sm'
                       : 'border-gray-300 bg-white hover:bg-gray-50'
@@ -74,54 +78,29 @@ export default function AddonGroups({ addons }: { addons: AddonGroup[] }) {
                     </div>
                   )}
 
-                  {showQtyControls ? (
-                    <div className="flex items-center justify-center gap-2 mt-3">
+                  {quantity > 0 && (
+                    <div
+                      className="mt-3 flex justify-center items-center gap-2"
+                      onClick={(e) => e.stopPropagation()}
+                    >
                       <button
                         onClick={() =>
-                          updateQuantity(
-                            group.id,
-                            option.id,
-                            -1,
-                            group.max_option_quantity!
-                          )
+                          updateQuantity(group.id, option.id, -1, maxQty)
                         }
                         className="w-8 h-8 rounded-full border border-gray-300 hover:bg-gray-100"
                       >
                         –
                       </button>
-                      <div className="w-6 text-center">{quantity}</div>
+                      <span className="w-6 text-center">{quantity}</span>
                       <button
                         onClick={() =>
-                          updateQuantity(
-                            group.id,
-                            option.id,
-                            1,
-                            group.max_option_quantity!
-                          )
+                          updateQuantity(group.id, option.id, 1, maxQty)
                         }
                         className="w-8 h-8 rounded-full border border-gray-300 hover:bg-gray-100"
                       >
                         +
                       </button>
                     </div>
-                  ) : (
-                    <button
-                      onClick={() =>
-                        updateQuantity(
-                          group.id,
-                          option.id,
-                          quantity === 0 ? 1 : -1,
-                          1
-                        )
-                      }
-                      className={`mt-3 w-full text-sm py-1.5 rounded ${
-                        quantity > 0
-                          ? 'bg-green-600 text-white'
-                          : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                      }`}
-                    >
-                      {quantity > 0 ? 'Selected' : 'Select'}
-                    </button>
                   )}
                 </div>
               );

--- a/components/__tests__/AddonGroups.test.tsx
+++ b/components/__tests__/AddonGroups.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import AddonGroups from '../AddonGroups';
 import type { AddonGroup } from '../../utils/types';
 
@@ -23,5 +24,30 @@ describe('AddonGroups', () => {
     expect(screen.getByText('Size')).toBeInTheDocument();
     expect(screen.getByText('Small')).toBeInTheDocument();
     expect(screen.getByText('Large')).toBeInTheDocument();
+  });
+
+  it('increments quantity and shows controls on tile click', async () => {
+    const addons: AddonGroup[] = [
+      {
+        id: '1',
+        name: 'Extras',
+        required: false,
+        multiple_choice: true,
+        max_group_select: 2,
+        max_option_quantity: 2,
+        addon_options: [
+          { id: 'a', name: 'Cheese', price: 50 },
+        ],
+      },
+    ];
+
+    render(<AddonGroups addons={addons} />);
+
+    const option = screen.getByText('Cheese');
+    await userEvent.click(option);
+
+    expect(screen.getByText('1')).toBeInTheDocument();
+    await userEvent.click(screen.getByText('Cheese'));
+    expect(screen.getByText('2')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- tweak AddonGroups component interaction
- update AddonGroups test to cover quantity changes

## Testing
- `npm install`
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_6878b6604da0832592e4d1fd8c25e3ec