### PR TITLE
Add floating cart drawer globally

### DIFF
--- a/components/CartDrawer.tsx
+++ b/components/CartDrawer.tsx
@@ -16,15 +16,13 @@ export default function CartDrawer() {
       <button
         type="button"
         onClick={toggle}
-        className="fixed bottom-4 right-4 bg-teal-600 text-white rounded-full w-12 h-12 flex items-center justify-center shadow-lg z-50"
+        className="fixed bottom-4 right-4 bg-teal-600 text-white rounded-full px-4 py-2 flex items-center shadow-lg z-50"
         aria-label="Toggle cart"
       >
-        <ShoppingCartIcon className="w-6 h-6" />
-        {itemCount > 0 && (
-          <span className="absolute -top-1 -right-1 bg-red-600 text-xs w-5 h-5 rounded-full flex items-center justify-center">
-            {itemCount}
-          </span>
-        )}
+        <ShoppingCartIcon className="w-5 h-5 mr-2" />
+        <span>
+          Cart ({itemCount} {itemCount === 1 ? 'item' : 'items'})
+        </span>
       </button>
       {open && (
         <>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,6 +4,7 @@ import { createBrowserSupabaseClient } from '@supabase/auth-helpers-nextjs';
 import { useState } from 'react';
 import { CartProvider } from '../context/CartContext';
 import { OrderTypeProvider } from '../context/OrderTypeContext';
+import CartDrawer from '../components/CartDrawer';
 
 export default function App({ Component, pageProps }) {
   const [supabase] = useState(() => createBrowserSupabaseClient());
@@ -13,6 +14,7 @@ export default function App({ Component, pageProps }) {
       <OrderTypeProvider>
         <CartProvider>
           <Component {...pageProps} />
+          <CartDrawer />
         </CartProvider>
       </OrderTypeProvider>
     </SessionContextProvider>


### PR DESCRIPTION
## Summary
- show cart button with item count in `CartDrawer`
- render `CartDrawer` from the root `_app`

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_687e628678e483259bb48d64dee3472c