### PR TITLE
Fix addon quantity buttons

### DIFF
--- a/components/AddonGroups.tsx
+++ b/components/AddonGroups.tsx
@@ -78,23 +78,22 @@ export default function AddonGroups({ addons }: { addons: AddonGroup[] }) {
                   )}
 
                   {quantity > 0 && (
-                    <div
-                      className="mt-3 flex justify-center items-center gap-2"
-                      onClick={(e) => e.stopPropagation()}
-                    >
+                    <div className="mt-3 flex justify-center items-center gap-2">
                       <button
-                        onClick={() =>
-                          updateQuantity(gid, option.id, -1, maxQty)
-                        }
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          updateQuantity(gid, option.id, -1, maxQty);
+                        }}
                         className="w-8 h-8 rounded-full border border-gray-300 hover:bg-gray-100"
                       >
                         –
                       </button>
                       <span className="w-6 text-center">{quantity}</span>
                       <button
-                        onClick={() =>
-                          updateQuantity(gid, option.id, 1, maxQty)
-                        }
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          updateQuantity(gid, option.id, 1, maxQty);
+                        }}
                         className="w-8 h-8 rounded-full border border-gray-300 hover:bg-gray-100"
                       >
                         +


### PR DESCRIPTION
## Summary
- fix +/– controls on AddonGroups tiles by stopping propagation inside the buttons

## Testing
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_6878bec1bbc88325a21ecf3199badd68