### PR TITLE
Fix addon quantity cap enforcement

### DIFF
--- a/components/__tests__/AddonGroups.groupCap.test.tsx
+++ b/components/__tests__/AddonGroups.groupCap.test.tsx
@@ -4,7 +4,7 @@ import AddonGroups from '../AddonGroups';
 import type { AddonGroup } from '../../utils/types';
 
 describe('AddonGroups group cap', () => {
-  it('allows multiple quantities for single option even if group cap is 1', async () => {
+  it('disables increasing quantity when group cap reached', async () => {
     const addons: AddonGroup[] = [
       {
         id: '1',
@@ -22,7 +22,7 @@ describe('AddonGroups group cap', () => {
 
     const option = screen.getByText('Ketchup');
     await userEvent.click(option);
-    await userEvent.click(screen.getByText('+'));
-    expect(screen.getByText('2')).toBeInTheDocument();
+    const plus = screen.getByText('+');
+    expect(plus).toBeDisabled();
   });
 });

--- a/components/__tests__/AddonGroups.quantityIncreaseWhenAtCap.test.tsx
+++ b/components/__tests__/AddonGroups.quantityIncreaseWhenAtCap.test.tsx
@@ -4,7 +4,7 @@ import AddonGroups from '../AddonGroups';
 import type { AddonGroup } from '../../utils/types';
 
 describe('AddonGroups quantity increments when group at cap', () => {
-  it('allows increasing qty of selected option when group at cap', async () => {
+  it('prevents increasing qty when group cap reached', async () => {
     const addons: AddonGroup[] = [
       {
         id: '1',
@@ -30,9 +30,8 @@ describe('AddonGroups quantity increments when group at cap', () => {
     // try to select mayo - should not add due to cap
     await userEvent.click(mayo);
     expect(screen.queryByText('1', { selector: 'span' })).toBeInTheDocument();
-    // we expect only ketchup is selected with quantity 1
-    // increase ketchup qty
-    await userEvent.click(screen.getAllByText('+')[0]);
-    expect(screen.getByText('2')).toBeInTheDocument();
+    // try to increase ketchup qty
+    const plus = screen.getByText('+');
+    expect(plus).toBeDisabled();
   });
 });


### PR DESCRIPTION
## Summary
- enforce group selection cap based on total quantity
- disable `+` when group cap reached
- update tests for new group cap behavior

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_687922cff7c48325950c817927b3bf62