### PR TITLE
Refine break handling in orders page

### DIFF
--- a/components/BreakModal.tsx
+++ b/components/BreakModal.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+interface BreakModalProps {
+  show: boolean;
+  onClose: () => void;
+  onSelect: (mins: number) => void;
+}
+
+export default function BreakModal({ show, onClose, onSelect }: BreakModalProps) {
+  if (!show) return null;
+  return (
+    <div
+      className="fixed inset-0 bg-black/30 flex items-start justify-center pt-20 z-[1000]"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div
+        className="bg-white rounded-xl shadow-lg p-4 w-72"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="text-lg font-semibold mb-3">Take a Break</h3>
+        <div className="grid grid-cols-2 gap-2">
+          {[10, 20, 30, 60].map((m) => (
+            <button
+              key={m}
+              onClick={() => {
+                onSelect(m);
+                onClose();
+              }}
+              className="px-3 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+            >
+              {m} min
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `BreakModal` for selecting break lengths
- show the modal from Orders page instead of dropdown
- hide break button when restaurant closed
- cancel breaks if restaurant is re-opened early

## Testing
- `npm install`
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_687fa3ea29508325a9e28338ae5300eb