### PR TITLE
Delay website preview link until user is loaded

### DIFF
--- a/pages/dashboard/website/preview.tsx
+++ b/pages/dashboard/website/preview.tsx
@@ -16,7 +16,7 @@ export default function WebsitePreview() {
   const router = useRouter();
   const [restaurant, setRestaurant] = useState<Restaurant | null>(null);
   const [loading, setLoading] = useState(true);
-  const { user } = useUser();
+  const { user, loading: userLoading } = useUser();
 
   useEffect(() => {
     const load = async () => {
@@ -67,15 +67,17 @@ export default function WebsitePreview() {
             {restaurant.website_description}
           </p>
         )}
-        <Link
-          href={{
-            pathname: '/restaurant/orders',
-            query: { restaurant_id: restaurant.id, user_id: user?.id },
-          }}
-          className="px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-700"
-        >
-          Preview Site
-        </Link>
+        {!userLoading && user && (
+          <Link
+            href={{
+              pathname: '/restaurant/orders',
+              query: { restaurant_id: restaurant.id, user_id: user.id },
+            }}
+            className="px-4 py-2 bg-teal-600 text-white rounded hover:bg-teal-700"
+          >
+            Preview Site
+          </Link>
+        )}
       </div>
     </DashboardLayout>
   );


### PR DESCRIPTION
## Summary
- use `useUser` loading state in website preview page
- hide preview link until the user is loaded and include `user_id` in query

## Testing
- `npm run test:ci -- --silent`


------
https://chatgpt.com/codex/tasks/task_e_689b24169d9c8325a67eac2e5bffe293