### PR TITLE
Improve break countdown UI

### DIFF
--- a/components/BreakCountdown.tsx
+++ b/components/BreakCountdown.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+
+interface BreakCountdownProps {
+  breakUntil: string;
+  onEnd: () => void;
+}
+
+export default function BreakCountdown({ breakUntil, onEnd }: BreakCountdownProps) {
+  const [timeLeft, setTimeLeft] = useState<number>(
+    new Date(breakUntil).getTime() - Date.now()
+  );
+
+  useEffect(() => {
+    const update = () => {
+      const diff = new Date(breakUntil).getTime() - Date.now();
+      if (diff <= 0) {
+        onEnd();
+        setTimeLeft(0);
+        return;
+      }
+      setTimeLeft(diff);
+    };
+    update();
+    const timer = setInterval(update, 1000);
+    return () => clearInterval(timer);
+  }, [breakUntil, onEnd]);
+
+  if (timeLeft <= 0) return null;
+
+  const mins = Math.floor(timeLeft / 60000);
+  const secs = Math.floor((timeLeft % 60000) / 1000);
+  const resumeAt = new Date(breakUntil).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+  return (
+    <div className="bg-red-100 text-red-800 font-bold rounded p-2 mb-2 inline-block">
+      <div className="text-sm">On Break</div>
+      <div className="text-lg">{String(mins).padStart(2, '0')}:{String(secs).padStart(2, '0')}</div>
+      <div className="text-xs font-normal">Resumes at {resumeAt}</div>
+    </div>
+  );
+}

--- a/pages/dashboard/orders.tsx
+++ b/pages/dashboard/orders.tsx
@@ -5,6 +5,7 @@ import { supabase } from '../../utils/supabaseClient';
 import { InboxIcon } from '@heroicons/react/24/outline';
 import OrderDetailsModal, { Order as OrderType } from '../../components/OrderDetailsModal';
 import BreakModal from '../../components/BreakModal';
+import BreakCountdown from '../../components/BreakCountdown';
 
 interface OrderAddon {
   id: number;
@@ -273,12 +274,6 @@ export default function OrdersPage() {
     return d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
   };
 
-  const formatCountdown = (until: string) => {
-    const diff = new Date(until).getTime() - Date.now();
-    const mins = Math.floor(diff / 60000);
-    const secs = Math.floor((diff % 60000) / 1000);
-    return `${String(mins).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
-  };
 
   const isOpenNow = () => {
     if (!todayHours || todayHours.closed || !todayHours.open_time || !todayHours.close_time) return false;
@@ -309,9 +304,7 @@ export default function OrdersPage() {
     <DashboardLayout>
       <h1 className="text-2xl font-bold mb-2">Live Orders</h1>
       {breakUntil && new Date(breakUntil).getTime() > now && (
-        <div className="mb-2 text-red-700 font-semibold">
-          On Break — Resumes in {formatCountdown(breakUntil)}
-        </div>
+        <BreakCountdown breakUntil={breakUntil} onEnd={endBreak} />
       )}
       <div className="mb-4 flex items-center justify-between">
         <div className="flex items-center space-x-2">


### PR DESCRIPTION
## Summary
- add BreakCountdown component for live timer
- embed BreakCountdown in the Orders page

## Testing
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_687fa8c6828883259ff9282c35dd89ea