### PR TITLE
Fetch restaurant-specific orders

### DIFF
--- a/pages/restaurant/orders.tsx
+++ b/pages/restaurant/orders.tsx
@@ -13,8 +13,9 @@ export default function OrdersPage() {
       const { data } = await supabase
         .from('orders')
         .select('*')
-        .eq('user_id', user.id)
+        .eq('restaurant_id', '358bbecc-4437-4cdf-bbea-bc0ffc0cb1ba')
         .order('created_at', { ascending: false })
+
       setOrders(data || [])
     }
     fetchOrders()


### PR DESCRIPTION
## Summary
- fetch orders for a specific restaurant id in restaurant orders page

## Testing
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_6895cd81b5248325bf8f1ea4ea3cb254