### PR TITLE
feat: add collapsing header for restaurant home

### DIFF
--- a/__tests__/Branding.test.tsx
+++ b/__tests__/Branding.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, act } from '@testing-library/react';
 import CustomerLayout from '../components/CustomerLayout';
 import Hero from '../components/customer/Hero';
+import Slides from '../components/customer/Slides';
 import OpenBadge from '../components/customer/OpenBadge';
 import BrandProvider from '../components/branding/BrandProvider';
 
@@ -43,8 +44,10 @@ test('footer hidden on hero and appears after scroll', () => {
   function Wrapper() {
     const [visible, setVisible] = React.useState(true);
     return (
-      <CustomerLayout restaurant={restaurant} hideFooter={visible} hideHeader={visible}>
-        <Hero restaurant={restaurant} onVisibilityChange={setVisible} />
+      <CustomerLayout restaurant={restaurant} hideFooter={visible} hideHeader>
+        <Slides onHeroInView={setVisible}>
+          <Hero restaurant={restaurant} />
+        </Slides>
       </CustomerLayout>
     );
   }

--- a/components/CustomerLayout.tsx
+++ b/components/CustomerLayout.tsx
@@ -41,7 +41,7 @@ export default function CustomerLayout({
         {children}
       </main>
 
-      <FooterNav cartCount={cartCount} hidden={hideFooter} />
+      {!hideFooter ? <FooterNav cartCount={cartCount} /> : <div style={{ height: 72 }} />} {/* slides: footer hides on hero */}
     </BrandProvider>
   );
 }

--- a/components/customer/CollapsingHeader.tsx
+++ b/components/customer/CollapsingHeader.tsx
@@ -1,0 +1,47 @@
+// slides: header
+import React from 'react';
+import Logo from '@/components/branding/Logo';
+import { useBrand } from '@/components/branding/BrandProvider';
+
+export default function CollapsingHeader({ compact }: { compact: boolean }) {
+  const { name } = useBrand();
+  return (
+    <div
+      aria-label="Brand header"
+      style={{
+        position: 'sticky',
+        top: 0,
+        zIndex: 30,
+        height: 64,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '8px 16px',
+        backdropFilter: 'saturate(180%) blur(8px)',
+        background: compact ? 'color-mix(in oklab, var(--brand) 18%, white)' : 'transparent',
+        boxShadow: compact ? '0 2px 12px rgba(0,0,0,0.08)' : 'none',
+        transition: 'background 220ms ease, box-shadow 220ms ease',
+      }}
+    >
+      <div
+        style={{
+          transform: compact ? 'translateX(0) scale(1)' : 'translateX(calc(50vw - 36px)) scale(1.7)',
+          transformOrigin: 'left center',
+          transition: 'transform 320ms cubic-bezier(.2,.7,.2,1)',
+        }}
+      >
+        <Logo size={32} />
+      </div>
+      <div
+        style={{
+          opacity: compact ? 1 : 0,
+          transform: compact ? 'translateY(0px)' : 'translateY(6px)',
+          transition: 'opacity 220ms ease, transform 220ms ease',
+          fontWeight: 700,
+        }}
+      >
+        {name}
+      </div>
+    </div>
+  );
+}

--- a/components/customer/Slides.tsx
+++ b/components/customer/Slides.tsx
@@ -1,13 +1,48 @@
-import React from 'react';
+// slides: restored
+import React, { useEffect, useRef } from 'react';
 
-export default function Slides({ children }: { children: React.ReactNode }) {
+export default function Slides({
+  children,
+  onHeroInView,
+}: {
+  children: React.ReactNode;
+  onHeroInView?: (v: boolean) => void;
+}) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const heroRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!onHeroInView || !heroRef.current) return;
+    const obs = new IntersectionObserver(
+      ([entry]) => onHeroInView(entry.isIntersecting),
+      { root: rootRef.current, threshold: 0.66 }
+    );
+    obs.observe(heroRef.current);
+    return () => obs.disconnect();
+  }, [onHeroInView]);
+
   return (
-    <div className="h-screen overflow-y-auto snap-y snap-mandatory">
-      {React.Children.map(children, (child, idx) => (
-        <div key={idx} className="h-screen snap-start">
-          {child}
-        </div>
-      ))}
+    <div
+      ref={rootRef}
+      style={{
+        height: '100vh',
+        overflowY: 'auto',
+        scrollSnapType: 'y mandatory',
+        WebkitOverflowScrolling: 'touch',
+      }}
+    >
+      {/* Hero sentinel: the first child should be wrapped so we can observe it */}
+      <div ref={heroRef} style={{ height: '100vh', scrollSnapAlign: 'start' }}>
+        {Array.isArray(children) ? children[0] : children}
+      </div>
+      {/* Remaining slides */}
+      {Array.isArray(children)
+        ? children.slice(1).map((c, i) => (
+            <div key={i} style={{ height: '100vh', scrollSnapAlign: 'start' }}>
+              {c}
+            </div>
+          ))
+        : null}
     </div>
   );
 }

