### PR TITLE
Improve menu card styling

### DIFF
--- a/__tests__/MenuItemCard.test.tsx
+++ b/__tests__/MenuItemCard.test.tsx
@@ -32,7 +32,7 @@ describe('MenuItemCard', () => {
     );
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: 'Add to Cart' }));
-    await user.click(screen.getByRole('button', { name: '+' }));
+    await user.click(screen.getByRole('button', { name: 'Increase quantity' }));
     expect(screen.getByTestId('qty').textContent).toBe('2');
   });
 
@@ -41,7 +41,7 @@ describe('MenuItemCard', () => {
     render(<MenuItemCard item={item} restaurantId="1" />);
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: 'Add to Cart' }));
-    await user.click(screen.getByRole('button', { name: '-' }));
+    await user.click(screen.getByRole('button', { name: 'Decrease quantity' }));
     expect(screen.getByTestId('qty').textContent).toBe('1');
   });
 });

--- a/components/MenuItemCard.tsx
+++ b/components/MenuItemCard.tsx
@@ -11,6 +11,7 @@ interface MenuItem {
   description?: string | null;
   price: number;
   image_url?: string | null;
+  is_vegan?: boolean | null;
   is_vegetarian?: boolean | null;
   is_18_plus?: boolean | null;
   stock_status?: 'in_stock' | 'scheduled' | 'out' | null;
@@ -32,6 +33,7 @@ export default function MenuItemCard({
   const [selections, setSelections] = useState<
     Record<string, Record<string, number>>
   >({});
+  const [recentlyAdded, setRecentlyAdded] = useState(false);
   const { addToCart } = useCart();
 
   const loadAddons = async () => {
@@ -90,6 +92,9 @@ export default function MenuItemCard({
       addons: addons.length ? addons : undefined,
     });
 
+    setRecentlyAdded(true);
+    setTimeout(() => setRecentlyAdded(false), 1000);
+
     setQty(1);
     setNotes('');
     setSelections({});
@@ -101,40 +106,49 @@ export default function MenuItemCard({
       <motion.div
         whileInView={{ opacity: [0, 1], y: [20, 0] }}
         viewport={{ once: true }}
-        className="bg-white rounded-xl shadow hover:shadow-md flex p-4 gap-4 min-h-[7rem]"
+        className="bg-white rounded-2xl shadow-md hover:shadow-xl transition-all flex p-4 gap-4 min-h-[7rem]"
       >
         {item.image_url && (
           <img
             src={item.image_url}
             alt={item.name}
-            className="w-24 h-24 object-cover rounded-md flex-shrink-0"
+            className="w-20 h-20 object-cover rounded-md flex-shrink-0"
           />
         )}
         <div className="flex flex-col flex-1 text-left">
-          <h3 className="font-semibold text-lg">{item.name}</h3>
-          <span className="font-semibold">${(item.price / 100).toFixed(2)}</span>
+          <div className="flex items-center gap-2">
+            <h3 className="font-bold flex-1">{item.name}</h3>
+            <span className="bg-emerald-100 text-emerald-800 text-xs px-2 py-1 rounded-md">
+              ${ (item.price / 100).toFixed(2) }
+            </span>
+          </div>
           {item.description && (
-            <p className="text-sm text-gray-600 mt-1">{item.description}</p>
+            <p className="text-sm text-gray-500 line-clamp-2 mt-1">{item.description}</p>
           )}
           <div className="text-xs flex flex-wrap gap-2 mt-2">
+            {item.is_vegan && (
+              <span className="px-2 py-1 rounded-full bg-green-100 text-green-800">🌱 Vegan</span>
+            )}
             {item.is_vegetarian && (
-              <span className="px-2 py-1 bg-green-100 rounded">🌱 Vegetarian</span>
+              <span className="px-2 py-1 rounded-full bg-yellow-100 text-yellow-800">🧀 Vegetarian</span>
             )}
             {item.is_18_plus && (
-              <span className="px-2 py-1 bg-red-100 rounded">🔥 18+</span>
+              <span className="px-2 py-1 rounded-full bg-red-100 text-red-800">🔞 18+</span>
             )}
             {item.stock_status === 'out' && (
               <span className="px-2 py-1 bg-gray-200 rounded">Out of stock</span>
             )}
           </div>
           <div className="mt-auto pt-3">
-            <button
+            <motion.button
               type="button"
+              aria-label="Add to Cart"
+              whileTap={{ scale: 0.9 }}
               onClick={handleClick}
-              className="bg-teal-600 text-white rounded-full py-2 px-4 hover:bg-teal-700 whitespace-nowrap w-full sm:w-auto"
+              className="bg-teal-600 text-white rounded-full py-2 px-4 hover:bg-teal-700 whitespace-nowrap w-full sm:w-auto flex items-center justify-center"
             >
-              Add to Cart
-            </button>
+              <span className="mr-1">🛒</span>{recentlyAdded ? '✓ Added' : 'Add to Cart'}
+            </motion.button>
           </div>
         </div>
       </motion.div>
@@ -163,6 +177,7 @@ export default function MenuItemCard({
               <div className="flex items-center border rounded">
                 <button
                   type="button"
+                  aria-label="Decrease quantity"
                   onClick={decrement}
                   className="w-8 h-8 flex items-center justify-center"
                 >
@@ -173,6 +188,7 @@ export default function MenuItemCard({
                 </span>
                 <button
                   type="button"
+                  aria-label="Increase quantity"
                   onClick={increment}
                   className="w-8 h-8 flex items-center justify-center"
                 >
@@ -191,12 +207,14 @@ export default function MenuItemCard({
             <div className="mt-6 flex justify-end gap-3">
               <button
                 type="button"
+                aria-label="Cancel"
                 onClick={() => setShowModal(false)}
                 className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300"
               >
                 Cancel
               </button>
               <button
+                aria-label="Confirm Add to Cart"
                 onClick={handleFinalAdd}
                 className="px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-700"
               >

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "swiper": "^11.2.10"
       },
       "devDependencies": {
+        "@tailwindcss/line-clamp": "^0.4.4",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
@@ -1922,6 +1923,16 @@
       "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/line-clamp": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz",
+      "integrity": "sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
       }
     },
     "node_modules/@tanstack/react-virtual": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "postcss": "^8.4.21",
     "tailwindcss": "^3.3.0",
     "ts-jest": "^29.4.0",
-    "typescript": "5.8.3"
+    "typescript": "5.8.3",
+    "@tailwindcss/line-clamp": "^0.4.4"
   }
 }

--- a/pages/restaurant/menu.tsx
+++ b/pages/restaurant/menu.tsx
@@ -247,7 +247,7 @@ export default function RestaurantMenuPage() {
                 className="space-y-4 scroll-mt-24"
               >
                 <h2 className="text-xl font-semibold text-left">{cat.name}</h2>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
                   {catItems.map((item) => (
                     <MenuItemCard
                       key={item.id}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,5 +4,5 @@ module.exports = {
     './components/**/*.{js,ts,jsx,tsx}',
   ],
   theme: { extend: {} },
-  plugins: [],
+  plugins: [require('@tailwindcss/line-clamp')],
 };


### PR DESCRIPTION
## Summary
- polish menu cards with rounded styling, price badge and updated badges
- adapt grid for three columns on large screens
- add line clamp plugin for Tailwind
- update tests for new accessible button labels

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_68827a7573248325b2631e3c6a852f33