### PR TITLE
Fix addon group quantity cap enforcement

### DIFF
--- a/components/__tests__/AddonGroups.groupCap.test.tsx
+++ b/components/__tests__/AddonGroups.groupCap.test.tsx
@@ -23,9 +23,8 @@ describe('AddonGroups group cap', () => {
     const option = screen.getByText('Ketchup');
     await userEvent.click(option);
     const plus = screen.getByText('+');
-    // With the group cap reached but this option already selected,
-    // the user should still be able to increase the quantity until the
-    // option's max quantity is hit.
-    expect(plus).not.toBeDisabled();
+    // Once the group cap is reached, even the selected option cannot be
+    // increased further.
+    expect(plus).toBeDisabled();
   });
 });

--- a/components/__tests__/AddonGroups.multiChoiceLimits.test.tsx
+++ b/components/__tests__/AddonGroups.multiChoiceLimits.test.tsx
@@ -27,15 +27,14 @@ describe('AddonGroups multiple choice limits', () => {
     const cheese = screen.getByText('Cheese');
     await userEvent.click(cheese);
     await userEvent.click(cheese);
-    await userEvent.click(cheese);
 
-    // plus button should be disabled at per-option cap
+    // plus button should be disabled at group cap
     let plus = screen.getByRole('button', { name: '+' });
     expect(plus).toBeDisabled();
 
     // clicking again should not increase quantity
     await userEvent.click(cheese);
-    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
 
     // select a second option
     const bacon = screen.getByText('Bacon');
@@ -46,10 +45,10 @@ describe('AddonGroups multiple choice limits', () => {
     // group cap reached - new option should not be added
     const onion = screen.getByText('Onion');
     await userEvent.click(onion);
-    // only two qty displays should be present (3 and 1)
+    // only one qty display should remain (2)
     const spans = container.querySelectorAll('span');
     const qtyVals = Array.from(spans).map(s => s.textContent);
     expect(qtyVals.filter(v => v === '1').length).toBe(0);
-    expect(qtyVals.filter(v => v === '3').length).toBe(1);
+    expect(qtyVals.filter(v => v === '2').length).toBe(1);
   });
 });

--- a/components/__tests__/AddonGroups.quantityIncreaseWhenAtCap.test.tsx
+++ b/components/__tests__/AddonGroups.quantityIncreaseWhenAtCap.test.tsx
@@ -4,7 +4,7 @@ import AddonGroups from '../AddonGroups';
 import type { AddonGroup } from '../../utils/types';
 
 describe('AddonGroups quantity increments when group at cap', () => {
-  it('allows increasing qty for existing option when group cap reached', async () => {
+  it('disables increasing qty when group cap reached', async () => {
     const addons: AddonGroup[] = [
       {
         id: '1',
@@ -32,8 +32,8 @@ describe('AddonGroups quantity increments when group at cap', () => {
     expect(screen.queryByText('1', { selector: 'span' })).toBeInTheDocument();
     // try to increase ketchup qty
     const plus = screen.getByText('+');
-    expect(plus).not.toBeDisabled();
+    expect(plus).toBeDisabled();
     await userEvent.click(plus);
-    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- enforce `max_group_select` as total quantity cap
- block increments when group at cap
- ensure UI disables options correctly
- update tests for new group cap rules

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687e412e2d8c83259e77f3c8370ef0bc