### PR TITLE
Improve order rejection flow

### DIFF
--- a/components/OrderDetailsModal.tsx
+++ b/components/OrderDetailsModal.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
+import RejectOrderModal from './RejectOrderModal';
 
 interface OrderAddon {
   id: number;
+  option_id: number;
   name: string;
   price: number;
   quantity: number;
@@ -10,6 +12,7 @@ interface OrderAddon {
 
 interface OrderItem {
   id: number;
+  item_id: number;
   name: string;
   price: number;
   quantity: number;
@@ -51,6 +54,8 @@ const formatAddress = (addr: any) => {
 
 export default function OrderDetailsModal({ order, onClose, onUpdateStatus }: Props) {
   const overlayRef = useRef<HTMLDivElement | null>(null);
+  const [showReject, setShowReject] = useState(false);
+  const lastTap = useRef<number>(0);
 
   useEffect(() => {
     if (!order) return;
@@ -158,15 +163,28 @@ export default function OrderDetailsModal({ order, onClose, onUpdateStatus }: Pr
             {order.status !== 'completed' && order.status !== 'cancelled' && (
               <button
                 type="button"
-                onClick={() => onUpdateStatus(order.id, 'cancelled')}
+                onClick={() => {
+                  const now = Date.now();
+                  if (now - lastTap.current < 500) {
+                    setShowReject(true);
+                  }
+                  lastTap.current = now;
+                }}
+                onDoubleClick={() => setShowReject(true)}
                 className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
               >
-                Cancel
+                Reject
               </button>
             )}
           </div>
         </div>
       </div>
+      <RejectOrderModal
+        order={order}
+        show={showReject}
+        onClose={() => setShowReject(false)}
+        onRejected={() => onUpdateStatus(order.id, 'cancelled')}
+      />
     </div>
   );
 }

--- a/components/RejectOrderModal.tsx
+++ b/components/RejectOrderModal.tsx
@@ -1,0 +1,106 @@
+import { useState } from 'react';
+import { supabase } from '../utils/supabaseClient';
+import { Order } from './OrderDetailsModal';
+
+interface Props {
+  order: Order;
+  show: boolean;
+  onClose: () => void;
+  onRejected: () => void;
+}
+
+export default function RejectOrderModal({ order, show, onClose, onRejected }: Props) {
+  const [reason, setReason] = useState('Item out of stock');
+  const [message, setMessage] = useState('');
+  const [itemIds, setItemIds] = useState<Set<number>>(new Set());
+  const [addonIds, setAddonIds] = useState<Set<number>>(new Set());
+  const [saving, setSaving] = useState(false);
+
+  if (!show) return null;
+
+  const toggleItem = (id: number) => {
+    setItemIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  };
+
+  const toggleAddon = (id: number) => {
+    setAddonIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  };
+
+  const handleConfirm = async () => {
+    if (saving) return;
+    setSaving(true);
+    try {
+      if (reason === 'Item out of stock') {
+        for (const id of Array.from(itemIds)) {
+          await supabase.from('menu_items').update({ stock_status: 'out' }).eq('id', id);
+        }
+        for (const id of Array.from(addonIds)) {
+          await supabase.from('addon_items').update({ stock_status: 'out' }).eq('id', id);
+        }
+      }
+      await supabase.from('orders').update({ status: 'cancelled' }).eq('id', order.id);
+      await supabase.from('order_rejections').insert([
+        { order_id: order.id, reason, message: message || null },
+      ]);
+      onRejected();
+    } catch (err) {
+      console.error('Failed to reject order', err);
+    } finally {
+      setSaving(false);
+      onClose();
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center p-4 z-[1000]" onClick={(e) => e.target === e.currentTarget && onClose()}>
+      <div className="bg-white rounded-xl shadow-lg w-full max-w-sm p-4 space-y-4" onClick={(e) => e.stopPropagation()}>
+        <h3 className="text-lg font-semibold">Reject Order</h3>
+        <div className="space-y-2 text-sm">
+          {['Item out of stock','Closing early','Problem in the kitchen','Other'].map((r) => (
+            <label key={r} className="flex items-center space-x-2">
+              <input type="radio" name="reason" value={r} checked={reason===r} onChange={() => setReason(r)} />
+              <span>{r}</span>
+            </label>
+          ))}
+        </div>
+        {reason === 'Item out of stock' && (
+          <div className="space-y-2 text-sm">
+            <p className="font-medium">Mark items out of stock</p>
+            <ul className="space-y-1">
+              {order.order_items.map((it) => (
+                <li key={it.id} className="ml-2">
+                  <label className="flex items-center space-x-2">
+                    <input type="checkbox" checked={itemIds.has(it.item_id)} onChange={() => toggleItem(it.item_id)} />
+                    <span>{it.name}</span>
+                  </label>
+                  {it.order_addons.map((ad) => (
+                    <label key={ad.id} className="flex items-center space-x-2 ml-6">
+                      <input type="checkbox" checked={addonIds.has(ad.option_id)} onChange={() => toggleAddon(ad.option_id)} />
+                      <span>{ad.name}</span>
+                    </label>
+                  ))}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        <div>
+          <label className="block text-sm font-medium mb-1">Custom message (optional)</label>
+          <textarea className="w-full border rounded p-2" rows={3} value={message} onChange={(e)=>setMessage(e.target.value)} />
+        </div>
+        <div className="flex justify-end space-x-2 pt-2">
+          <button type="button" onClick={onClose} className="px-4 py-2 border border-red-600 text-red-600 rounded hover:bg-red-50">Cancel</button>
+          <button type="button" onClick={handleConfirm} className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700" disabled={saving}>{saving ? 'Rejecting...' : 'Reject Order'}</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/pages/dashboard/orders.tsx
+++ b/pages/dashboard/orders.tsx
@@ -9,6 +9,7 @@ import BreakCountdown from '../../components/BreakCountdown';
 
 interface OrderAddon {
   id: number;
+  option_id: number;
   name: string;
   price: number;
   quantity: number;
@@ -16,6 +17,7 @@ interface OrderAddon {
 
 interface OrderItem {
   id: number;
+  item_id: number;
   name: string;
   price: number;
   quantity: number;
@@ -107,11 +109,12 @@ export default function OrdersPage() {
           created_at,
           order_items(
             id,
+            item_id,
             name,
             price,
             quantity,
             notes,
-            order_addons(id,name,price,quantity)
+            order_addons(id,option_id,name,price,quantity)
           )
         `
         )


### PR DESCRIPTION
## Summary
- add RejectOrderModal component for double-tap rejection workflow
- fetch item_id/option_id for order details so stock can be updated
- open reject modal on double click in OrderDetailsModal

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_687fb69df23c83259e95cb5faa3d5e61