### PR TITLE
Add CustomerLayout with PWA meta and tests

### DIFF
--- a/__tests__/CustomerLayout.test.tsx
+++ b/__tests__/CustomerLayout.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import CustomerLayout from '../components/CustomerLayout';
+import { useRouter } from 'next/router';
+
+// Mock Next.js router
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+// Mock Next.js Head to simply render children for easier assertions
+jest.mock('next/head', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const mockUseRouter = useRouter as jest.Mock;
+
+describe('CustomerLayout', () => {
+  beforeEach(() => {
+    document.head.innerHTML = '';
+    mockUseRouter.mockReturnValue({ pathname: '/' });
+  });
+
+  it('renders children and cart count', () => {
+    render(<CustomerLayout cartCount={2}>Hello</CustomerLayout>);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('includes PWA meta tags by default', async () => {
+    render(<CustomerLayout>Child</CustomerLayout>);
+    await waitFor(() => {
+      expect(document.querySelector('meta[name="theme-color"]')).toBeInTheDocument();
+      expect(document.querySelector('link[rel="manifest"]')).toBeInTheDocument();
+    });
+  });
+
+  it('allows disabling PWA meta tags', () => {
+    render(<CustomerLayout includePwaMeta={false}>Child</CustomerLayout>);
+    expect(document.querySelector('meta[name="theme-color"]')).not.toBeInTheDocument();
+  });
+});

--- a/components/CustomerLayout.tsx
+++ b/components/CustomerLayout.tsx
@@ -1,0 +1,36 @@
+import Head from 'next/head';
+import { ReactNode } from 'react';
+import BottomNavBar from './BottomNavBar';
+
+interface CustomerLayoutProps {
+  children: ReactNode;
+  cartCount?: number;
+  includePwaMeta?: boolean;
+}
+
+export default function CustomerLayout({
+  children,
+  cartCount = 0,
+  includePwaMeta = true,
+}: CustomerLayoutProps) {
+  return (
+    <>
+      {includePwaMeta && (
+        <Head>
+          <title>OrderFast – Restaurant</title>
+          <meta name="theme-color" content="#000000" />
+          <meta name="apple-mobile-web-app-capable" content="yes" />
+          <meta name="mobile-web-app-capable" content="yes" />
+          <link rel="manifest" href="/manifest.json" />
+          <link rel="apple-touch-icon" href="/icons/icon-192x192.png" />
+        </Head>
+      )}
+
+      <main className="min-h-screen pb-24 bg-white text-gray-900">
+        {children}
+      </main>
+
+      <BottomNavBar cartCount={cartCount} />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add new `CustomerLayout` component for customer-facing pages
- support optional PWA meta tags and cart count
- test rendering and PWA meta behavior

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_687fe35a76008325b1cbc6702967713a