### PR TITLE
Fix addon group save bug

### DIFF
--- a/components/AddonGroupModal.tsx
+++ b/components/AddonGroupModal.tsx
@@ -177,8 +177,8 @@ export default function AddonGroupModal({
         .from('item_addon_links')
         .upsert(
           itemIds.map((id) => ({
-            item_id: Number(id),
-            group_id: Number(groupId),
+            item_id: id,
+            group_id: groupId,
           })),
           { onConflict: 'item_id,group_id' }
         );

--- a/utils/saveItemAddonLinks.ts
+++ b/utils/saveItemAddonLinks.ts
@@ -20,7 +20,7 @@ export async function saveItemAddonLinks(items: ItemLinkData[]) {
   }
   if (!validItems.length) return;
 
-  const itemIds = validItems.map((i) => Number(i.id));
+  const itemIds = validItems.map((i) => i.id);
 
   try {
     // Remove existing links for these items
@@ -35,8 +35,8 @@ export async function saveItemAddonLinks(items: ItemLinkData[]) {
     // Prepare rows for batch insert
     const rows = validItems.flatMap((item) =>
       (item.selectedAddonGroupIds || []).map((gid) => ({
-        item_id: Number(item.id),
-        group_id: Number(gid),
+        item_id: item.id,
+        group_id: gid,
       }))
     );
 

--- a/utils/updateItemAddonLinks.ts
+++ b/utils/updateItemAddonLinks.ts
@@ -17,13 +17,13 @@ export async function updateItemAddonLinks(
     const { error: deleteError } = await supabase
       .from('item_addon_links')
       .delete()
-      .eq('item_id', Number(itemId));
+      .eq('item_id', itemId);
     if (deleteError) throw deleteError;
 
     if (selectedAddonGroupIds.length > 0) {
       const rows = selectedAddonGroupIds.map((groupId) => ({
-        item_id: Number(itemId),
-        group_id: Number(groupId),
+        item_id: itemId,
+        group_id: groupId,
       }));
       const { error: upsertError } = await supabase
         .from('item_addon_links')


### PR DESCRIPTION
## Summary
- handle menu item IDs as strings when updating addon group links
- stop converting IDs to numbers when saving addon links
- avoid numeric conversion when assigning addon groups to items

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_687970e5267c8325ae3c5f07078d10f6