### PR TITLE
Fix Supabase user retrieval and query logic

### DIFF
--- a/pages/restaurant/orders.tsx
+++ b/pages/restaurant/orders.tsx
@@ -58,7 +58,7 @@ export default function CustomerOrdersPage() {
   const router = useRouter();
   const { cart } = useCart();
   const itemCount = cart.items.reduce((sum, it) => sum + it.quantity, 0);
-  const { user } = useUser();
+  const user = useUser();
   const userId = user?.id;
   const userEmail = user?.email;
 
@@ -75,17 +75,14 @@ export default function CustomerOrdersPage() {
 
       const { data: ordersData, error: ordersError } = await supabase
         .from('orders')
-        .select(
-          `id, short_order_number, order_type, delivery_address, customer_notes, status, total_price, created_at,
-          order_items(id,item_id,name,price,quantity,notes,order_addons(id,option_id,name,price,quantity))`
-        )
+        .select('*')
         .or(`user_id.eq.${userId},guest_email.eq.${userEmail}`)
         .order('created_at', { ascending: false });
 
       console.log('User ID:', userId);
       console.log('User Email:', userEmail);
       console.log('Orders:', ordersData);
-      console.log('Error:', ordersError);
+      console.log('Orders Error:', ordersError);
 
       if (!ordersError && ordersData) {
         setOrders(ordersData as Order[]);


### PR DESCRIPTION
## Summary
- fix Supabase `useUser` usage in restaurant orders page
- revise orders query with user ID/email filtering and debug logging

## Testing
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_6894915167788325bcbfa0cc7034b482