--- a/pages/restaurant/index.tsx
+++ b/pages/restaurant/index.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import CustomerLayout from '../../components/CustomerLayout';
 import Hero from '../../components/customer/Hero';
 import Slides from '../../components/customer/Slides'; // slides: restored
+import CollapsingHeader from '../../components/customer/CollapsingHeader';
 import { supabase } from '../../utils/supabaseClient';
 import { useCart } from '../../context/CartContext';
 
@@ -11,7 +12,7 @@ export default function RestaurantHomePage() {
   const { restaurant_id } = router.query;
   const restaurantId = Array.isArray(restaurant_id) ? restaurant_id[0] : restaurant_id;
   const [restaurant, setRestaurant] = useState<any | null>(null);
-  const [heroVisible, setHeroVisible] = useState(true);
+  const [heroInView, setHeroInView] = useState(true);
   const { cart } = useCart();
   const cartCount = cart.items.reduce((sum, it) => sum + it.quantity, 0);
 
@@ -29,23 +30,32 @@ export default function RestaurantHomePage() {
     <CustomerLayout
       restaurant={restaurant}
       cartCount={cartCount}
-      hideFooter={heroVisible}
+      hideFooter={heroInView}
       hideHeader
     >
       {restaurant && (
-        <Slides>
-          <Hero restaurant={restaurant} onVisibilityChange={setHeroVisible} />
-          <section className="flex items-center justify-center h-full w-full" style={{ background: 'var(--surface)', color: 'var(--ink)' }}>
-            <div className="text-center">
-              <p>Menu preview coming soon.</p>
-            </div>
-          </section>
-          <section className="flex items-center justify-center h-full w-full" style={{ background: 'var(--surface)', color: 'var(--ink)' }}>
-            <div className="text-center">
-              <p>Gallery placeholder.</p>
-            </div>
-          </section>
-        </Slides>
+        <>
+          <CollapsingHeader compact={!heroInView} />
+          <Slides onHeroInView={setHeroInView}>
+            <Hero restaurant={restaurant} />
+            <section
+              className="flex items-center justify-center h-full w-full"
+              style={{ background: 'var(--surface)', color: 'var(--ink)' }}
+            >
+              <div className="text-center">
+                <p>Menu preview coming soon.</p>
+              </div>
+            </section>
+            <section
+              className="flex items-center justify-center h-full w-full"
+              style={{ background: 'var(--surface)', color: 'var(--ink)' }}
+            >
+              <div className="text-center">
+                <p>Gallery placeholder.</p>
+              </div>
+            </section>
+          </Slides>
+        </>
       )}
     </CustomerLayout>
   );


### PR DESCRIPTION
## Summary
- add vertically snapping Slides wrapper with hero visibility tracking
- introduce CollapsingHeader that shrinks logo and reveals brand after scrolling
- hide customer footer nav while hero is visible

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_689b58cfad6883259b1635b2c1f6e9ad