### PR TITLE
Fix addon group cap logic

### DIFF
--- a/components/AddonGroups.tsx
+++ b/components/AddonGroups.tsx
@@ -117,11 +117,11 @@ export default function AddonGroups({ addons }: { addons: AddonGroup[] }) {
                   : group.max_option_quantity;
               const groupMax = group.max_group_select;
               const groupSelections = selectedQuantities[gid] || {};
-              const totalSelected = Object.values(groupSelections).reduce(
-                (sum, q) => sum + q,
-                0
-              );
-              const groupCapHit = groupMax != null && totalSelected >= groupMax;
+              const distinctSelected = Object.values(groupSelections).filter(
+                q => q > 0
+              ).length;
+              const groupCapHit =
+                groupMax != null && distinctSelected >= groupMax;
 
               return (
                 <div


### PR DESCRIPTION
## Summary
- fix group selection cap logic to count distinct options
- keep groupCapHit disabled logic for increment button

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68792bf79b908325ad2e914882c6996c