### PR TITLE
feat: centralize customer branding

### DIFF
--- a/__tests__/Branding.test.tsx
+++ b/__tests__/Branding.test.tsx
@@ -5,14 +5,6 @@ import Hero from '../components/customer/Hero';
 import OpenBadge from '../components/customer/OpenBadge';
 import BrandProvider from '../components/branding/BrandProvider';
 
-jest.mock('../utils/supabaseClient', () => ({
-  supabase: {
-    from: () => ({
-      select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null }) }) }),
-    }),
-  },
-}));
-
 jest.mock('next/router', () => ({
   useRouter: () => ({ query: {} }),
 }));
@@ -22,7 +14,7 @@ const restaurant = { id: 1, name: 'Demo Diner', is_open: true, brand_color: '#ff
 test('brand variables apply to button and badge', () => {
   render(
     <BrandProvider restaurant={restaurant}>
-      <button data-testid="btn" style={{ background: 'var(--brand)' }}>
+      <button data-testid="btn" className="btn-primary">
         Btn
       </button>
       <OpenBadge isOpen />
@@ -30,11 +22,11 @@ test('brand variables apply to button and badge', () => {
   );
   const btn = screen.getByTestId('btn');
   const badge = screen.getByText('Open');
-  const root = btn.closest('[data-brand]') as HTMLElement;
+  const root = btn.closest('[data-brand-root]') as HTMLElement;
   expect(root).toHaveStyle('--brand: #ff0000');
-  expect(btn).toHaveStyle('background: var(--brand)');
+  expect(btn).toHaveClass('btn-primary');
   expect(badge).toHaveStyle('border: 1px solid var(--brand)');
-  expect(badge).toHaveClass('brand-pill');
+  expect(badge).toHaveClass('pill');
 });
 
 test('footer hidden on hero and appears after scroll', () => {

--- a/components/AddToOrderModal.tsx
+++ b/components/AddToOrderModal.tsx
@@ -100,8 +100,7 @@ export default function AddToOrderModal({
         <div className="px-6 pb-6">
           <button
             onClick={handleAdd}
-            className="w-full text-white py-2 rounded hover:opacity-90"
-            style={{ background: 'var(--brand)' }}
+            className="w-full py-2 rounded hover:opacity-90 btn-primary"
           >
             Add to Order
           </button>

--- a/components/CartDrawer.tsx
+++ b/components/CartDrawer.tsx
@@ -117,8 +117,7 @@ function CartContent({ onClose }: { onClose?: () => void }) {
         <button
           type="button"
           onClick={() => router.push('/checkout')}
-          className="w-full px-4 py-2 text-white rounded hover:opacity-90"
-          style={{ background: 'var(--brand)' }}
+          className="w-full px-4 py-2 rounded hover:opacity-90 btn-primary"
         >
           Proceed to Checkout
         </button>
@@ -161,8 +160,7 @@ export default function CartDrawer({ inline = false }: CartDrawerProps) {
       <button
         type="button"
         onClick={toggle}
-        className={`fixed bottom-4 right-4 text-white rounded-full px-4 py-2 flex items-center shadow-lg z-50 transition-transform ${bounce ? 'animate-bounce' : ''}`}
-        style={{ background: 'var(--brand)' }}
+        className={`fixed bottom-4 right-4 rounded-full px-4 py-2 flex items-center shadow-lg z-50 transition-transform btn-primary ${bounce ? 'animate-bounce' : ''}`}
         aria-label="Toggle cart"
       >
         <ShoppingCartIcon className="w-5 h-5 mr-2" />

--- a/components/CustomerLayout.tsx
+++ b/components/CustomerLayout.tsx
@@ -1,6 +1,6 @@
 import Head from 'next/head';
 import { ReactNode } from 'react';
-import BrandProvider from './branding/BrandProvider';
+import BrandProvider from './branding/BrandProvider'; // brand: provider mount
 import TopBar from './customer/TopBar';
 import FooterNav from './customer/FooterNav';
 
@@ -22,7 +22,7 @@ export default function CustomerLayout({
   hideFooter,
 }: CustomerLayoutProps) {
   return (
-    <BrandProvider restaurant={restaurant}>
+    <BrandProvider restaurant={restaurant}> {/* brand: provider mount */}
       {includePwaMeta && (
         <Head>
           <title>OrderFast – Restaurant</title>

--- a/components/MenuItemCard.tsx
+++ b/components/MenuItemCard.tsx
@@ -142,7 +142,7 @@ export default function MenuItemCard({
             <p className="text-sm text-gray-600 line-clamp-2 mt-1">
               {item.description}
               {descriptionTooLong && (
-                <button onClick={handleClick} className="text-[var(--brand)] text-xs ml-1">More</button>
+                <button onClick={handleClick} className="link-brand text-xs ml-1">More</button>
               )}
             </p>
           )}
@@ -156,8 +156,7 @@ export default function MenuItemCard({
               whileTap={{ scale: 0.95 }}
               animate={recentlyAdded ? { scale: [1, 1.05, 1] } : {}}
               onClick={handleClick}
-              className="text-white text-sm h-9 px-4 rounded-full w-full sm:w-auto flex items-center justify-center gap-1 brand-btn"
-              style={{ background: 'var(--brand)' }}
+              className="text-sm h-9 px-4 rounded-full w-full sm:w-auto flex items-center justify-center gap-1 btn-primary"
             >
               <ShoppingCart className="w-4 h-4" />
               {recentlyAdded ? '✓ Added' : 'Add to Cart'}
@@ -229,8 +228,7 @@ export default function MenuItemCard({
               <button
                 aria-label="Confirm Add to Cart"
                 onClick={handleFinalAdd}
-                className="px-4 py-2 text-white rounded hover:opacity-90"
-                style={{ background: 'var(--brand)' }}
+                className="px-4 py-2 rounded hover:opacity-90 btn-primary"
               >
                 Add to Cart
               </button>

--- a/components/branding/Logo.tsx
+++ b/components/branding/Logo.tsx
@@ -1,39 +1,31 @@
+// slides/brand: added
 import React from 'react';
-import Image from 'next/image';
 import { useBrand } from './BrandProvider';
 
-interface Props {
-  size?: number;
-  className?: string;
-  ariaLabel?: string;
-}
-
-export default function Logo({ size = 32, className = '', ariaLabel }: Props) {
-  const { logoUrl, name, initials } = useBrand();
-  const label = ariaLabel || name;
+export default function Logo({ size = 28, className = '' }: { size?: number; className?: string }) {
+  const { logoUrl, initials, name } = useBrand();
   if (logoUrl) {
     return (
-      <Image
-        src={logoUrl}
-        alt={label}
-        width={size}
-        height={size}
-        className={`object-cover rounded-full ${className}`}
-      />
+      <span className={className} style={{ display: 'inline-flex', width: size, height: size, borderRadius: '9999px', overflow: 'hidden' }}>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={logoUrl} alt={name} width={size} height={size} style={{ width: size, height: size, objectFit: 'cover' }} />
+      </span>
     );
   }
-  const style: React.CSSProperties = {
-    width: size,
-    height: size,
-    fontSize: size * 0.5,
-  };
   return (
-    <div
-      aria-label={label}
-      className={`rounded-full bg-[var(--brand)] text-white flex items-center justify-center font-semibold ${className}`}
-      style={style}
+    <span
+      className={className}
+      style={{
+        width: size, height: size, borderRadius: '9999px',
+        background: 'var(--brand)', color: 'white',
+        display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+        fontWeight: 700, letterSpacing: 0.5,
+      }}
+      aria-label={name}
+      title={name}
     >
       {initials}
-    </div>
+    </span>
   );
 }
+

--- a/components/customer/FooterNav.tsx
+++ b/components/customer/FooterNav.tsx
@@ -24,7 +24,7 @@ export default function FooterNav({ cartCount = 0, hidden }: Props) {
       href={build(href)}
       className={`flex flex-col items-center justify-center text-xs transition-all ${
         current === (href === '/' ? '/restaurant' : `/restaurant/${href}`)
-          ? 'text-[var(--brand)]'
+          ? 'nav-active'
           : 'text-[var(--muted)]'
       }`}
     >
@@ -43,7 +43,7 @@ export default function FooterNav({ cartCount = 0, hidden }: Props) {
         <div className="absolute -top-6 left-1/2 -translate-x-1/2">
           <Link
             href={build('cart')}
-            className="relative w-14 h-14 rounded-full bg-[var(--brand)] text-white flex items-center justify-center shadow-lg"
+            className="relative w-14 h-14 rounded-full fab flex items-center justify-center shadow-lg"
           >
             <ShoppingCart className="w-6 h-6" />
             {cartCount > 0 && (

--- a/components/customer/Hero.tsx
+++ b/components/customer/Hero.tsx
@@ -4,7 +4,6 @@ import React, { useEffect, useRef } from 'react';
 import { useRouter } from 'next/router';
 import OpenBadge from './OpenBadge';
 import Logo from '../branding/Logo';
-import { useBrand } from '../branding/BrandProvider';
 
 interface Props {
   restaurant: any;
@@ -14,7 +13,6 @@ interface Props {
 export default function Hero({ restaurant, onVisibilityChange }: Props) {
   const ref = useRef<HTMLDivElement | null>(null);
   const router = useRouter();
-  const { brand } = useBrand();
 
   useEffect(() => {
     if (!ref.current || !onVisibilityChange) return;
@@ -41,7 +39,7 @@ export default function Hero({ restaurant, onVisibilityChange }: Props) {
           <p className="max-w-md text-white/90">{restaurant.website_description}</p>
         )}
         {typeof restaurant?.is_open === 'boolean' && <OpenBadge isOpen={restaurant.is_open} />}
-        <Link href={orderHref} className="brand-btn" style={{ background: brand }}>
+        <Link href={orderHref} className="btn-primary">
           Order Now
         </Link>
       </div>

--- a/components/customer/OpenBadge.tsx
+++ b/components/customer/OpenBadge.tsx
@@ -3,11 +3,11 @@ import React from 'react';
 export default function OpenBadge({ isOpen }: { isOpen?: boolean | null }) {
   return (
     <span
-      className="brand-pill"
+      className="pill"
       style={{
         border: `1px solid var(--brand)`,
         color: isOpen ? 'var(--brand-700)' : 'var(--muted)',
-        background: 'var(--card)',
+        background: isOpen ? undefined : 'var(--card)',
       }}
     >
       {isOpen ? 'Open' : 'Closed'}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,5 @@
 import '../styles/globals.css';
+import '../styles/brand.css'; // brand: tokens
 import { SessionContextProvider } from '@supabase/auth-helpers-react';
 import { CartProvider } from '../context/CartContext';
 import { OrderTypeProvider } from '../context/OrderTypeContext';

--- a/pages/restaurant/index.tsx
+++ b/pages/restaurant/index.tsx
@@ -2,7 +2,7 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import CustomerLayout from '../../components/CustomerLayout';
 import Hero from '../../components/customer/Hero';
-import Slides from '../../components/customer/Slides';
+import Slides from '../../components/customer/Slides'; // slides: restored
 import { supabase } from '../../utils/supabaseClient';
 import { useCart } from '../../context/CartContext';
 

--- a/pages/restaurant/orders.tsx
+++ b/pages/restaurant/orders.tsx
@@ -210,9 +210,7 @@ export default function OrdersPage() {
                 <div className="flex items-baseline justify-between">
                   <div className="text-base font-semibold">Order #{String(order.short_order_number ?? order.id).slice(0, 4)}</div>
                   {order.status && (
-                    <span className="ml-2 text-xs rounded-full px-2 py-0.5 capitalize"
-                      style={{ background: 'var(--brand)', color: '#fff' }}
-                    >
+                    <span className="ml-2 text-xs rounded-full px-2 py-0.5 pill capitalize">
                       {String(order.status).replace(/_/g, ' ')}
                     </span>
                   )}
@@ -238,10 +236,7 @@ export default function OrdersPage() {
               {/* Status + Placed */}
               <div className="flex items-center gap-2 mb-2">
                 {activeOrder.status && (
-                  <span
-                    className="text-xs rounded-full px-2 py-0.5 capitalize"
-                    style={{ background: 'var(--brand)', color: '#fff' }}
-                  >
+                  <span className="text-xs rounded-full px-2 py-0.5 pill capitalize">
                     {String(activeOrder.status).replace(/_/g, ' ')}
                   </span>
                 )}

--- a/styles/brand.css
+++ b/styles/brand.css
@@ -1,42 +1,15 @@
-:root {
-  --brand: hsl(20 90% 50%);
-  --brand-600: hsl(20 90% 45%);
-  --brand-700: hsl(20 90% 40%);
-  --ink: hsl(230 15% 12%);
-  --surface: hsl(0 0% 98%);
-  --card: hsl(0 0% 100% / 0.7);
-  --muted: hsl(230 10% 46%);
-}
+/* brand: tokens */
+[data-brand-root] .btn-primary { background: var(--brand); color: #fff; }
+[data-brand-root] .btn-primary:hover { background: var(--brand-700); }
+[data-brand-root] .pill { background: color-mix(in oklab, var(--brand) 18%, white); color: var(--brand); }
+[data-brand-root] .fab { background: var(--brand); color: #fff; }
+[data-brand-root] .nav-active { color: var(--brand); }
+[data-brand-root] .link-brand { color: var(--brand); }
 
-[data-brand] {
-  color: var(--ink);
-  background-color: var(--surface);
-}
-
-.brand-glass {
+/* Optional glass effect for headers/nav */
+[data-brand-root] .brand-glass {
   backdrop-filter: saturate(160%) blur(12px);
-  background: color-mix(in oklab, var(--card), transparent 30%);
-  box-shadow: 0 6px 24px rgba(0,0,0,.08);
+  background: color-mix(in oklab, var(--card) 70%, transparent);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.08);
 }
 
-.brand-pill {
-  border: 1px solid color-mix(in oklab, var(--brand), black 12%);
-  border-radius: 9999px;
-  padding: 3px 10px;
-  font-size: 12px;
-  line-height: 1.2;
-}
-
-.brand-btn {
-  background: var(--brand);
-  color: #fff;
-  border-radius: 14px;
-  padding: 12px 18px;
-  box-shadow: 0 8px 20px rgba(0,0,0,.12);
-  transition: transform .12s ease, box-shadow .12s ease;
-}
-
-.brand-btn:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 10px 24px rgba(0,0,0,.16);
-}


### PR DESCRIPTION
## Summary
- add BrandProvider and Logo components for centralized branding
- introduce CSS variable tokens for primary UI accents
- switch customer UI elements to brand tokens and Logo component

## Testing
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689b4f1ce63c83258b00128e75441282