### PR TITLE
Handle brand context safely and wrap restaurant routes

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,16 +1,24 @@
 import '../styles/globals.css';
-import '../styles/brand.css'; // brand: tokens
+import '@/styles/brand.css';
+import type { AppProps } from 'next/app';
+import { useRouter } from 'next/router';
+import { BrandProvider } from '@/components/branding/BrandProvider';
 import { SessionContextProvider } from '@supabase/auth-helpers-react';
 import { CartProvider } from '../context/CartContext';
 import { OrderTypeProvider } from '../context/OrderTypeContext';
 import { supabase } from '../utils/supabaseClient';
 
-export default function App({ Component, pageProps }) {
+export default function App({ Component, pageProps }: AppProps) {
+  const router = useRouter();
+  const isRestaurantRoute = router.pathname.startsWith('/restaurant');
+  const page = <Component {...pageProps} />;
+  const content = isRestaurantRoute ? <BrandProvider>{page}</BrandProvider> : page;
+
   return (
     <SessionContextProvider supabaseClient={supabase} initialSession={pageProps.initialSession}>
       <OrderTypeProvider>
         <CartProvider>
-          <Component {...pageProps} />
+          {content}
         </CartProvider>
       </OrderTypeProvider>
     </SessionContextProvider>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -4,7 +4,6 @@
 @tailwind components;
 @tailwind utilities;
 
-@import './brand.css';
 
 body {
   font-family: 'Inter', sans-serif;


### PR DESCRIPTION
## Summary
- Guard branding hook with deterministic fallback brand
- Ensure `/restaurant` routes are wrapped in `BrandProvider`
- Import brand CSS once and remove duplicate include

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b55fc587c8325b41a6841a86ff708