### PR TITLE
Fix item link saving with UUIDs

### DIFF
--- a/components/AddItemModal.tsx
+++ b/components/AddItemModal.tsx
@@ -142,7 +142,7 @@ export default function AddItemModal({
           const { data: links } = await supabase
             .from('menu_item_categories')
             .select('category_id')
-            .eq('item_id', item.id);
+            .eq('item_id', String(item.id));
           if (links?.length) {
             setSelectedCategories(links.map((l) => l.category_id));
           } else if (item.category_id) {
@@ -154,7 +154,7 @@ export default function AddItemModal({
           const { data: addonLinks } = await supabase
             .from('item_addon_links')
             .select('group_id')
-            .eq('item_id', item.id);
+            .eq('item_id', String(item.id));
           if (addonLinks?.length) {
             setSelectedAddons(addonLinks.map((l) => String(l.group_id)));
           } else {
@@ -242,11 +242,17 @@ export default function AddItemModal({
 
     if (data?.id) {
       if (item) {
-        await supabase.from('menu_item_categories').delete().eq('item_id', data.id);
+        await supabase
+          .from('menu_item_categories')
+          .delete()
+          .eq('item_id', String(data.id));
       }
       if (selectedCategories.length) {
         await supabase.from('menu_item_categories').insert(
-          selectedCategories.map((cid) => ({ item_id: data.id, category_id: cid }))
+          selectedCategories.map((cid) => ({
+            item_id: String(data.id),
+            category_id: String(cid),
+          }))
         );
       }
       await updateItemAddonLinks(String(data.id), selectedAddons);
@@ -292,9 +298,15 @@ export default function AddItemModal({
       onClose();
       return;
     }
-    await supabase.from('menu_items').delete().eq('id', item.id);
-    await supabase.from('menu_item_categories').delete().eq('item_id', item.id);
-    await supabase.from('item_addon_links').delete().eq('item_id', item.id);
+    await supabase.from('menu_items').delete().eq('id', String(item.id));
+    await supabase
+      .from('menu_item_categories')
+      .delete()
+      .eq('item_id', String(item.id));
+    await supabase
+      .from('item_addon_links')
+      .delete()
+      .eq('item_id', String(item.id));
     onDeleted?.();
     onClose();
   };

--- a/components/AddonGroupModal.tsx
+++ b/components/AddonGroupModal.tsx
@@ -166,7 +166,7 @@ export default function AddonGroupModal({
     const { error: deleteError } = await supabase
       .from('item_addon_links')
       .delete()
-      .eq('group_id', groupId);
+      .eq('group_id', String(groupId));
     if (deleteError) {
       alert('Failed to update item links: ' + deleteError.message);
       return;
@@ -177,8 +177,8 @@ export default function AddonGroupModal({
         .from('item_addon_links')
         .upsert(
           itemIds.map((id) => ({
-            item_id: id,
-            group_id: groupId,
+            item_id: String(id),
+            group_id: String(groupId),
           })),
           { onConflict: 'item_id,group_id' }
         );

--- a/utils/saveItemAddonLinks.ts
+++ b/utils/saveItemAddonLinks.ts
@@ -20,7 +20,7 @@ export async function saveItemAddonLinks(items: ItemLinkData[]) {
   }
   if (!validItems.length) return;
 
-  const itemIds = validItems.map((i) => i.id);
+  const itemIds = validItems.map((i) => String(i.id));
 
   try {
     // Remove existing links for these items
@@ -35,8 +35,8 @@ export async function saveItemAddonLinks(items: ItemLinkData[]) {
     // Prepare rows for batch insert
     const rows = validItems.flatMap((item) =>
       (item.selectedAddonGroupIds || []).map((gid) => ({
-        item_id: item.id,
-        group_id: gid,
+        item_id: String(item.id),
+        group_id: String(gid),
       }))
     );
 

--- a/utils/updateItemAddonLinks.ts
+++ b/utils/updateItemAddonLinks.ts
@@ -14,16 +14,17 @@ export async function updateItemAddonLinks(
   }
   // Remove existing links for the item
   try {
+    const itemIdStr = String(itemId);
     const { error: deleteError } = await supabase
       .from('item_addon_links')
       .delete()
-      .eq('item_id', itemId);
+      .eq('item_id', itemIdStr);
     if (deleteError) throw deleteError;
 
     if (selectedAddonGroupIds.length > 0) {
       const rows = selectedAddonGroupIds.map((groupId) => ({
-        item_id: itemId,
-        group_id: groupId,
+        item_id: itemIdStr,
+        group_id: String(groupId),
       }));
       const { error: upsertError } = await supabase
         .from('item_addon_links')


### PR DESCRIPTION
## Summary
- ensure addon and category link helpers use string ids
- convert ids to strings in AddonGroupModal and AddItemModal

## Testing
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_687974096dc88325bf2a342014061c43