### PR TITLE
Fix addon quantity limits

### DIFF
--- a/supabase/migrations/20250711000000_create_view_addons_for_item.sql
+++ b/supabase/migrations/20250711000000_create_view_addons_for_item.sql
@@ -5,6 +5,8 @@ SELECT
   ag.name AS addon_group_name,
   ag.required,
   ag.multiple_choice,
+  ag.max_group_select,
+  ag.max_option_quantity,
   ao.id AS addon_option_id,
   ao.name AS addon_option_name,
   ao.price

--- a/utils/getAddonsForItem.ts
+++ b/utils/getAddonsForItem.ts
@@ -25,6 +25,8 @@ export async function getAddonsForItem(
         name: row.addon_group_name,
         required: row.required,
         multiple_choice: row.multiple_choice,
+        max_group_select: row.max_group_select,
+        max_option_quantity: row.max_option_quantity,
         addon_options: [],
       };
     }


### PR DESCRIPTION
## Summary
- include `max_group_select` and `max_option_quantity` columns in `view_addons_for_item`
- expose these fields from `getAddonsForItem`

## Testing
- `npm test -- -t AddonGroups`

------
https://chatgpt.com/codex/tasks/task_e_6878e45779bc8325b68627519ed819d7