### PR TITLE
refactor: use object-based router replace

### DIFF
--- a/pages/restaurant/orders.tsx
+++ b/pages/restaurant/orders.tsx
@@ -55,9 +55,12 @@ export default function OrdersPage() {
     if (loading) return
     if (!qUserId && user?.id) {
       setNormalizingUrl(true)
-      const next = { ...router.query, user_id: user.id }
       router
-        .replace({ pathname: router.pathname, query: next }, undefined, { shallow: true })
+        .replace(
+          { pathname: router.pathname, query: { ...router.query, user_id: user.id } },
+          undefined,
+          { shallow: true }
+        )
         .finally(() => setNormalizingUrl(false))
     }
   }, [router.isReady, loading, qUserId, user?.id])


### PR DESCRIPTION
## Summary
- use object-based navigation when normalizing `user_id` query on the orders page

## Testing
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689b12ed4cc4832591d451d2b48ab141