### PR TITLE
Add simple CartTest component

### DIFF
--- a/components/CartTest.tsx
+++ b/components/CartTest.tsx
@@ -1,0 +1,37 @@
+import { useCart } from '../context/CartContext';
+
+export default function CartTest() {
+  const { cart, subtotal, addToCart, clearCart } = useCart();
+
+  const handleAdd = () => {
+    addToCart('test', {
+      item_id: 'test-burger',
+      name: 'Burger',
+      price: 9.99,
+      quantity: 1,
+    });
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <p className="text-lg">Items in cart: {cart.items.length}</p>
+      <p className="text-lg">Subtotal: ${subtotal.toFixed(2)}</p>
+      <div className="flex gap-4">
+        <button
+          type="button"
+          onClick={handleAdd}
+          className="px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-700"
+        >
+          Add Test Item
+        </button>
+        <button
+          type="button"
+          onClick={clearCart}
+          className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300"
+        >
+          Clear Cart
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/pages/test-cart.tsx
+++ b/pages/test-cart.tsx
@@ -1,0 +1,10 @@
+import CartTest from '../components/CartTest';
+
+export default function TestCartPage() {
+  return (
+    <main className="p-6 max-w-md mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Cart Test</h1>
+      <CartTest />
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- create `CartTest` component to display cart size & subtotal
- add button to add a sample Burger item and clear cart
- create `/test-cart` page to demo component

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_687e4c53baa48325be9f059709032601