### PR TITLE
Allow previewing orders for specific user

### DIFF
--- a/pages/dashboard/website/preview.tsx
+++ b/pages/dashboard/website/preview.tsx
@@ -15,6 +15,7 @@ export default function WebsitePreview() {
   const router = useRouter();
   const [restaurant, setRestaurant] = useState<Restaurant | null>(null);
   const [loading, setLoading] = useState(true);
+  const [userId, setUserId] = useState<string>('');
 
   useEffect(() => {
     const load = async () => {
@@ -25,6 +26,7 @@ export default function WebsitePreview() {
         router.push('/login');
         return;
       }
+      setUserId(session.user.id);
       const { data: ru } = await supabase
         .from('restaurant_users')
         .select('restaurant_id')
@@ -66,10 +68,10 @@ export default function WebsitePreview() {
           </p>
         )}
         <Link
-          href={`/restaurant/menu?restaurant_id=${restaurant.id}`}
+          href={`/restaurant/orders?restaurant_id=${restaurant.id}&user_id=${userId}`}
           className="px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-700"
         >
-          View Menu
+          Preview Site
         </Link>
       </div>
     </DashboardLayout>

--- a/pages/restaurant/orders.tsx
+++ b/pages/restaurant/orders.tsx
@@ -1,28 +1,36 @@
 import { useEffect, useState } from 'react'
 import { useSupabaseClient } from '@supabase/auth-helpers-react'
 import { useUser } from '@/lib/useUser'
+import { useRouter } from 'next/router'
 
 export default function OrdersPage() {
   const supabase = useSupabaseClient()
   const { user, loading } = useUser()
+  const router = useRouter()
+  const forcedUserId = typeof router.query.user_id === 'string' ? router.query.user_id : undefined
   const [orders, setOrders] = useState<any[]>([])
 
   useEffect(() => {
-    if (!user || loading) return
+    if (loading) return
+    const targetUserId = forcedUserId || user?.id
+    if (!targetUserId) return
+
     const fetchOrders = async () => {
       const { data } = await supabase
         .from('orders')
         .select('*')
-        .eq('user_id', user.id)
+        .eq('user_id', targetUserId)
         .order('created_at', { ascending: false })
+
       setOrders(data || [])
     }
+
     fetchOrders()
-  }, [user, loading])
+  }, [forcedUserId, user, loading, supabase])
 
   if (loading) return null
 
-  if (!user) {
+  if (!forcedUserId && !user) {
     return (
       <div className="max-w-screen-sm mx-auto px-4 pb-24 flex items-center justify-center h-96">
         <div className="text-center">
@@ -40,10 +48,12 @@ export default function OrdersPage() {
         <p>No orders found.</p>
       ) : (
         <ul className="space-y-4">
-          {orders.map(order => (
+          {orders.map((order: any) => (
             <li key={order.id} className="border p-4 rounded">
-              <div className="font-bold">Order #{order.id.slice(0, 4)}</div>
-              <div>{order.status}</div>
+              <div className="font-bold">Order #{String(order.short_order_number ?? order.id).slice(0, 4)}</div>
+              <div className="text-sm text-gray-600">{order.status}</div>
+              <div className="text-sm">Placed: {new Date(order.created_at).toLocaleString()}</div>
+              <div className="text-sm">Total: £{Number(order.total_price ?? 0).toFixed(2)}</div>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Summary
- Support showing orders for an explicit `user_id` on the restaurant orders page
- Pass admin's user ID in dashboard "Preview Site" link for the orders page

## Testing
- `npm run build`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689ae5b452f883259ec320aec6cbc232