### PR TITLE
Add stock alert on orders page

### DIFF
--- a/pages/dashboard/menu-builder.tsx
+++ b/pages/dashboard/menu-builder.tsx
@@ -120,6 +120,14 @@ export default function MenuBuilder() {
   const fileRef = useRef<HTMLInputElement | null>(null);
   const router = useRouter();
 
+  useEffect(() => {
+    if (!router.isReady) return;
+    const t = router.query.tab;
+    if (t === 'menu' || t === 'addons' || t === 'stock' || t === 'build') {
+      setActiveTab(t as any);
+    }
+  }, [router.isReady, router.query.tab]);
+
   // Load draft menu from localStorage
   useEffect(() => {
     const cats = localStorage.getItem('draftCategories');


### PR DESCRIPTION
## Summary
- show count of out-of-stock items on Orders page
- link alert to Stock tab
- allow Menu Builder to open specific tab via query param

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_687fca2880508325a6a8c1f275c9388e