### PR TITLE
Fix add-on selection limit logic

### DIFF
--- a/components/AddonGroups.tsx
+++ b/components/AddonGroups.tsx
@@ -15,18 +15,20 @@ export default function AddonGroups({ addons }: { addons: AddonGroup[] }) {
     setSelectedQuantities(prev => {
       const group = prev[groupId] || {};
       const current = group[optionId] || 0;
-      const selectedCount = Object.values(group).filter(q => q > 0).length;
 
-      if (
-        groupMax != null &&
-        current === 0 &&
-        delta > 0 &&
-        selectedCount >= groupMax
-      ) {
+      // Count how many distinct options in this group currently have a
+      // quantity greater than zero.
+      const distinctCount = Object.values(group).filter(q => q > 0).length;
+
+      // Adding a brand new option should respect the group cap. Increasing the
+      // quantity of an already-selected option should not count against the cap.
+      const isNewSelection = current === 0 && delta > 0;
+      if (groupMax != null && isNewSelection && distinctCount >= groupMax) {
         return prev;
       }
 
-      const newQty = Math.max(0, Math.min(current + delta, maxQty));
+      const newQty = Math.min(Math.max(current + delta, 0), maxQty);
+      if (newQty === current) return prev;
 
       return {
         ...prev,

--- a/components/__tests__/AddonGroups.quantityIncreaseWhenAtCap.test.tsx
+++ b/components/__tests__/AddonGroups.quantityIncreaseWhenAtCap.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AddonGroups from '../AddonGroups';
+import type { AddonGroup } from '../../utils/types';
+
+describe('AddonGroups quantity increments when group at cap', () => {
+  it('allows increasing qty of selected option when group at cap', async () => {
+    const addons: AddonGroup[] = [
+      {
+        id: '1',
+        group_id: '1',
+        name: 'Sauce',
+        required: false,
+        multiple_choice: true,
+        max_group_select: 1,
+        max_option_quantity: 10,
+        addon_options: [
+          { id: 'a', name: 'Ketchup', price: 0 },
+          { id: 'b', name: 'Mayo', price: 0 },
+        ],
+      },
+    ];
+
+    render(<AddonGroups addons={addons} />);
+
+    const ketchup = screen.getByText('Ketchup');
+    const mayo = screen.getByText('Mayo');
+
+    await userEvent.click(ketchup); // select ketchup
+    // try to select mayo - should not add due to cap
+    await userEvent.click(mayo);
+    expect(screen.queryByText('1', { selector: 'span' })).toBeInTheDocument();
+    // we expect only ketchup is selected with quantity 1
+    // increase ketchup qty
+    await userEvent.click(screen.getAllByText('+')[0]);
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- update the quantity update logic to distinguish between adding a new option and incrementing an existing one
- add regression test covering increasing quantity when the group is at its distinct option cap

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_687906edf9a883258420339e754a1adf