### PR TITLE
Improve reject order modal style

### DIFF
--- a/components/RejectOrderModal.tsx
+++ b/components/RejectOrderModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { supabase } from '../utils/supabaseClient';
 import { Order } from './OrderDetailsModal';
 
@@ -15,6 +15,9 @@ export default function RejectOrderModal({ order, show, onClose, onRejected }: P
   const [itemIds, setItemIds] = useState<Set<number>>(new Set());
   const [addonIds, setAddonIds] = useState<Set<number>>(new Set());
   const [saving, setSaving] = useState(false);
+  const [clickedOnce, setClickedOnce] = useState(false);
+  const [showTip, setShowTip] = useState(false);
+  const tipTimer = useRef<NodeJS.Timeout | null>(null);
 
   if (!show) return null;
 
@@ -59,11 +62,28 @@ export default function RejectOrderModal({ order, show, onClose, onRejected }: P
     }
   };
 
+  const handleRejectClick = () => {
+    if (clickedOnce) {
+      if (tipTimer.current) clearTimeout(tipTimer.current);
+      setShowTip(false);
+      setClickedOnce(false);
+      handleConfirm();
+    } else {
+      setClickedOnce(true);
+      setShowTip(true);
+      tipTimer.current = setTimeout(() => {
+        setClickedOnce(false);
+        setShowTip(false);
+      }, 2500);
+    }
+  };
+
   return (
     <div className="fixed inset-0 bg-black/40 flex items-center justify-center p-4 z-[1000]" onClick={(e) => e.target === e.currentTarget && onClose()}>
       <div className="bg-white rounded-xl shadow-lg w-full max-w-sm p-4 space-y-4" onClick={(e) => e.stopPropagation()}>
         <h3 className="text-lg font-semibold">Reject Order</h3>
         <div className="space-y-2 text-sm">
+          <p className="font-medium">Reason for rejecting</p>
           {['Item out of stock','Closing early','Problem in the kitchen','Other'].map((r) => (
             <label key={r} className="flex items-center space-x-2">
               <input type="radio" name="reason" value={r} checked={reason===r} onChange={() => setReason(r)} />
@@ -76,29 +96,51 @@ export default function RejectOrderModal({ order, show, onClose, onRejected }: P
             <p className="font-medium">Mark items out of stock</p>
             <ul className="space-y-1">
               {order.order_items.map((it) => (
-                <li key={it.id} className="ml-2">
+                <li key={it.id} className="ml-2 space-y-1">
                   <label className="flex items-center space-x-2">
-                    <input type="checkbox" checked={itemIds.has(it.item_id)} onChange={() => toggleItem(it.item_id)} />
-                    <span>{it.name}</span>
+                    <input
+                      type="checkbox"
+                      checked={itemIds.has(it.item_id)}
+                      onChange={() => toggleItem(it.item_id)}
+                    />
+                    <span className="font-medium">{it.name}</span>
                   </label>
-                  {it.order_addons.map((ad) => (
-                    <label key={ad.id} className="flex items-center space-x-2 ml-6">
-                      <input type="checkbox" checked={addonIds.has(ad.option_id)} onChange={() => toggleAddon(ad.option_id)} />
-                      <span>{ad.name}</span>
-                    </label>
-                  ))}
+                  {it.order_addons.length > 0 && (
+                    <ul className="ml-6 space-y-1">
+                      {it.order_addons.map((ad) => (
+                        <li key={ad.id}>
+                          <label className="flex items-center space-x-2">
+                            <input
+                              type="checkbox"
+                              checked={addonIds.has(ad.option_id)}
+                              onChange={() => toggleAddon(ad.option_id)}
+                            />
+                            <span>{ad.name}</span>
+                          </label>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
                 </li>
               ))}
             </ul>
           </div>
         )}
-        <div>
+        <div className="space-y-1">
           <label className="block text-sm font-medium mb-1">Custom message (optional)</label>
-          <textarea className="w-full border rounded p-2" rows={3} value={message} onChange={(e)=>setMessage(e.target.value)} />
+          <textarea className="w-full border rounded-md p-2 min-h-[6rem]" rows={4} value={message} onChange={(e)=>setMessage(e.target.value)} />
         </div>
-        <div className="flex justify-end space-x-2 pt-2">
+        <div className="flex justify-end space-x-2 pt-2 relative">
           <button type="button" onClick={onClose} className="px-4 py-2 border border-red-600 text-red-600 rounded hover:bg-red-50">Cancel</button>
-          <button type="button" onClick={handleConfirm} className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700" disabled={saving}>{saving ? 'Rejecting...' : 'Reject Order'}</button>
+          <button type="button" onClick={handleRejectClick} className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700" disabled={saving}>{saving ? 'Rejecting...' : 'Reject Order'}</button>
+          {showTip && (
+            <div className="absolute -top-8 right-0 text-xs" role="tooltip">
+              <div className="relative bg-white rounded shadow px-2 py-1">
+                Double click to reject
+                <div className="absolute left-1/2 -bottom-1 w-2 h-2 bg-white rotate-45 shadow -translate-x-1/2"></div>
+              </div>
+            </div>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- style the reject order modal with Tailwind
- nest addon items for better alignment
- add textarea padding and height
- show tooltip on first click that requests a double-click to reject

## Testing
- `npm run test:ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687fbf46ed988325b46adf4881357e91