### PR TITLE
feat(orders): add tappable cards with modal details

### DIFF
--- a/pages/restaurant/orders.tsx
+++ b/pages/restaurant/orders.tsx
@@ -14,6 +14,18 @@ export default function OrdersPage() {
 
   const [orders, setOrders] = useState<any[]>([])
 
+  const [activeOrder, setActiveOrder] = useState<any | null>(null)
+  const openOrder = (o: any) => setActiveOrder(o)
+  const closeOrder = () => setActiveOrder(null)
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeOrder()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [])
+
   useEffect(() => {
     if (loading) return
 
@@ -60,13 +72,127 @@ export default function OrdersPage() {
         ) : (
           <ul className="space-y-4">
             {orders.map((order: any) => (
-              <li key={order.id} className="border p-4 rounded">
+              <li
+                key={order.id}
+                className="border p-4 rounded cursor-pointer hover:bg-gray-50 focus:bg-gray-50 focus:outline-none"
+                role="button"
+                tabIndex={0}
+                onClick={() => openOrder(order)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    openOrder(order)
+                  }
+                }}
+                aria-label={`Open details for order ${String(order.short_order_number ?? order.id).slice(0, 4)}`}
+              >
                 <div className="font-bold">Order #{String(order.short_order_number ?? order.id).slice(0, 4)}</div>
                 <div className="text-sm text-gray-600">{order.status}</div>
                 <div className="text-sm">Placed: {new Date(order.created_at).toLocaleString()}</div>
+                <div className="text-xs text-gray-400 mt-1">Tap for details</div>
               </li>
             ))}
           </ul>
+        )}
+        {activeOrder && (
+          <div
+            className="fixed inset-0 z-50 flex items-end sm:items-center justify-center"
+            aria-modal="true"
+            role="dialog"
+          >
+            {/* Backdrop */}
+            <div
+              className="absolute inset-0 bg-black/40"
+              onClick={closeOrder}
+            />
+            {/* Sheet/Modal */}
+            <div className="relative w-full sm:max-w-md bg-white rounded-t-2xl sm:rounded-2xl shadow-lg p-4 sm:p-6 z-10">
+              {/* Header */}
+              <div className="flex items-center justify-between mb-3">
+                <div className="text-base sm:text-lg font-semibold">
+                  Order #{String(activeOrder.short_order_number ?? activeOrder.id).slice(0, 4)}
+                </div>
+                <button
+                  onClick={closeOrder}
+                  className="text-gray-500 hover:text-gray-700 focus:outline-none"
+                  aria-label="Close order details"
+                >
+                  ✕
+                </button>
+              </div>
+
+              {/* Status row */}
+              <div className="text-sm text-gray-600 mb-2">
+                Status: <span className="font-medium">{activeOrder.status ?? '—'}</span>
+              </div>
+
+              {/* Meta */}
+              <div className="text-sm text-gray-600 mb-4">
+                Placed: {activeOrder.created_at ? new Date(activeOrder.created_at).toLocaleString() : '—'}
+              </div>
+
+              {/* Items / Notes (show if present on the order object; otherwise omit) */}
+              {Array.isArray(activeOrder.items) && activeOrder.items.length > 0 && (
+                <div className="mb-4">
+                  <div className="text-sm font-medium mb-2">Items</div>
+                  <ul className="space-y-2">
+                    {activeOrder.items.map((it: any, idx: number) => (
+                      <li key={idx} className="text-sm text-gray-700">
+                        <span className="font-medium">{it?.name ?? 'Item'}</span>
+                        {typeof it?.quantity === 'number' && <span> × {it.quantity}</span>}
+                        {typeof it?.price === 'number' && <span className="ml-1">— £{Number(it.price).toFixed(2)}</span>}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {activeOrder.notes && (
+                <div className="mb-4">
+                  <div className="text-sm font-medium mb-1">Customer notes</div>
+                  <div className="text-sm text-gray-700 whitespace-pre-wrap">{activeOrder.notes}</div>
+                </div>
+              )}
+
+              {/* Totals (only if present) */}
+              {(typeof activeOrder.subtotal === 'number' || typeof activeOrder.total === 'number') && (
+                <div className="border-t pt-3 mt-3 text-sm">
+                  {typeof activeOrder.subtotal === 'number' && (
+                    <div className="flex justify-between">
+                      <span className="text-gray-600">Subtotal</span>
+                      <span className="font-medium">£{Number(activeOrder.subtotal).toFixed(2)}</span>
+                    </div>
+                  )}
+                  {typeof activeOrder.total === 'number' && (
+                    <div className="flex justify-between">
+                      <span className="text-gray-600">Total</span>
+                      <span className="font-semibold">£{Number(activeOrder.total).toFixed(2)}</span>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Actions (non-destructive placeholders; no logic changed) */}
+              <div className="mt-4 flex gap-2">
+                <button
+                  className="flex-1 py-2 rounded-xl border text-sm font-medium hover:bg-gray-50"
+                  onClick={closeOrder}
+                >
+                  Close
+                </button>
+                <button
+                  className="flex-1 py-2 rounded-xl bg-black text-white text-sm font-medium hover:opacity-90"
+                  onClick={() => {
+                    // Placeholder for future tracking/navigation
+                    // e.g., router.push(`/restaurant/orders/${activeOrder.id}`)
+                    closeOrder()
+                  }}
+                >
+                  Track Order
+                </button>
+              </div>
+            </div>
+          </div>
         )}
       </div>
     </CustomerLayout>


### PR DESCRIPTION
## Summary
- make each order card a tappable/keyboard-activatable button
- show order information in an accessible modal with close controls

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_689affe27be48325ac332cc2d0b78cc8