### PR TITLE
Add category images and navigation

### DIFF
--- a/supabase/migrations/20250712000000_add_category_image_url.sql
+++ b/supabase/migrations/20250712000000_add_category_image_url.sql
@@ -1,0 +1,1 @@
+alter table menu_categories add column if not exists image_url text;


### PR DESCRIPTION
## Summary
- add `image_url` column for categories
- allow admins to upload a category image
- show images or default icons in menu category bar
- implement horizontal scroll navigation for menu

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_687e6e3f90bc832585b77e4145e6e5dd