### PR TITLE
Disable add-on increment when limits hit

### DIFF
--- a/components/AddonGroups.tsx
+++ b/components/AddonGroups.tsx
@@ -111,6 +111,11 @@ export default function AddonGroups({ addons }: { addons: AddonGroup[] }) {
                   ? Infinity
                   : group.max_option_quantity;
               const groupMax = group.max_group_select;
+              const groupSelections = selectedQuantities[gid] || {};
+              const distinctSelected = Object.values(groupSelections).filter(
+                q => q > 0
+              ).length;
+              const groupCapHit = groupMax != null && distinctSelected >= groupMax;
 
               return (
                 <div
@@ -158,7 +163,8 @@ export default function AddonGroups({ addons }: { addons: AddonGroup[] }) {
                           e.stopPropagation();
                           updateQuantity(gid, option.id, 1, maxQty, groupMax);
                         }}
-                        className="w-8 h-8 rounded-full border border-gray-300 hover:bg-gray-100"
+                        disabled={quantity >= maxQty || (groupCapHit && quantity === 0)}
+                        className="w-8 h-8 rounded-full border border-gray-300 hover:bg-gray-100 disabled:opacity-50"
                       >
                         +
                       </button>

--- a/components/__tests__/AddonGroups.test.tsx
+++ b/components/__tests__/AddonGroups.test.tsx
@@ -79,6 +79,29 @@ describe('AddonGroups', () => {
     expect(screen.getByText('1')).toBeInTheDocument();
   });
 
+  it('disables the plus button at max quantity', async () => {
+    const addons: AddonGroup[] = [
+      {
+        id: '1',
+        group_id: '1',
+        name: 'Extras',
+        required: false,
+        multiple_choice: true,
+        max_group_select: 2,
+        max_option_quantity: 1,
+        addon_options: [{ id: 'a', name: 'Cheese', price: 50 }],
+      },
+    ];
+
+    render(<AddonGroups addons={addons} />);
+
+    const option = screen.getByText('Cheese');
+    await userEvent.click(option);
+
+    const plus = screen.getByRole('button', { name: '+' });
+    expect(plus).toBeDisabled();
+  });
+
   it('returns error when required group has no selection', () => {
     const addons: AddonGroup[] = [
       {


### PR DESCRIPTION
## Summary
- prevent exceeding addon caps in `AddonGroups`
- test that the `+` button is disabled when quantity is maxed

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68791f2b368c8325a1feaf4a707f5f3d