### PR TITLE
fix(restaurant): Orders preview reads user_id from URL with auth fallback; strict user_id filter with optional restaurant_id

### DIFF
--- a/pages/restaurant/orders.tsx
+++ b/pages/restaurant/orders.tsx
@@ -14,13 +14,14 @@ export default function OrdersPage() {
 
   useEffect(() => {
     if (loading) return
-    const targetUserId = qUserId || user?.id
-    if (!targetUserId) {
-      setOrders([])
-      return
-    }
 
     const fetchOrders = async () => {
+      const targetUserId = qUserId || user?.id
+      if (!targetUserId) {
+        setOrders([])
+        return
+      }
+
       let query = supabase
         .from('orders')
         .select('*')
@@ -31,7 +32,10 @@ export default function OrdersPage() {
         query = query.eq('restaurant_id', qRestaurantId)
       }
 
-      const { data } = await query
+      const { data, error } = await query
+      if (error) {
+        console.error('[orders] fetch error', error)
+      }
       setOrders(data || [])
     }
 


### PR DESCRIPTION
## Summary
- read preview `user_id` and optional `restaurant_id` from query string
- fetch orders strictly by `user_id` with optional restaurant narrowing and error logging

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_689af3c4ae08832582563e94f438c5f1