### PR TITLE
Add add-to-cart UI

### DIFF
--- a/__tests__/MenuItemCard.test.tsx
+++ b/__tests__/MenuItemCard.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MenuItemCard from '../components/MenuItemCard';
+import { useCart } from '../context/CartContext';
+
+jest.mock('../utils/getAddonsForItem', () => ({
+  getAddonsForItem: jest.fn(() => Promise.resolve([])),
+}));
+
+jest.mock('../context/CartContext', () => ({
+  useCart: jest.fn(),
+}));
+
+const mockUseCart = useCart as jest.Mock;
+
+describe('MenuItemCard', () => {
+  beforeEach(() => {
+    mockUseCart.mockReturnValue({
+      cart: { restaurant_id: null, items: [] },
+      subtotal: 0,
+      addToCart: jest.fn(),
+      removeFromCart: jest.fn(),
+      updateQuantity: jest.fn(),
+      clearCart: jest.fn(),
+      setItemNotes: jest.fn(),
+    });
+  });
+
+  it('updates quantity when + button clicked', async () => {
+    render(
+      <MenuItemCard item={{ id: 1, name: 'Burger', price: 5 }} restaurantId="1" />
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: '+' }));
+    expect(screen.getByTestId('qty').textContent).toBe('2');
+  });
+
+  it('does not allow quantity below 1', async () => {
+    const item = { id: 2, name: 'Fries', price: 3 };
+    render(<MenuItemCard item={item} restaurantId="1" />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: '-' }));
+    expect(screen.getByTestId('qty').textContent).toBe('1');
+  });
+});

--- a/pages/restaurant/menu.tsx
+++ b/pages/restaurant/menu.tsx
@@ -160,7 +160,11 @@ export default function RestaurantMenuPage() {
                 <h2 className="text-xl font-semibold text-left">{cat.name}</h2>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                   {catItems.map((item) => (
-                    <MenuItemCard key={item.id} item={item} />
+                    <MenuItemCard
+                      key={item.id}
+                      item={item}
+                      restaurantId={restaurantId as string}
+                    />
                   ))}
                 </div>
               </section>


### PR DESCRIPTION
## Summary
- add cart interactions to `MenuItemCard`
- pass `restaurantId` to menu item cards
- test quantity controls for menu items

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_687e52e54c3883259e96664db7fd59af