### PR TITLE
Add More page with common links

### DIFF
--- a/pages/more.tsx
+++ b/pages/more.tsx
@@ -1,0 +1,73 @@
+import { LogOut, User, Percent, Mail, Info, FileText, Shield } from 'lucide-react';
+import CustomerLayout from '../components/CustomerLayout';
+import Link from 'next/link';
+
+export default function MorePage() {
+  const isLoggedIn = true; // TODO: replace with real auth check
+
+  const items = [
+    isLoggedIn && {
+      title: 'Profile',
+      icon: <User className="w-5 h-5" />,
+      href: '/account',
+    },
+    {
+      title: 'Promo Codes',
+      icon: <Percent className="w-5 h-5" />,
+      href: '/promos',
+    },
+    {
+      title: 'Contact Us',
+      icon: <Mail className="w-5 h-5" />,
+      href: '/contact',
+    },
+    {
+      title: 'About Us',
+      icon: <Info className="w-5 h-5" />,
+      href: '/about',
+    },
+    {
+      title: 'Terms & Conditions',
+      icon: <FileText className="w-5 h-5" />,
+      href: '/terms',
+    },
+    {
+      title: 'Privacy Policy',
+      icon: <Shield className="w-5 h-5" />,
+      href: '/privacy',
+    },
+    isLoggedIn && {
+      title: 'Log Out',
+      icon: <LogOut className="w-5 h-5" />,
+      href: '/logout',
+    },
+  ].filter(Boolean) as { title: string; icon: JSX.Element; href: string }[];
+
+  return (
+    <CustomerLayout cartCount={0}>
+      <div className="p-4 space-y-2 max-w-md mx-auto">
+        <h1 className="text-lg font-semibold mb-4">More</h1>
+        {items.map((item, idx) => (
+          <Link key={idx} href={item.href}>
+            <div className="flex items-center justify-between p-4 bg-gray-100 rounded-md hover:bg-gray-200 transition">
+              <div className="flex items-center gap-3 text-sm font-medium">
+                {item.icon}
+                {item.title}
+              </div>
+              <span className="text-gray-400 text-xs">›</span>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </CustomerLayout>
+  );
+}
+
+export async function getStaticProps() {
+  return {
+    props: {
+      customerMode: true,
+      cartCount: 0,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add `pages/more.tsx` implementing a mobile friendly "More" page wrapped in `CustomerLayout`
- include links for profile, promos, contact, about, terms, privacy and logout

## Testing
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_687ff5e8a6f883259d9e83d947d0b810