### PR TITLE
Use shared Supabase client in website preview

### DIFF
--- a/pages/dashboard/website/preview.tsx
+++ b/pages/dashboard/website/preview.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import DashboardLayout from '../../../components/DashboardLayout';
-import { supabase } from '../../../utils/supabaseClient';
+import { useSupabaseClient } from '@supabase/auth-helpers-react';
 import { useUser } from '@/lib/useUser';
 
 interface Restaurant {
@@ -14,6 +14,7 @@ interface Restaurant {
 
 export default function WebsitePreview() {
   const router = useRouter();
+  const supabase = useSupabaseClient();
   const [restaurant, setRestaurant] = useState<Restaurant | null>(null);
   const [loading, setLoading] = useState(true);
   const { user, loading: userLoading } = useUser();


### PR DESCRIPTION
## Summary
- Use `useSupabaseClient` hook in website preview to share the Supabase client with `useUser`

## Testing
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689b2a00f36483258a3142aeee796708