### PR TITLE
Improve order & reject modal design

### DIFF
--- a/components/OrderDetailsModal.tsx
+++ b/components/OrderDetailsModal.tsx
@@ -78,7 +78,7 @@ export default function OrderDetailsModal({ order, onClose, onUpdateStatus }: Pr
     >
       <div
         onClick={(e) => e.stopPropagation()}
-        className="bg-white rounded-xl shadow-lg w-full max-w-lg max-h-[90vh] overflow-y-auto relative"
+        className="bg-white rounded-xl shadow-lg w-full max-w-xl max-h-[90vh] overflow-y-auto relative"
       >
         <button
           type="button"
@@ -89,49 +89,78 @@ export default function OrderDetailsModal({ order, onClose, onUpdateStatus }: Pr
           <XMarkIcon className="w-5 h-5" />
         </button>
         <div className="p-6 space-y-4 text-sm">
-          <h3 className="text-xl font-semibold">
+          <h3 className="text-2xl font-bold">
             Order #{String(order.short_order_number ?? 0).padStart(4, '0')}
           </h3>
-          <p>
-            <strong>Customer:</strong> {order.customer_name || 'Guest'} {order.phone_number || ''}
-          </p>
-          {order.order_type === 'delivery' && order.delivery_address && (
-            <p>
-              <strong>Address:</strong> {formatAddress(order.delivery_address)}
-            </p>
-          )}
-          <p>
-            <strong>Status:</strong> {order.status}
-          </p>
-          <p>
-            <strong>Placed:</strong> {new Date(order.created_at).toLocaleString()}
-          </p>
-          <ul className="space-y-2">
+          <div className="space-y-1">
+            <div className="flex justify-between">
+              <span className="text-gray-500 font-medium">Customer</span>
+              <span className="text-gray-700">
+                {order.customer_name || 'Guest'} {order.phone_number || ''}
+              </span>
+            </div>
+            <div className="flex justify-between items-center">
+              <span className="text-gray-500 font-medium">Status</span>
+              <span>
+                <span
+                  className={`px-2 py-0.5 text-xs font-semibold rounded-full ${{
+                    pending: 'bg-gray-200 text-gray-800',
+                    accepted: 'bg-green-200 text-green-800',
+                    cancelled: 'bg-red-200 text-red-800',
+                  }[order.status] || 'bg-yellow-200 text-yellow-800'}`}
+                >
+                  {order.status}
+                </span>
+              </span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-gray-500 font-medium">Placed</span>
+              <span className="text-gray-700">
+                {new Date(order.created_at).toLocaleString()}
+              </span>
+            </div>
+            {order.order_type === 'delivery' && order.delivery_address && (
+              <div className="flex justify-between">
+                <span className="text-gray-500 font-medium">Address</span>
+                <span className="text-right text-gray-700 ml-4">
+                  {formatAddress(order.delivery_address)}
+                </span>
+              </div>
+            )}
+          </div>
+          <ul className="space-y-3 text-sm">
             {order.order_items.map((it) => (
-              <li key={it.id} className="border rounded p-2">
+              <li key={it.id} className="border rounded-lg p-3">
                 <div className="flex justify-between">
-                  <span>
+                  <span className="font-semibold">
                     {it.name} × {it.quantity}
                   </span>
-                  <span>{formatPrice(it.price * it.quantity)}</span>
+                  <span className="font-medium">
+                    {formatPrice(it.price * it.quantity)}
+                  </span>
                 </div>
                 {it.order_addons && it.order_addons.length > 0 && (
                   <ul className="mt-1 ml-4 space-y-1 text-gray-600">
                     {it.order_addons.map((ad) => (
                       <li key={ad.id} className="flex justify-between">
                         <span>
-                          {ad.name} × {ad.quantity}
+                          {ad.name}
+                          <span className="text-xs text-gray-500 ml-1">x{ad.quantity}</span>
                         </span>
                         <span>{formatPrice(ad.price * ad.quantity)}</span>
                       </li>
                     ))}
                   </ul>
                 )}
-                {it.notes && <p className="italic ml-4 mt-1">{it.notes}</p>}
+                {it.notes && (
+                  <p className="italic text-gray-600 ml-4 mt-1">{it.notes}</p>
+                )}
               </li>
             ))}
           </ul>
-          {order.customer_notes && <p className="italic">{order.customer_notes}</p>}
+          {order.customer_notes && (
+            <p className="italic">{order.customer_notes}</p>
+          )}
           <p className="font-semibold">Total: {formatPrice(order.total_price)}</p>
           <div className="flex justify-end space-x-2 pt-2">
             {(() => {

--- a/components/RejectOrderModal.tsx
+++ b/components/RejectOrderModal.tsx
@@ -79,68 +79,101 @@ export default function RejectOrderModal({ order, show, onClose, onRejected }: P
   };
 
   return (
-    <div className="fixed inset-0 bg-black/40 flex items-center justify-center p-4 z-[1000]" onClick={(e) => e.target === e.currentTarget && onClose()}>
-      <div className="bg-white rounded-xl shadow-lg w-full max-w-sm p-4 space-y-4" onClick={(e) => e.stopPropagation()}>
-        <h3 className="text-lg font-semibold">Reject Order</h3>
-        <div className="space-y-2 text-sm">
-          <p className="font-medium">Reason for rejecting</p>
-          {['Item out of stock','Closing early','Problem in the kitchen','Other'].map((r) => (
-            <label key={r} className="flex items-center space-x-2">
-              <input type="radio" name="reason" value={r} checked={reason===r} onChange={() => setReason(r)} />
-              <span>{r}</span>
-            </label>
-          ))}
-        </div>
-        {reason === 'Item out of stock' && (
-          <div className="space-y-2 text-sm">
-            <p className="font-medium">Mark items out of stock</p>
-            <ul className="space-y-1">
-              {order.order_items.map((it) => (
-                <li key={it.id} className="ml-2 space-y-1">
-                  <label className="flex items-center space-x-2">
-                    <input
-                      type="checkbox"
-                      checked={itemIds.has(it.item_id)}
-                      onChange={() => toggleItem(it.item_id)}
-                    />
-                    <span className="font-medium">{it.name}</span>
-                  </label>
-                  {it.order_addons.length > 0 && (
-                    <ul className="ml-6 space-y-1">
-                      {it.order_addons.map((ad) => (
-                        <li key={ad.id}>
-                          <label className="flex items-center space-x-2">
-                            <input
-                              type="checkbox"
-                              checked={addonIds.has(ad.option_id)}
-                              onChange={() => toggleAddon(ad.option_id)}
-                            />
-                            <span>{ad.name}</span>
-                          </label>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                </li>
-              ))}
-            </ul>
+    <div
+      className="fixed inset-0 bg-black/40 flex items-center justify-center p-4 z-[1000]"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div
+        className="bg-white rounded-xl shadow-lg w-full max-w-sm sm:max-w-md overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="bg-gray-100 px-4 py-2 font-bold text-center">Reject Order</div>
+        <div className="p-4 space-y-4 text-sm">
+          <div className="space-y-2 bg-gray-50 p-3 rounded">
+            <p className="font-medium">Reason for rejecting</p>
+            {['Item out of stock', 'Closing early', 'Problem in the kitchen', 'Other'].map((r) => (
+              <label key={r} className="flex items-center space-x-2">
+                <input
+                  type="radio"
+                  name="reason"
+                  value={r}
+                  checked={reason === r}
+                  onChange={() => setReason(r)}
+                />
+                <span>{r}</span>
+              </label>
+            ))}
           </div>
-        )}
-        <div className="space-y-1">
-          <label className="block text-sm font-medium mb-1">Custom message (optional)</label>
-          <textarea className="w-full border rounded-md p-2 min-h-[6rem]" rows={4} value={message} onChange={(e)=>setMessage(e.target.value)} />
-        </div>
-        <div className="flex justify-end space-x-2 pt-2 relative">
-          <button type="button" onClick={onClose} className="px-4 py-2 border border-red-600 text-red-600 rounded hover:bg-red-50">Cancel</button>
-          <button type="button" onClick={handleRejectClick} className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700" disabled={saving}>{saving ? 'Rejecting...' : 'Reject Order'}</button>
-          {showTip && (
-            <div className="absolute -top-8 right-0 text-xs" role="tooltip">
+          {reason === 'Item out of stock' && (
+            <div className="space-y-2 bg-gray-50 p-3 rounded">
+              <p className="font-medium">Mark items out of stock</p>
+              <ul className="space-y-1">
+                {order.order_items.map((it) => (
+                  <li key={it.id} className="ml-2 space-y-1">
+                    <label className="flex items-center space-x-2">
+                      <input
+                        type="checkbox"
+                        checked={itemIds.has(it.item_id)}
+                        onChange={() => toggleItem(it.item_id)}
+                      />
+                      <span className="font-medium">{it.name}</span>
+                    </label>
+                    {it.order_addons.length > 0 && (
+                      <ul className="ml-6 space-y-1">
+                        {it.order_addons.map((ad) => (
+                          <li key={ad.id}>
+                            <label className="flex items-center space-x-2">
+                              <input
+                                type="checkbox"
+                                checked={addonIds.has(ad.option_id)}
+                                onChange={() => toggleAddon(ad.option_id)}
+                              />
+                              <span>{ad.name}</span>
+                            </label>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          <div className="space-y-1">
+            <label className="block text-sm font-medium mb-1">Custom message (optional)</label>
+            <textarea
+              className="w-full border rounded-md p-2 min-h-[6rem]"
+              rows={4}
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+            />
+          </div>
+          <div className="flex flex-col sm:flex-row justify-end gap-2 pt-2 relative">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 border border-red-600 text-red-600 rounded hover:bg-red-50 w-full sm:w-auto"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleRejectClick}
+              className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 w-full sm:w-auto"
+              disabled={saving}
+            >
+              {saving ? 'Rejecting...' : 'Reject Order'}
+            </button>
+            <div
+              className={`absolute -top-8 right-0 text-xs transition-opacity duration-300 ${showTip ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+              role="tooltip"
+            >
               <div className="relative bg-white rounded shadow px-2 py-1">
                 Double click to reject
                 <div className="absolute left-1/2 -bottom-1 w-2 h-2 bg-white rotate-45 shadow -translate-x-1/2"></div>
               </div>
             </div>
-          )}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- style order details modal with badges and cards
- revamp reject order modal layout and tooltip

## Testing
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_687fc24395a88325b1966512e24da4fb