### PR TITLE
Fix plus button disable logic in AddonGroups

### DIFF
--- a/components/AddonGroups.tsx
+++ b/components/AddonGroups.tsx
@@ -59,8 +59,16 @@ export default function AddonGroups({ addons }: { addons: AddonGroup[] }) {
       // Total quantity currently selected in this group
       const totalCount = Object.values(group).reduce((sum, q) => sum + q, 0);
 
-      // Prevent increasing quantities beyond the overall group cap
-      if (groupMax != null && delta > 0 && totalCount >= groupMax) {
+      // Prevent increasing quantities when the group cap is hit and this
+      // option has not been selected yet. This allows increasing the
+      // quantity of an already-selected option even if the group cap is
+      // reached.
+      if (
+        groupMax != null &&
+        delta > 0 &&
+        totalCount >= groupMax &&
+        current === 0
+      ) {
         return prev;
       }
 
@@ -161,7 +169,9 @@ export default function AddonGroups({ addons }: { addons: AddonGroup[] }) {
                           e.stopPropagation();
                           updateQuantity(gid, option.id, 1, maxQty, groupMax);
                         }}
-                        disabled={quantity >= maxQty || groupCapHit}
+                        disabled={
+                          quantity >= maxQty || (groupCapHit && quantity === 0)
+                        }
                         className="w-8 h-8 rounded-full border border-gray-300 hover:bg-gray-100 disabled:opacity-50"
                       >
                         +

--- a/components/__tests__/AddonGroups.groupCap.test.tsx
+++ b/components/__tests__/AddonGroups.groupCap.test.tsx
@@ -23,6 +23,9 @@ describe('AddonGroups group cap', () => {
     const option = screen.getByText('Ketchup');
     await userEvent.click(option);
     const plus = screen.getByText('+');
-    expect(plus).toBeDisabled();
+    // With the group cap reached but this option already selected,
+    // the user should still be able to increase the quantity until the
+    // option's max quantity is hit.
+    expect(plus).not.toBeDisabled();
   });
 });

--- a/components/__tests__/AddonGroups.quantityIncreaseWhenAtCap.test.tsx
+++ b/components/__tests__/AddonGroups.quantityIncreaseWhenAtCap.test.tsx
@@ -4,7 +4,7 @@ import AddonGroups from '../AddonGroups';
 import type { AddonGroup } from '../../utils/types';
 
 describe('AddonGroups quantity increments when group at cap', () => {
-  it('prevents increasing qty when group cap reached', async () => {
+  it('allows increasing qty for existing option when group cap reached', async () => {
     const addons: AddonGroup[] = [
       {
         id: '1',
@@ -32,6 +32,8 @@ describe('AddonGroups quantity increments when group at cap', () => {
     expect(screen.queryByText('1', { selector: 'span' })).toBeInTheDocument();
     // try to increase ketchup qty
     const plus = screen.getByText('+');
-    expect(plus).toBeDisabled();
+    expect(plus).not.toBeDisabled();
+    await userEvent.click(plus);
+    expect(screen.getByText('2')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- allow incrementing quantity when group cap is hit but the option is already selected
- update disabled condition for the "+" button
- update tests to match new behaviour

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_687928b560ec8325b0b4bed1cc99b8bb