### PR TITLE
Fix addon group cap counting

### DIFF
--- a/components/AddonGroups.tsx
+++ b/components/AddonGroups.tsx
@@ -182,10 +182,11 @@ export default function AddonGroups({ addons }: { addons: AddonGroup[] }) {
                     : 1;
 
                   const groupSelections = selectedQuantities[gid] || {};
-                  const distinctSelected = Object.values(groupSelections).filter(
-                    (q) => q > 0,
-                  ).length;
-                  const groupCapHit = distinctSelected >= groupMax;
+                  const totalGroupQty = Object.values(groupSelections).reduce(
+                    (sum, q) => sum + q,
+                    0,
+                  );
+                  const groupCapHit = totalGroupQty >= groupMax;
 
                   const handleTileClick = () => {
                     if (maxQty === 0 || groupMax === 0) return;

--- a/components/__tests__/AddonGroups.multiChoiceLimits.test.tsx
+++ b/components/__tests__/AddonGroups.multiChoiceLimits.test.tsx
@@ -40,7 +40,8 @@ describe('AddonGroups multiple choice limits', () => {
     // select a second option
     const bacon = screen.getByText('Bacon');
     await userEvent.click(bacon);
-    expect(screen.getByText('1')).toBeInTheDocument();
+    // selection should be blocked when total group quantity at cap
+    expect(screen.queryByText('1')).not.toBeInTheDocument();
 
     // group cap reached - new option should not be added
     const onion = screen.getByText('Onion');
@@ -48,7 +49,7 @@ describe('AddonGroups multiple choice limits', () => {
     // only two qty displays should be present (3 and 1)
     const spans = container.querySelectorAll('span');
     const qtyVals = Array.from(spans).map(s => s.textContent);
-    expect(qtyVals.filter(v => v === '1').length).toBe(1);
+    expect(qtyVals.filter(v => v === '1').length).toBe(0);
     expect(qtyVals.filter(v => v === '3').length).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- enforce addon group selection cap based on total quantity
- update multi-choice limits test for new behavior

## Testing
- `npm run test:ci --silent`

------
https://chatgpt.com/codex/tasks/task_e_687aacf01fa88325a8deba3b22087098