### PR TITLE
Add highlight & modal to pending orders

### DIFF
--- a/components/OrderDetailsModal.tsx
+++ b/components/OrderDetailsModal.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useRef } from 'react';
+import { XMarkIcon } from '@heroicons/react/24/outline';
+
+interface OrderAddon {
+  id: number;
+  name: string;
+  price: number;
+  quantity: number;
+}
+
+interface OrderItem {
+  id: number;
+  name: string;
+  price: number;
+  quantity: number;
+  notes: string | null;
+  order_addons: OrderAddon[];
+}
+
+export interface Order {
+  id: string;
+  order_type: 'delivery' | 'collection';
+  customer_name: string | null;
+  phone_number: string | null;
+  delivery_address: any;
+  scheduled_for: string | null;
+  customer_notes: string | null;
+  status: string;
+  total_price: number | null;
+  created_at: string;
+  order_items: OrderItem[];
+}
+
+interface Props {
+  order: Order | null;
+  onClose: () => void;
+  onUpdateStatus: (id: string, status: string) => void;
+}
+
+const formatPrice = (p: number | null) => {
+  return p ? `£${(p / 100).toFixed(2)}` : '£0.00';
+};
+
+const formatAddress = (addr: any) => {
+  if (!addr) return '';
+  return [addr.address_line_1, addr.address_line_2, addr.postcode]
+    .filter(Boolean)
+    .join(', ');
+};
+
+export default function OrderDetailsModal({ order, onClose, onUpdateStatus }: Props) {
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!order) return;
+    const original = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = original;
+    };
+  }, [order]);
+
+  if (!order) return null;
+
+  return (
+    <div
+      ref={overlayRef}
+      onClick={(e) => {
+        if (e.target === overlayRef.current) onClose();
+      }}
+      className="fixed inset-0 bg-black/40 flex items-center justify-center p-4 z-[1000]"
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="bg-white rounded-xl shadow-lg w-full max-w-lg max-h-[90vh] overflow-y-auto relative"
+      >
+        <button
+          type="button"
+          aria-label="Close"
+          onClick={onClose}
+          className="absolute right-2 top-2 text-gray-500 hover:text-gray-700"
+        >
+          <XMarkIcon className="w-5 h-5" />
+        </button>
+        <div className="p-6 space-y-4 text-sm">
+          <h3 className="text-xl font-semibold">Order #{order.id.slice(-6)}</h3>
+          <p>
+            <strong>Customer:</strong> {order.customer_name || 'Guest'} {order.phone_number || ''}
+          </p>
+          {order.order_type === 'delivery' && order.delivery_address && (
+            <p>
+              <strong>Address:</strong> {formatAddress(order.delivery_address)}
+            </p>
+          )}
+          <p>
+            <strong>Status:</strong> {order.status}
+          </p>
+          <p>
+            <strong>Placed:</strong> {new Date(order.created_at).toLocaleString()}
+          </p>
+          <ul className="space-y-2">
+            {order.order_items.map((it) => (
+              <li key={it.id} className="border rounded p-2">
+                <div className="flex justify-between">
+                  <span>
+                    {it.name} × {it.quantity}
+                  </span>
+                  <span>{formatPrice(it.price * it.quantity)}</span>
+                </div>
+                {it.order_addons && it.order_addons.length > 0 && (
+                  <ul className="mt-1 ml-4 space-y-1 text-gray-600">
+                    {it.order_addons.map((ad) => (
+                      <li key={ad.id} className="flex justify-between">
+                        <span>
+                          {ad.name} × {ad.quantity}
+                        </span>
+                        <span>{formatPrice(ad.price * ad.quantity)}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                {it.notes && <p className="italic ml-4 mt-1">{it.notes}</p>}
+              </li>
+            ))}
+          </ul>
+          {order.customer_notes && <p className="italic">{order.customer_notes}</p>}
+          <p className="font-semibold">Total: {formatPrice(order.total_price)}</p>
+          <div className="flex justify-end space-x-2 pt-2">
+            <button
+              type="button"
+              onClick={() => onUpdateStatus(order.id, 'accepted')}
+              className="px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-700"
+            >
+              Accept
+            </button>
+            <button
+              type="button"
+              onClick={() => onUpdateStatus(order.id, 'completed')}
+              className="px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-700"
+            >
+              Complete
+            </button>
+            <button
+              type="button"
+              onClick={() => onUpdateStatus(order.id, 'cancelled')}
+              className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `OrderDetailsModal` component for viewing and managing one order
- refactor Orders dashboard page to show a single list
- highlight recent pending orders and refresh highlighting periodically
- open modal on click to accept/complete/cancel

## Testing
- `npm install`
- `npm test -- -b`


------
https://chatgpt.com/codex/tasks/task_e_687f75db0be88325aeec9c84af5abcff