### PR TITLE
fix: redirect orders login to global path

### DIFF
--- a/pages/restaurant/orders.tsx
+++ b/pages/restaurant/orders.tsx
@@ -18,7 +18,7 @@ export default function OrdersPage() {
 
   useEffect(() => {
     if (!loading && !user && !guestEmail) {
-      router.replace('/restaurant/login')
+      router.replace('/login')
     }
   }, [loading, user, guestEmail])
 


### PR DESCRIPTION
## Summary
- fix redirect path in restaurant orders page to global login

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6894a424580c832581324f30804cb294