### PR TITLE
Improve menu page icons and layout

### DIFF
--- a/components/CategoryIcon.tsx
+++ b/components/CategoryIcon.tsx
@@ -1,0 +1,20 @@
+import { LucideIcon, CupSoda, Drumstick, Pizza, Dessert, Sandwich, Salad } from "lucide-react";
+
+const mappings: [string, LucideIcon][] = [
+  ["burger", Drumstick],
+  ["drink", CupSoda],
+  ["beverage", CupSoda],
+  ["pizza", Pizza],
+  ["dessert", Dessert],
+  ["sweet", Dessert],
+  ["sandwich", Sandwich],
+  ["salad", Salad],
+];
+
+export default function CategoryIcon({ category }: { category: string }) {
+  const lower = category.toLowerCase();
+  const found = mappings.find(([key]) => lower.includes(key));
+  if (!found) return null;
+  const Icon = found[1];
+  return <Icon className="w-6 h-6" />;
+}

--- a/components/MenuItemCard.tsx
+++ b/components/MenuItemCard.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { motion } from 'framer-motion';
-import { ShoppingCart, Leaf, Carrot, Beer } from 'lucide-react';
+import { ShoppingCart } from 'lucide-react';
 import { useCart } from '../context/CartContext';
 import { getAddonsForItem } from '../utils/getAddonsForItem';
 import type { AddonGroup } from '../utils/types';
@@ -36,6 +36,8 @@ export default function MenuItemCard({
   >({});
   const [recentlyAdded, setRecentlyAdded] = useState(false);
   const { addToCart } = useCart();
+
+  const descriptionTooLong = (item.description?.length || 0) > 150;
 
   const loadAddons = async () => {
     setLoading(true);
@@ -113,39 +115,39 @@ export default function MenuItemCard({
           <img
             src={item.image_url}
             alt={item.name}
-            className="w-20 h-20 object-cover rounded-md flex-shrink-0"
+            onClick={handleClick}
+            className="w-20 h-20 object-cover rounded-md flex-shrink-0 cursor-pointer"
           />
         )}
         <div className="flex flex-col flex-1 text-left">
-          <div className="flex items-center gap-2">
-            <h3 className="font-bold flex-1">{item.name}</h3>
-            <span className="bg-emerald-100 text-emerald-800 text-xs px-2 py-1 rounded-md">
-              ${ (item.price / 100).toFixed(2) }
-            </span>
+          <div className="flex items-start justify-between gap-2">
+            <h3 onClick={handleClick} className="font-bold flex-1 cursor-pointer">
+              {item.name}
+            </h3>
+            <div className="flex items-center gap-1 whitespace-nowrap">
+              {item.is_vegan && (
+                <span title="Vegan" className="text-sm">🌱</span>
+              )}
+              {item.is_vegetarian && (
+                <span title="Vegetarian" className="text-sm">🧀</span>
+              )}
+              {item.is_18_plus && (
+                <span title="18+" className="text-sm">🔞</span>
+              )}
+              <span className="font-semibold text-sm">${(item.price / 100).toFixed(2)}</span>
+            </div>
           </div>
           {item.description && (
-            <p className="text-sm text-gray-500 line-clamp-2 mt-1">{item.description}</p>
+            <p className="text-sm text-gray-600 line-clamp-2 mt-1">
+              {item.description}
+              {descriptionTooLong && (
+                <button onClick={handleClick} className="text-teal-600 text-xs ml-1">More</button>
+              )}
+            </p>
           )}
-          <div className="text-xs flex flex-wrap gap-2 mt-2">
-            {item.is_vegan && (
-              <span className="px-2 py-1 rounded-full bg-green-100 text-green-800 inline-flex items-center gap-1">
-                <Leaf className="w-3 h-3" /> Vegan
-              </span>
-            )}
-            {item.is_vegetarian && (
-              <span className="px-2 py-1 rounded-full bg-yellow-100 text-yellow-800 inline-flex items-center gap-1">
-                <Carrot className="w-3 h-3" /> Vegetarian
-              </span>
-            )}
-            {item.is_18_plus && (
-              <span className="px-2 py-1 rounded-full bg-red-100 text-red-800 inline-flex items-center gap-1">
-                <Beer className="w-3 h-3" /> 18+
-              </span>
-            )}
-            {item.stock_status === 'out' && (
-              <span className="px-2 py-1 bg-gray-200 rounded">Out of stock</span>
-            )}
-          </div>
+          {item.stock_status === 'out' && (
+            <span className="text-xs mt-1 text-gray-500">Out of stock</span>
+          )}
           <div className="mt-auto pt-3">
             <motion.button
               type="button"

--- a/pages/restaurant/menu.tsx
+++ b/pages/restaurant/menu.tsx
@@ -1,20 +1,13 @@
 import { useRouter } from "next/router";
 import { useEffect, useState, useRef } from "react";
 import { motion } from "framer-motion";
-import { Search, ChevronUp, Sandwich, Pizza, CupSoda, Dessert, HelpCircle } from "lucide-react";
+import { Search, ChevronUp } from "lucide-react";
+import CategoryIcon from "../../components/CategoryIcon";
 import { supabase } from "../../utils/supabaseClient";
 import MenuItemCard from "../../components/MenuItemCard";
 import { useCart } from "../../context/CartContext";
 import CustomerLayout from "../../components/CustomerLayout";
 
-function getCategoryIcon(name: string) {
-  const lower = name.toLowerCase();
-  if (lower.includes("burger")) return Sandwich;
-  if (lower.includes("pizza")) return Pizza;
-  if (lower.includes("drink") || lower.includes("beverage")) return CupSoda;
-  if (lower.includes("dessert") || lower.includes("sweet")) return Dessert;
-  return HelpCircle;
-}
 
 interface Restaurant {
   id: string | number;
@@ -241,10 +234,7 @@ export default function RestaurantMenuPage() {
                   className="w-12 h-12 rounded-full object-cover"
                 />
               ) : (
-                (() => {
-                  const Icon = getCategoryIcon(c.name);
-                  return <Icon className="w-6 h-6" />;
-                })()
+                <CategoryIcon category={c.name} />
               )}
               <span className="text-xs mt-1 whitespace-nowrap">{c.name}</span>
             </button>


### PR DESCRIPTION
## Summary
- add reusable `CategoryIcon` component for menu categories
- show dietary emoji inline with price
- expose description with "More" link to open modal
- update menu page to use `CategoryIcon`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688284421d4c8325b31bb844492885b5