### PR TITLE
Use CartDrawer for static cart page

### DIFF
--- a/components/CartDrawer.tsx
+++ b/components/CartDrawer.tsx
@@ -4,14 +4,136 @@ import { useCart } from '../context/CartContext';
 import { XMarkIcon, ShoppingCartIcon } from '@heroicons/react/24/outline';
 import { Trash2 } from 'lucide-react';
 
-export default function CartDrawer() {
+interface CartDrawerProps {
+  /**
+   * When true, renders the drawer content inline with no toggle button
+   * or overlay. Used for the full cart page.
+   */
+  inline?: boolean;
+}
+
+function CartContent({ onClose }: { onClose?: () => void }) {
   const { cart, subtotal, updateQuantity, removeFromCart, clearCart } = useCart();
-  const [open, setOpen] = useState(false);
   const router = useRouter();
+
+  return (
+    <>
+      <div className="p-4 flex justify-between items-center border-b">
+        <h2 className="text-lg font-semibold">Your Cart</h2>
+        {onClose && (
+          <button onClick={onClose} aria-label="Close" className="text-gray-500">
+            <XMarkIcon className="w-5 h-5" />
+          </button>
+        )}
+      </div>
+      <div
+        className="p-4 overflow-y-auto"
+        style={onClose ? { maxHeight: 'calc(100vh - 9rem)' } : undefined}
+      >
+        {cart.items.length === 0 ? (
+          <p className="text-center text-gray-500">Your cart is empty.</p>
+        ) : (
+          cart.items.map((item) => {
+            const addonsTotal = (item.addons || []).reduce(
+              (sum, a) => sum + a.price * a.quantity,
+              0
+            );
+            const itemTotal = item.price * item.quantity + addonsTotal;
+            return (
+              <div key={item.item_id} className="border-b py-3 text-sm">
+                <div className="flex justify-between items-start">
+                  <div>
+                    <p className="font-medium">{item.name}</p>
+                    <p className="text-xs text-gray-500">
+                      ${(item.price / 100).toFixed(2)}
+                    </p>
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <button
+                      type="button"
+                      onClick={() => updateQuantity(item.item_id, item.quantity - 1)}
+                      className="w-6 h-6 flex items-center justify-center border rounded"
+                    >
+                      -
+                    </button>
+                    <span>{item.quantity}</span>
+                    <button
+                      type="button"
+                      onClick={() => updateQuantity(item.item_id, item.quantity + 1)}
+                      className="w-6 h-6 flex items-center justify-center border rounded"
+                    >
+                      +
+                    </button>
+                  </div>
+                </div>
+                {item.addons && item.addons.length > 0 && (
+                  <ul className="mt-2 ml-4 space-y-1">
+                    {item.addons.map((addon) => (
+                      <li key={addon.option_id} className="flex justify-between">
+                        <span>
+                          {addon.name} × {addon.quantity}
+                        </span>
+                        <span>
+                          ${((addon.price * addon.quantity) / 100).toFixed(2)}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                {item.notes && (
+                  <p className="mt-1 ml-4 text-xs italic text-gray-600">
+                    {item.notes}
+                  </p>
+                )}
+                <div className="mt-2 flex justify-between items-center">
+                  <span className="font-medium">
+                    Subtotal: ${(itemTotal / 100).toFixed(2)}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => removeFromCart(item.item_id)}
+                    className="text-red-600 flex items-center text-sm"
+                  >
+                    <Trash2 className="w-4 h-4 mr-1" /> Remove
+                  </button>
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+      <div className="p-4 border-t space-y-2">
+        <div className="flex justify-between font-semibold">
+          <span>Subtotal</span>
+          <span>${(subtotal / 100).toFixed(2)}</span>
+        </div>
+        <button
+          type="button"
+          onClick={clearCart}
+          className="w-full px-4 py-2 bg-gray-200 rounded hover:bg-gray-300"
+        >
+          Clear Cart
+        </button>
+        <button
+          type="button"
+          onClick={() => router.push('/checkout')}
+          className="w-full px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-700"
+        >
+          Proceed to Checkout
+        </button>
+      </div>
+    </>
+  );
+}
+
+export default function CartDrawer({ inline = false }: CartDrawerProps) {
+  const { cart } = useCart();
+  const [open, setOpen] = useState(false);
 
   const toggle = () => setOpen((o) => !o);
 
   const itemCount = cart.items.reduce((sum, it) => sum + it.quantity, 0);
+
   const prevCount = useRef(itemCount);
   const [bounce, setBounce] = useState(false);
 
@@ -23,6 +145,15 @@ export default function CartDrawer() {
     }
     prevCount.current = itemCount;
   }, [itemCount]);
+
+  if (inline) {
+    // Render content directly without drawer behaviour
+    return (
+      <div className="max-w-screen-sm mx-auto px-4 pt-6">
+        <CartContent />
+      </div>
+    );
+  }
 
   return (
     <>
@@ -39,105 +170,9 @@ export default function CartDrawer() {
       </button>
       {open && (
         <>
-          <div
-            className="fixed inset-0 bg-black/40 z-40"
-            onClick={toggle}
-          />
-          <div className="fixed inset-y-0 right-0 w-80 max-w-full bg-white shadow-lg z-50 transform transition-transform">
-            <div className="p-4 flex justify-between items-center border-b">
-              <h2 className="text-lg font-semibold">Your Cart</h2>
-              <button onClick={toggle} aria-label="Close" className="text-gray-500">
-                <XMarkIcon className="w-5 h-5" />
-              </button>
-            </div>
-            <div className="p-4 overflow-y-auto" style={{ maxHeight: 'calc(100vh - 9rem)' }}>
-              {cart.items.length === 0 ? (
-                <p className="text-center text-gray-500">Your cart is empty.</p>
-              ) : (
-                cart.items.map((item) => {
-                  const addonsTotal = (item.addons || []).reduce(
-                    (sum, a) => sum + a.price * a.quantity,
-                    0
-                  );
-                  const itemTotal = item.price * item.quantity + addonsTotal;
-                  return (
-                    <div key={item.item_id} className="border-b py-3 text-sm">
-                      <div className="flex justify-between items-start">
-                        <div>
-                          <p className="font-medium">{item.name}</p>
-                          <p className="text-xs text-gray-500">${(item.price / 100).toFixed(2)}</p>
-                        </div>
-                        <div className="flex items-center space-x-2">
-                          <button
-                            type="button"
-                            onClick={() => updateQuantity(item.item_id, item.quantity - 1)}
-                            className="w-6 h-6 flex items-center justify-center border rounded"
-                          >
-                            -
-                          </button>
-                          <span>{item.quantity}</span>
-                          <button
-                            type="button"
-                            onClick={() => updateQuantity(item.item_id, item.quantity + 1)}
-                            className="w-6 h-6 flex items-center justify-center border rounded"
-                          >
-                            +
-                          </button>
-                        </div>
-                      </div>
-                      {item.addons && item.addons.length > 0 && (
-                        <ul className="mt-2 ml-4 space-y-1">
-                          {item.addons.map((addon) => (
-                            <li key={addon.option_id} className="flex justify-between">
-                              <span>
-                                {addon.name} × {addon.quantity}
-                              </span>
-                              <span>${((addon.price * addon.quantity) / 100).toFixed(2)}</span>
-                            </li>
-                          ))}
-                        </ul>
-                      )}
-                      {item.notes && (
-                        <p className="mt-1 ml-4 text-xs italic text-gray-600">{item.notes}</p>
-                      )}
-                      <div className="mt-2 flex justify-between items-center">
-                        <span className="font-medium">Subtotal: ${(itemTotal / 100).toFixed(2)}</span>
-                        <button
-                          type="button"
-                          onClick={() => removeFromCart(item.item_id)}
-                          className="text-red-600 flex items-center text-sm"
-                        >
-                          <Trash2 className="w-4 h-4 mr-1" /> Remove
-                        </button>
-                      </div>
-                    </div>
-                  );
-                })
-              )}
-            </div>
-            <div className="p-4 border-t space-y-2">
-              <div className="flex justify-between font-semibold">
-                <span>Subtotal</span>
-                <span>${(subtotal / 100).toFixed(2)}</span>
-              </div>
-              <button
-                type="button"
-                onClick={clearCart}
-                className="w-full px-4 py-2 bg-gray-200 rounded hover:bg-gray-300"
-              >
-                Clear Cart
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setOpen(false);
-                  router.push('/checkout');
-                }}
-                className="w-full px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-700"
-              >
-                Proceed to Checkout
-              </button>
-            </div>
+          <div className="fixed inset-0 bg-black/40 z-40" onClick={toggle} />
+          <div className="fixed inset-y-0 right-0 w-80 max-w-full bg-white shadow-lg z-50">
+            <CartContent onClose={toggle} />
           </div>
         </>
       )}

--- a/pages/restaurant/cart.tsx
+++ b/pages/restaurant/cart.tsx
@@ -1,96 +1,14 @@
-import Link from 'next/link';
-import { motion } from 'framer-motion';
 import { useCart } from '../../context/CartContext';
 import CustomerLayout from '../../components/CustomerLayout';
+import CartDrawer from '../../components/CartDrawer';
 
 export default function CartPage() {
-  const { cart, subtotal, updateQuantity, removeFromCart } = useCart();
-
+  const { cart } = useCart();
   const itemCount = cart.items.reduce((sum, it) => sum + it.quantity, 0);
 
   return (
     <CustomerLayout cartCount={itemCount}>
-      <main className="max-w-screen-sm mx-auto px-4 pb-28 pt-6">
-        <h1 className="text-2xl font-bold mb-6">Your Cart</h1>
-        {cart.items.length === 0 ? (
-          <div className="text-center text-gray-500 mt-12">
-            <p>Your cart is empty</p>
-            <Link
-              href="/menu"
-              className="mt-4 inline-block px-4 py-2 bg-primary text-white rounded-full"
-            >
-              Browse Menu
-            </Link>
-          </div>
-        ) : (
-          <div>
-            {cart.items.map((item) => {
-              const img = (item as any).image_url as string | undefined;
-              const tag = (item as any).tag as string | undefined;
-              return (
-                <div
-                  key={item.item_id}
-                  className="flex justify-between items-center p-4 rounded-xl shadow-sm mb-3"
-                >
-                  <div className="flex items-center gap-3">
-                    {img && (
-                      <img
-                        src={img}
-                        alt={item.name}
-                        className="w-16 h-16 object-cover rounded-md"
-                      />
-                    )}
-                    <div>
-                      <p className="font-semibold">{item.name}</p>
-                      <p className="text-sm text-gray-600">${(item.price / 100).toFixed(2)}</p>
-                      {tag && <span className="text-xs text-gray-500">{tag}</span>}
-                    </div>
-                  </div>
-                  <div className="text-right">
-                    <div className="flex items-center justify-end space-x-2">
-                      <motion.button
-                        type="button"
-                        whileTap={{ scale: 0.9 }}
-                        onClick={() => updateQuantity(item.item_id, item.quantity - 1)}
-                        className="w-6 h-6 flex items-center justify-center border rounded"
-                      >
-                        -
-                      </motion.button>
-                      <span>{item.quantity}</span>
-                      <motion.button
-                        type="button"
-                        whileTap={{ scale: 0.9 }}
-                        onClick={() => updateQuantity(item.item_id, item.quantity + 1)}
-                        className="w-6 h-6 flex items-center justify-center border rounded"
-                      >
-                        +
-                      </motion.button>
-                    </div>
-                    <button
-                      type="button"
-                      onClick={() => removeFromCart(item.item_id)}
-                      className="text-xs text-red-500 underline ml-2"
-                    >
-                      Remove
-                    </button>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        )}
-        {cart.items.length > 0 && (
-          <div className="fixed bottom-0 left-0 right-0 bg-white px-4 py-3 shadow-md">
-            <p className="text-right font-semibold">Total: ${(subtotal / 100).toFixed(2)}</p>
-            <Link
-              href="/checkout"
-              className="bg-primary text-white rounded-full w-full py-3 block text-center mt-2"
-            >
-              Continue to Checkout
-            </Link>
-          </div>
-        )}
-      </main>
+      <CartDrawer inline />
     </CustomerLayout>
   );
 }


### PR DESCRIPTION
## Summary
- simplify `CartDrawer` so it can render inline
- replace manual cart logic in `pages/restaurant/cart.tsx` with `CartDrawer`

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6883571952f4832592acd31fc1e0956f