### PR TITLE
Add bottom nav and cart page

### DIFF
--- a/components/BottomNavBar.tsx
+++ b/components/BottomNavBar.tsx
@@ -1,0 +1,59 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { Home, Utensils, ListOrdered, Menu, ShoppingCart } from 'lucide-react';
+
+export default function BottomNavBar({ cartCount = 0 }: { cartCount?: number }) {
+  const router = useRouter();
+  const current = router.pathname;
+  const isActive = (path: string) => current.startsWith(path);
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 shadow-md z-50 md:hidden">
+      <div className="relative flex justify-between items-center px-6 py-2">
+        <Link
+          href="/"
+          className={`flex flex-col items-center text-xs ${isActive('/restaurant') || current === '/' ? 'text-black font-semibold' : 'text-gray-400'}`}
+        >
+          <Home className="w-5 h-5 mb-1" />
+          Home
+        </Link>
+        <Link
+          href="/menu"
+          className={`flex flex-col items-center text-xs ${isActive('/menu') ? 'text-black font-semibold' : 'text-gray-400'}`}
+        >
+          <Utensils className="w-5 h-5 mb-1" />
+          Menu
+        </Link>
+
+        <div className="absolute -top-6 left-1/2 transform -translate-x-1/2">
+          <Link
+            href="/cart"
+            className="relative bg-black text-white rounded-full w-14 h-14 flex items-center justify-center shadow-lg hover:scale-105 transition"
+          >
+            <ShoppingCart className="w-6 h-6" />
+            {cartCount > 0 && (
+              <span className="absolute -top-1 -right-1 bg-red-500 text-white text-[10px] font-bold w-5 h-5 rounded-full flex items-center justify-center">
+                {cartCount}
+              </span>
+            )}
+          </Link>
+        </div>
+
+        <Link
+          href="/orders"
+          className={`flex flex-col items-center text-xs ${isActive('/orders') ? 'text-black font-semibold' : 'text-gray-400'}`}
+        >
+          <ListOrdered className="w-5 h-5 mb-1" />
+          Orders
+        </Link>
+        <Link
+          href="/more"
+          className={`flex flex-col items-center text-xs ${isActive('/more') ? 'text-black font-semibold' : 'text-gray-400'}`}
+        >
+          <Menu className="w-5 h-5 mb-1" />
+          More
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,10 +6,19 @@ import { useRouter } from 'next/router';
 import { CartProvider } from '../context/CartContext';
 import { OrderTypeProvider } from '../context/OrderTypeContext';
 import CartDrawer from '../components/CartDrawer';
+import BottomNavBar from '../components/BottomNavBar';
+import { useCart } from '../context/CartContext';
 
 export default function App({ Component, pageProps }) {
   const [supabase] = useState(() => createBrowserSupabaseClient());
   const router = useRouter();
+
+  function BottomNavWrapper() {
+    const { cart } = useCart();
+    const count = cart.items.reduce((sum, it) => sum + it.quantity, 0);
+    if (router.pathname === '/checkout') return null;
+    return <BottomNavBar cartCount={count} />;
+  }
 
   return (
     <SessionContextProvider supabaseClient={supabase} initialSession={pageProps.initialSession}>
@@ -17,6 +26,7 @@ export default function App({ Component, pageProps }) {
         <CartProvider>
           <Component {...pageProps} />
           {router.pathname !== '/checkout' && <CartDrawer />}
+          <BottomNavWrapper />
         </CartProvider>
       </OrderTypeProvider>
     </SessionContextProvider>

--- a/pages/cart.tsx
+++ b/pages/cart.tsx
@@ -1,0 +1,60 @@
+import Link from 'next/link';
+import { useCart } from '../context/CartContext';
+
+export default function CartPage() {
+  const { cart, subtotal, updateQuantity, removeFromCart } = useCart();
+
+  const itemCount = cart.items.reduce((sum, it) => sum + it.quantity, 0);
+
+  return (
+    <main className="p-4 pb-24 max-w-md mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Your Cart</h1>
+      {cart.items.length === 0 ? (
+        <p className="text-center text-gray-500">Your cart is empty.</p>
+      ) : (
+        <ul className="space-y-4">
+          {cart.items.map((item) => (
+            <li key={item.item_id} className="border p-3 rounded flex justify-between items-start">
+              <div>
+                <p className="font-medium">{item.name}</p>
+                <p className="text-sm text-gray-500">${(item.price / 100).toFixed(2)}</p>
+              </div>
+              <div className="flex items-center space-x-2">
+                <button
+                  type="button"
+                  onClick={() => updateQuantity(item.item_id, item.quantity - 1)}
+                  className="w-6 h-6 flex items-center justify-center border rounded"
+                >
+                  -
+                </button>
+                <span>{item.quantity}</span>
+                <button
+                  type="button"
+                  onClick={() => updateQuantity(item.item_id, item.quantity + 1)}
+                  className="w-6 h-6 flex items-center justify-center border rounded"
+                >
+                  +
+                </button>
+                <button
+                  type="button"
+                  onClick={() => removeFromCart(item.item_id)}
+                  className="text-sm text-red-500"
+                >
+                  Remove
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+      {cart.items.length > 0 && (
+        <div className="mt-6 space-y-2">
+          <p className="text-right font-semibold">Subtotal: ${(subtotal / 100).toFixed(2)}</p>
+          <Link href="/checkout" className="block text-center py-2 bg-teal-600 text-white rounded">
+            Proceed to Checkout ({itemCount} {itemCount === 1 ? 'item' : 'items'})
+          </Link>
+        </div>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add bottom navigation component with floating cart button
- show bottom nav and cart drawer from `_app`
- create simple cart page to manage cart items
- wire up tests with new dependencies

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_687fdeb3977c8325af278f81f0ef7bfe