### PR TITLE
Add break feature to orders page

### DIFF
--- a/supabase/migrations/20250722143000_add_break_until.sql
+++ b/supabase/migrations/20250722143000_add_break_until.sql
@@ -1,0 +1,5 @@
+-- Add break_until column to restaurants table
+alter table restaurants
+  add column if not exists break_until timestamptz;
+
+-- Allow null by default; no default values.


### PR DESCRIPTION
## Summary
- add `break_until` column migration for restaurants table
- manage restaurant breaks from Orders page with Take a Break button
- show live break countdown and automatically reopen restaurant
- subscribe to restaurant updates for realtime UI

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_687f9dd0705c8325a947830f3a9f1455