### PR TITLE
Fix addon assignment persistence

### DIFF
--- a/utils/saveItemAddonLinks.ts
+++ b/utils/saveItemAddonLinks.ts
@@ -33,12 +33,13 @@ export async function saveItemAddonLinks(items: ItemLinkData[]) {
     }
 
     // Prepare rows for batch insert
-    const rows = validItems.flatMap((item) =>
-      (item.selectedAddonGroupIds || []).map((gid) => ({
+    const rows = validItems.flatMap((item) => {
+      const unique = Array.from(new Set((item.selectedAddonGroupIds || []).map(String)));
+      return unique.map((gid) => ({
         item_id: String(item.id),
-        group_id: String(gid),
-      }))
-    );
+        group_id: gid,
+      }));
+    });
 
     if (rows.length) {
       const { error } = await supabase

--- a/utils/updateItemAddonLinks.ts
+++ b/utils/updateItemAddonLinks.ts
@@ -22,9 +22,10 @@ export async function updateItemAddonLinks(
     if (deleteError) throw deleteError;
 
     if (selectedAddonGroupIds.length > 0) {
-      const rows = selectedAddonGroupIds.map((groupId) => ({
+      const unique = Array.from(new Set(selectedAddonGroupIds.map(String)));
+      const rows = unique.map((groupId) => ({
         item_id: itemIdStr,
-        group_id: String(groupId),
+        group_id: groupId,
       }));
       const { error: upsertError } = await supabase
         .from('item_addon_links')


### PR DESCRIPTION
## Summary
- preserve item assignments when editing addon group assignments
- dedupe addon links when saving

## Testing
- `npx tsc -p tsconfig.json`
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_687a8c6f32f48325841bf2f30a94f239