### PR TITLE
Add customerMode prop for customer pages

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -13,7 +13,7 @@ export default function App({ Component, pageProps }) {
   const [supabase] = useState(() => createBrowserSupabaseClient());
   const router = useRouter();
 
-  const isCustomerPage = router.pathname.startsWith('/website');
+  const isCustomerPage = pageProps.customerMode === true;
 
   function BottomNavWrapper() {
     const { cart } = useCart();

--- a/pages/cart.tsx
+++ b/pages/cart.tsx
@@ -58,3 +58,12 @@ export default function CartPage() {
     </main>
   );
 }
+
+export async function getStaticProps() {
+  return {
+    props: {
+      customerMode: true,
+      cartCount: 0,
+    },
+  };
+}

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -323,3 +323,12 @@ export default function CheckoutPage() {
     </div>
   );
 }
+
+export async function getStaticProps() {
+  return {
+    props: {
+      customerMode: true,
+      cartCount: 0,
+    },
+  };
+}

--- a/pages/order-confirmation.tsx
+++ b/pages/order-confirmation.tsx
@@ -16,3 +16,12 @@ export default function OrderConfirmation() {
     </div>
   );
 }
+
+export async function getStaticProps() {
+  return {
+    props: {
+      customerMode: true,
+      cartCount: 0,
+    },
+  };
+}

--- a/pages/restaurant/index.tsx
+++ b/pages/restaurant/index.tsx
@@ -73,3 +73,12 @@ export default function RestaurantPage() {
     </div>
   );
 }
+
+export async function getStaticProps() {
+  return {
+    props: {
+      customerMode: true,
+      cartCount: 0,
+    },
+  };
+}

--- a/pages/restaurant/menu.tsx
+++ b/pages/restaurant/menu.tsx
@@ -231,3 +231,12 @@ export default function RestaurantMenuPage() {
     </div>
   );
 }
+
+export async function getStaticProps() {
+  return {
+    props: {
+      customerMode: true,
+      cartCount: 0,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- show BottomNavBar when `pageProps.customerMode` is true
- mark customer pages with `customerMode` and placeholder `cartCount`

## Testing
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_687fea52bb2c832594561e3022bc4560