### PR TITLE
Fix addon limit enforcement with boolean string props

### DIFF
--- a/components/AddonGroups.tsx
+++ b/components/AddonGroups.tsx
@@ -1,9 +1,9 @@
-import { useState } from 'react';
-import type { AddonGroup } from '../utils/types';
+import { useState } from "react";
+import type { AddonGroup } from "../utils/types";
 
 export function validateAddonSelections(
   addons: AddonGroup[],
-  selections: Record<string, Record<string, number>>
+  selections: Record<string, Record<string, number>>,
 ) {
   const errors: Record<string, string> = {};
   for (const group of addons) {
@@ -14,16 +14,16 @@ export function validateAddonSelections(
 
     const messages: string[] = [];
 
-    if (group.required && quantities.every(q => q <= 0)) {
-      messages.push('Selection required');
+    if (group.required && quantities.every((q) => q <= 0)) {
+      messages.push("Selection required");
     }
 
     const effectiveGroupMax =
       group.max_group_select != null
         ? group.max_group_select
-        : group.multiple_choice
-        ? null
-        : 1;
+        : Boolean(group.multiple_choice)
+          ? null
+          : 1;
 
     const distinctSelected = quantities.filter((q) => q > 0).length;
 
@@ -33,21 +33,22 @@ export function validateAddonSelections(
 
     if (
       group.max_option_quantity != null &&
-      quantities.some(q => q > group.max_option_quantity)
+      quantities.some((q) => q > group.max_option_quantity)
     ) {
       messages.push(`Max ${group.max_option_quantity} per option`);
     }
 
     if (messages.length) {
-      errors[gid] = messages.join('. ');
+      errors[gid] = messages.join(". ");
     }
   }
   return errors;
 }
 
 export default function AddonGroups({ addons }: { addons: AddonGroup[] }) {
-  const [selectedQuantities, setSelectedQuantities] =
-    useState<Record<string, Record<string, number>>>({});
+  const [selectedQuantities, setSelectedQuantities] = useState<
+    Record<string, Record<string, number>>
+  >({});
 
   const errors = validateAddonSelections(addons, selectedQuantities);
 
@@ -57,15 +58,15 @@ export default function AddonGroups({ addons }: { addons: AddonGroup[] }) {
     delta: number,
     maxQty: number,
     groupMax: number,
-    multipleChoice: boolean
+    multipleChoice: boolean,
   ) => {
-    setSelectedQuantities(prev => {
+    setSelectedQuantities((prev) => {
       const group = prev[groupId] || {};
       const current = group[optionId] || 0;
 
-      const distinctCount = Object.values(group).filter(q => q > 0).length;
+      const distinctCount = Object.values(group).filter((q) => q > 0).length;
 
-      console.log('updateQuantity', {
+      console.log("updateQuantity", {
         groupId,
         optionId,
         delta,
@@ -84,14 +85,14 @@ export default function AddonGroups({ addons }: { addons: AddonGroup[] }) {
       }
 
       if (delta > 0 && current >= maxQty) {
-        console.log('blocked: option quantity cap');
+        console.log("blocked: option quantity cap");
         return prev;
       }
 
       // Prevent selecting a new option when the group cap is hit. Allow
       // increasing the quantity of an already-selected option.
       if (delta > 0 && distinctCount >= groupMax && current === 0) {
-        console.log('blocked: group cap reached');
+        console.log("blocked: group cap reached");
         return prev;
       }
 
@@ -110,145 +111,193 @@ export default function AddonGroups({ addons }: { addons: AddonGroup[] }) {
 
   return (
     <div className="space-y-6">
-      {addons.map(group => (
-        console.log('render group', {
-          id: group.group_id ?? group.id,
-          multiple_choice: group.multiple_choice,
-          max_option_quantity: group.max_option_quantity,
-          max_group_select: group.max_group_select,
-          required: group.required,
-        }),
-        <div key={group.group_id ?? group.id} className="bg-white border rounded-xl p-4 shadow-sm">
-          <div className="flex justify-between items-center mb-2">
-            <h3 className="text-lg font-semibold">
-              {group.name}
-              {group.required && (
-                <span className="text-red-500 text-sm ml-2">(Required)</span>
-              )}
-            </h3>
-            <p className="text-sm text-gray-500">
-              {group.multiple_choice
-                ? group.max_group_select != null
-                  ? `Pick up to ${group.max_group_select}`
-                  : 'Multiple Choice'
-                : 'Pick one'}
-            </p>
-          </div>
-
-          <div className="flex gap-3 overflow-x-auto pb-1">
-            {group.addon_options.map((option) => {
-              const gid = group.group_id ?? group.id;
-              const quantity = selectedQuantities[gid]?.[option.id] || 0;
-// Determine max quantity per option
-const maxQty = group.multiple_choice
-  ? group.max_option_quantity ?? Infinity
-  : 1;
-
-// Determine max number of distinct selections in group
-const groupMax = group.multiple_choice
-  ? group.max_group_select ?? Infinity
-  : 1;
-
-              const groupSelections = selectedQuantities[gid] || {};
-              const distinctSelected = Object.values(groupSelections).filter(
-                q => q > 0
-              ).length;
-              const groupCapHit = distinctSelected >= groupMax;
-
-              const handleTileClick = () => {
-                if (quantity >= maxQty) {
-                  console.log('blocked: option quantity cap');
-                  return;
-                }
-                if (group.multiple_choice && groupCapHit && quantity === 0) {
-                  console.log('blocked: group cap reached');
-                  return;
-                }
-                updateQuantity(gid, option.id, 1, maxQty, groupMax, !!group.multiple_choice);
-              };
-
-              return (
-                <div
-                  key={option.id}
-onClick={() => {
-  if (quantity >= maxQty) {
-    console.log('blocked click: option quantity cap');
-    return;
-  }
-  if (group.multiple_choice && groupCapHit && quantity === 0) {
-    console.log('blocked click: group cap reached');
-    return;
-  }
-  updateQuantity(gid, option.id, 1, maxQty, groupMax, !!group.multiple_choice);
-}}
-
-                  className={`min-w-[160px] max-w-[180px] border rounded-lg p-3 flex-shrink-0 transition cursor-pointer text-center ${
-                    quantity > 0
-                      ? 'border-green-500 bg-green-50 shadow-sm'
-                      : 'border-gray-300 bg-white hover:bg-gray-50'
-                  } ${
-                    group.multiple_choice &&
-                    (quantity >= maxQty || (groupCapHit && quantity === 0))
-                      ? 'pointer-events-none opacity-50'
-                      : ''
-                  }`}
-                >
-                  {option.image_url && (
-                    <img
-                      src={option.image_url}
-                      alt={option.name}
-                      className="w-full h-20 object-cover rounded mb-2"
-                    />
+      {addons.map(
+        (group) => (
+          console.log("render group", {
+            id: group.group_id ?? group.id,
+            multiple_choice: group.multiple_choice,
+            max_option_quantity: group.max_option_quantity,
+            max_group_select: group.max_group_select,
+            required: group.required,
+          }),
+          (
+            <div
+              key={group.group_id ?? group.id}
+              className="bg-white border rounded-xl p-4 shadow-sm"
+            >
+              <div className="flex justify-between items-center mb-2">
+                <h3 className="text-lg font-semibold">
+                  {group.name}
+                  {group.required && (
+                    <span className="text-red-500 text-sm ml-2">
+                      (Required)
+                    </span>
                   )}
+                </h3>
+                <p className="text-sm text-gray-500">
+                  {(
+                    typeof group.multiple_choice === "string"
+                      ? group.multiple_choice === "true"
+                      : !!group.multiple_choice
+                  )
+                    ? group.max_group_select != null
+                      ? `Pick up to ${group.max_group_select}`
+                      : "Multiple Choice"
+                    : "Pick one"}
+                </p>
+              </div>
 
-                  <div className="font-medium">{option.name}</div>
-                  {option.price && option.price > 0 && (
-                    <div className="text-sm text-gray-500">
-                      +£{(option.price / 100).toFixed(2)}
-                    </div>
-                  )}
+              <div className="flex gap-3 overflow-x-auto pb-1">
+                {group.addon_options.map((option) => {
+                  const gid = group.group_id ?? group.id;
+                  const quantity = selectedQuantities[gid]?.[option.id] || 0;
 
-                  {quantity > 0 && group.multiple_choice && (
-                    <div className="mt-3 flex justify-center items-center gap-2">
-                      <button
-                        type="button"
-                        onClick={(e: React.MouseEvent) => {
-                          e.preventDefault();
-                          e.stopPropagation();
-                          updateQuantity(gid, option.id, -1, maxQty, groupMax, !!group.multiple_choice);
-                        }}
-                        className="w-8 h-8 rounded-full border border-gray-300 hover:bg-gray-100"
-                      >
-                        –
-                      </button>
-                      <span className="w-6 text-center">{quantity}</span>
-                      <button
-                        type="button"
-                        onClick={(e: React.MouseEvent) => {
-                          e.preventDefault();
-                          e.stopPropagation();
-                          updateQuantity(gid, option.id, 1, maxQty, groupMax, !!group.multiple_choice);
-                        }}
-                        disabled={
-                          quantity >= maxQty || (groupCapHit && quantity === 0)
+                  // Cast boolean-like values coming from the API
+                  const multipleChoice =
+                    typeof group.multiple_choice === "string"
+                      ? group.multiple_choice === "true"
+                      : !!group.multiple_choice;
+
+                  // Determine max quantity per option
+                  const maxQty = multipleChoice
+                    ? (group.max_option_quantity ?? Infinity)
+                    : 1;
+
+                  // Determine max number of distinct selections in group
+                  const groupMax = multipleChoice
+                    ? (group.max_group_select ?? Infinity)
+                    : 1;
+
+                  const groupSelections = selectedQuantities[gid] || {};
+                  const distinctSelected = Object.values(
+                    groupSelections,
+                  ).filter((q) => q > 0).length;
+                  const groupCapHit = distinctSelected >= groupMax;
+
+                  const handleTileClick = () => {
+                    if (quantity >= maxQty) {
+                      console.log("blocked: option quantity cap");
+                      return;
+                    }
+                    if (multipleChoice && groupCapHit && quantity === 0) {
+                      console.log("blocked: group cap reached");
+                      return;
+                    }
+                    updateQuantity(
+                      gid,
+                      option.id,
+                      1,
+                      maxQty,
+                      groupMax,
+                      multipleChoice,
+                    );
+                  };
+
+                  return (
+                    <div
+                      key={option.id}
+                      onClick={() => {
+                        if (quantity >= maxQty) {
+                          console.log("blocked click: option quantity cap");
+                          return;
                         }
-                        className="w-8 h-8 rounded-full border border-gray-300 hover:bg-gray-100 disabled:opacity-50"
-                      >
-                        +
-                      </button>
+                        if (multipleChoice && groupCapHit && quantity === 0) {
+                          console.log("blocked click: group cap reached");
+                          return;
+                        }
+                        updateQuantity(
+                          gid,
+                          option.id,
+                          1,
+                          maxQty,
+                          groupMax,
+                          multipleChoice,
+                        );
+                      }}
+                      className={`min-w-[160px] max-w-[180px] border rounded-lg p-3 flex-shrink-0 transition cursor-pointer text-center ${
+                        quantity > 0
+                          ? "border-green-500 bg-green-50 shadow-sm"
+                          : "border-gray-300 bg-white hover:bg-gray-50"
+                      } ${
+                        multipleChoice &&
+                        (quantity >= maxQty || (groupCapHit && quantity === 0))
+                          ? "pointer-events-none opacity-50"
+                          : ""
+                      }`}
+                    >
+                      {option.image_url && (
+                        <img
+                          src={option.image_url}
+                          alt={option.name}
+                          className="w-full h-20 object-cover rounded mb-2"
+                        />
+                      )}
+
+                      <div className="font-medium">{option.name}</div>
+                      {option.price && option.price > 0 && (
+                        <div className="text-sm text-gray-500">
+                          +£{(option.price / 100).toFixed(2)}
+                        </div>
+                      )}
+
+                      {quantity > 0 && multipleChoice && (
+                        <div className="mt-3 flex justify-center items-center gap-2">
+                          <button
+                            type="button"
+                            onClick={(e: React.MouseEvent) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              updateQuantity(
+                                gid,
+                                option.id,
+                                -1,
+                                maxQty,
+                                groupMax,
+                                multipleChoice,
+                              );
+                            }}
+                            className="w-8 h-8 rounded-full border border-gray-300 hover:bg-gray-100"
+                          >
+                            –
+                          </button>
+                          <span className="w-6 text-center">{quantity}</span>
+                          <button
+                            type="button"
+                            onClick={(e: React.MouseEvent) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              updateQuantity(
+                                gid,
+                                option.id,
+                                1,
+                                maxQty,
+                                groupMax,
+                                multipleChoice,
+                              );
+                            }}
+                            disabled={
+                              quantity >= maxQty ||
+                              (groupCapHit && quantity === 0)
+                            }
+                            className="w-8 h-8 rounded-full border border-gray-300 hover:bg-gray-100 disabled:opacity-50"
+                          >
+                            +
+                          </button>
+                        </div>
+                      )}
                     </div>
-                  )}
-                </div>
-              );
-            })}
-          </div>
-          {errors[group.group_id ?? group.id] && (
-            <p className="text-red-600 text-sm mt-2">
-              {errors[group.group_id ?? group.id]}
-            </p>
-          )}
-        </div>
-      ))}
+                  );
+                })}
+              </div>
+              {errors[group.group_id ?? group.id] && (
+                <p className="text-red-600 text-sm mt-2">
+                  {errors[group.group_id ?? group.id]}
+                </p>
+              )}
+            </div>
+          )
+        ),
+      )}
     </div>
   );
 }

--- a/components/__tests__/AddonGroups.booleanStringProps.test.tsx
+++ b/components/__tests__/AddonGroups.booleanStringProps.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AddonGroups from "../AddonGroups";
+import type { AddonGroup } from "../../utils/types";
+
+describe("AddonGroups boolean string props", () => {
+  it('treats "false" string as false (single choice)', async () => {
+    const addons: AddonGroup[] = [
+      {
+        id: "1",
+        group_id: "1",
+        name: "Size",
+        required: false,
+        multiple_choice: "false" as unknown as any,
+        max_option_quantity: 1,
+        addon_options: [
+          { id: "a", name: "Small", price: 0 },
+          { id: "b", name: "Large", price: 0 },
+        ],
+      },
+    ];
+
+    const { container } = render(<AddonGroups addons={addons} />);
+
+    const small = screen.getByText("Small");
+    const large = screen.getByText("Large");
+
+    await userEvent.click(small);
+    await userEvent.click(large);
+
+    const selected = container.querySelectorAll(".border-green-500");
+    expect(selected).toHaveLength(1);
+    expect(selected[0]).toHaveTextContent("Large");
+  });
+
+  it('treats "true" string as true and enforces caps', async () => {
+    const addons: AddonGroup[] = [
+      {
+        id: "1",
+        group_id: "1",
+        name: "Extras",
+        required: false,
+        multiple_choice: "true" as unknown as any,
+        max_group_select: 1,
+        max_option_quantity: 2,
+        addon_options: [
+          { id: "a", name: "Cheese", price: 0 },
+          { id: "b", name: "Bacon", price: 0 },
+        ],
+      },
+    ];
+
+    render(<AddonGroups addons={addons} />);
+
+    const cheese = screen.getByText("Cheese");
+    const bacon = screen.getByText("Bacon");
+
+    await userEvent.click(cheese);
+    await userEvent.click(bacon);
+    await userEvent.click(bacon);
+
+    // group cap reached - cheese quantity should remain 1
+    const qtySpans = screen.getAllByText("1");
+    expect(qtySpans.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- normalize `multiple_choice` props that may come as strings
- update addon group component to use normalized boolean
- add regression test for string boolean props

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687a18b4e9b48325acfde2b2cdc07846