### PR TITLE
Fix addon quantity buttons

### DIFF
--- a/components/AddonGroups.tsx
+++ b/components/AddonGroups.tsx
@@ -80,7 +80,9 @@ export default function AddonGroups({ addons }: { addons: AddonGroup[] }) {
                   {quantity > 0 && (
                     <div className="mt-3 flex justify-center items-center gap-2">
                       <button
+                        type="button"
                         onClick={(e: React.MouseEvent) => {
+                          e.preventDefault();
                           e.stopPropagation();
                           updateQuantity(gid, option.id, -1, maxQty);
                         }}
@@ -90,7 +92,9 @@ export default function AddonGroups({ addons }: { addons: AddonGroup[] }) {
                       </button>
                       <span className="w-6 text-center">{quantity}</span>
                       <button
+                        type="button"
                         onClick={(e: React.MouseEvent) => {
+                          e.preventDefault();
                           e.stopPropagation();
                           updateQuantity(gid, option.id, 1, maxQty);
                         }}


### PR DESCRIPTION
## Summary
- ensure +/- buttons don't trigger form submissions
- stop propagation correctly and prevent default actions before adjusting quantity

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6878db9ac6a0832588b62c21d2b0b55e