### PR TITLE
Add order type modal

### DIFF
--- a/components/OrderTypeModal.tsx
+++ b/components/OrderTypeModal.tsx
@@ -1,0 +1,37 @@
+import { useRef } from 'react';
+
+interface OrderTypeModalProps {
+  onSelect: (type: 'delivery' | 'collection') => void;
+}
+
+export default function OrderTypeModal({ onSelect }: OrderTypeModalProps) {
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+  return (
+    <div
+      ref={overlayRef}
+      onClick={(e) => e.target === overlayRef.current && null}
+      className="fixed inset-0 bg-black/40 flex items-center justify-center z-[1000]"
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="bg-white rounded-xl p-6 w-80 text-center"
+      >
+        <h3 className="text-lg font-semibold mb-6">How would you like to order?</h3>
+        <div className="space-y-4">
+          <button
+            onClick={() => onSelect('delivery')}
+            className="w-full py-3 bg-teal-600 text-white text-lg rounded-lg hover:bg-teal-700"
+          >
+            Delivery
+          </button>
+          <button
+            onClick={() => onSelect('collection')}
+            className="w-full py-3 bg-teal-600 text-white text-lg rounded-lg hover:bg-teal-700"
+          >
+            Collection
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/context/OrderTypeContext.tsx
+++ b/context/OrderTypeContext.tsx
@@ -1,0 +1,49 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import OrderTypeModal from '../components/OrderTypeModal';
+
+export type OrderType = 'delivery' | 'collection';
+
+interface OrderTypeContextValue {
+  orderType: OrderType | null;
+  setOrderType: (type: OrderType) => void;
+}
+
+const OrderTypeContext = createContext<OrderTypeContextValue | undefined>(undefined);
+
+export function OrderTypeProvider({ children }: { children: ReactNode }) {
+  const [orderType, setOrderTypeState] = useState<OrderType | null>(null);
+  const [showModal, setShowModal] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('orderfast_order_type');
+    if (stored === 'delivery' || stored === 'collection') {
+      setOrderTypeState(stored as OrderType);
+    } else {
+      setShowModal(true);
+    }
+  }, []);
+
+  const setOrderType = (type: OrderType) => {
+    localStorage.setItem('orderfast_order_type', type);
+    setOrderTypeState(type);
+    setShowModal(false);
+  };
+
+  const value: OrderTypeContextValue = {
+    orderType,
+    setOrderType,
+  };
+
+  return (
+    <OrderTypeContext.Provider value={value}>
+      {children}
+      {showModal && <OrderTypeModal onSelect={setOrderType} />}
+    </OrderTypeContext.Provider>
+  );
+}
+
+export function useOrderType() {
+  const ctx = useContext(OrderTypeContext);
+  if (!ctx) throw new Error('useOrderType must be used within OrderTypeProvider');
+  return ctx;
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,15 +3,18 @@ import { SessionContextProvider } from '@supabase/auth-helpers-react';
 import { createBrowserSupabaseClient } from '@supabase/auth-helpers-nextjs';
 import { useState } from 'react';
 import { CartProvider } from '../context/CartContext';
+import { OrderTypeProvider } from '../context/OrderTypeContext';
 
 export default function App({ Component, pageProps }) {
   const [supabase] = useState(() => createBrowserSupabaseClient());
 
   return (
     <SessionContextProvider supabaseClient={supabase} initialSession={pageProps.initialSession}>
-      <CartProvider>
-        <Component {...pageProps} />
-      </CartProvider>
+      <OrderTypeProvider>
+        <CartProvider>
+          <Component {...pageProps} />
+        </CartProvider>
+      </OrderTypeProvider>
     </SessionContextProvider>
   );
 }


### PR DESCRIPTION
## Summary
- ask users how they want to order when app loads
- store selection in localStorage and context

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e506bbcd083259e45bbe139c31def