### PR TITLE
Fix AddonGroups quantity cap check

### DIFF
--- a/components/AddonGroups.tsx
+++ b/components/AddonGroups.tsx
@@ -62,6 +62,8 @@ export default function AddonGroups({ addons }: { addons: AddonGroup[] }) {
       const group = prev[groupId] || {};
       const current = group[optionId] || 0;
 
+      if (delta > 0 && current >= maxQty) return prev;
+
       const distinctCount = Object.values(group).filter(q => q > 0).length;
 
       // Prevent selecting a new option when the group cap is hit. Allow


### PR DESCRIPTION
## Summary
- guard against increasing addon quantity once max option quantity is reached

## Testing
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_687939ee77008325be349907b7e406d4