### PR TITLE
Fix menu add-on modal flow

### DIFF
--- a/__tests__/MenuItemCard.test.tsx
+++ b/__tests__/MenuItemCard.test.tsx
@@ -26,19 +26,21 @@ describe('MenuItemCard', () => {
     });
   });
 
-  it('updates quantity when + button clicked', async () => {
+  it('opens modal and updates quantity inside', async () => {
     render(
       <MenuItemCard item={{ id: 1, name: 'Burger', price: 5 }} restaurantId="1" />
     );
     const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'Add to Cart' }));
     await user.click(screen.getByRole('button', { name: '+' }));
     expect(screen.getByTestId('qty').textContent).toBe('2');
   });
 
-  it('does not allow quantity below 1', async () => {
+  it('does not allow quantity below 1 in modal', async () => {
     const item = { id: 2, name: 'Fries', price: 3 };
     render(<MenuItemCard item={item} restaurantId="1" />);
     const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'Add to Cart' }));
     await user.click(screen.getByRole('button', { name: '-' }));
     expect(screen.getByTestId('qty').textContent).toBe('1');
   });

--- a/components/AddonGroups.tsx
+++ b/components/AddonGroups.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import type { AddonGroup } from "../utils/types";
 
 export function validateAddonSelections(
@@ -47,12 +47,26 @@ export function validateAddonSelections(
   return errors;
 }
 
-export default function AddonGroups({ addons }: { addons: AddonGroup[] }) {
+export default function AddonGroups({
+  addons,
+  onChange,
+  initialSelections,
+}: {
+  addons: AddonGroup[];
+  onChange?: (sel: Record<string, Record<string, number>>) => void;
+  initialSelections?: Record<string, Record<string, number>>;
+}) {
   const [selectedQuantities, setSelectedQuantities] = useState<
     Record<string, Record<string, number>>
-  >({});
+  >(initialSelections || {});
 
   const errors = validateAddonSelections(addons, selectedQuantities);
+
+  useEffect(() => {
+    if (onChange) {
+      onChange(selectedQuantities);
+    }
+  }, [selectedQuantities, onChange]);
 
   const updateQuantity = (
     groupId: string,


### PR DESCRIPTION
## Summary
- open quantity/add-on modal from menu item button
- allow passing selections from `AddonGroups`
- update tests for new modal flow

## Testing
- `npm run test:ci` *(fails: npm unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_687e578cb7408325ba7552f7257c83a0