### PR TITLE
Use user-specific order query

### DIFF
--- a/pages/restaurant/orders.tsx
+++ b/pages/restaurant/orders.tsx
@@ -13,7 +13,7 @@ export default function OrdersPage() {
       const { data } = await supabase
         .from('orders')
         .select('*')
-        .eq('restaurant_id', '358bbecc-4437-4cdf-bbea-bc0ffc0cb1ba')
+        .eq('user_id', user.id)
         .order('created_at', { ascending: false })
 
       setOrders(data || [])


### PR DESCRIPTION
## Summary
- Query user-specific orders from Supabase without guest logic.

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6895fb4a91488325a78c7ed47559e685