### PR TITLE
Add orders debug section to restaurant orders page

### DIFF
--- a/pages/restaurant/orders.tsx
+++ b/pages/restaurant/orders.tsx
@@ -36,6 +36,7 @@ export default function OrdersPage() {
 
   return (
     <div className="max-w-screen-sm mx-auto px-4 pb-24">
+      <pre>{JSON.stringify(orders, null, 2)}</pre>
       <h1 className="text-xl font-semibold mb-4">Your Orders</h1>
       {orders.length === 0 ? (
         <p>No orders found.</p>


### PR DESCRIPTION
## Summary
- log raw order data in `restaurant/orders` page

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6895edc04460832599f67551776fa3e0