### PR TITLE
Animate single logo into collapsing header on home

### DIFF
--- a/components/CustomerLayout.tsx
+++ b/components/CustomerLayout.tsx
@@ -41,7 +41,7 @@ export default function CustomerLayout({
         {children}
       </main>
 
-      {!hideFooter ? <FooterNav cartCount={cartCount} /> : <div style={{ height: 72 }} />} {/* slides: footer hides on hero */}
+      {!hideFooter ? <FooterNav cartCount={cartCount} /> : null} {/* slides: footer hides on hero */}
     </BrandProvider>
   );
 }

--- a/components/customer/CollapsingHeader.tsx
+++ b/components/customer/CollapsingHeader.tsx
@@ -1,47 +1,62 @@
-// slides: header
+// slides: header (single shared logo that moves from hero center to slim header)
 import React from 'react';
 import Logo from '@/components/branding/Logo';
 import { useBrand } from '@/components/branding/BrandProvider';
 
-export default function CollapsingHeader({ compact }: { compact: boolean }) {
+export default function CollapsingHeader({ heroInView }: { heroInView: boolean }) {
   const { name } = useBrand();
+
+  // Header shell only shows AFTER hero; while hero is visible, the shell is transparent/invisible.
+  // The Logo element is ONE node that we position/transform between center-of-hero and top-left header.
   return (
-    <div
-      aria-label="Brand header"
-      style={{
-        position: 'sticky',
-        top: 0,
-        zIndex: 30,
-        height: 64,
-        display: 'flex',
-        alignItems: 'center',
-        gap: 12,
-        padding: '8px 16px',
-        backdropFilter: 'saturate(180%) blur(8px)',
-        background: compact ? 'color-mix(in oklab, var(--brand) 18%, white)' : 'transparent',
-        boxShadow: compact ? '0 2px 12px rgba(0,0,0,0.08)' : 'none',
-        transition: 'background 220ms ease, box-shadow 220ms ease',
-      }}
-    >
+    <>
+      {/* Slim header shell (becomes visible only after hero) */}
+      <div
+        aria-label="Brand header"
+        style={{
+          position: 'sticky',
+          top: 0,
+          zIndex: 20,
+          height: 56,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          padding: '8px 16px',
+          backdropFilter: heroInView ? 'none' : 'saturate(180%) blur(8px)',
+          background: heroInView ? 'transparent' : 'color-mix(in oklab, var(--brand) 18%, white)',
+          boxShadow: heroInView ? 'none' : '0 2px 12px rgba(0,0,0,0.08)',
+          transition: 'background 220ms ease, box-shadow 220ms ease',
+        }}
+      >
+        {/* Title fades in only after hero */}
+        <div
+          style={{
+            opacity: heroInView ? 0 : 1,
+            transform: heroInView ? 'translateY(6px)' : 'translateY(0)',
+            transition: 'opacity 220ms ease, transform 220ms ease',
+            fontWeight: 700,
+          }}
+        >
+          {name}
+        </div>
+      </div>
+
+      {/* SINGLE shared logo element — visually centered on hero, then animates to header-left */}
       <div
         style={{
-          transform: compact ? 'translateX(0) scale(1)' : 'translateX(calc(50vw - 36px)) scale(1.7)',
+          position: 'fixed',
+          zIndex: 30,
+          // Center over hero vs. dock to header
+          top: heroInView ? '50vh' : 12,
+          left: heroInView ? '50vw' : 16,
+          transform: heroInView ? 'translate(-50%, -50%) scale(1.6)' : 'translate(0,0) scale(1)',
           transformOrigin: 'left center',
-          transition: 'transform 320ms cubic-bezier(.2,.7,.2,1)',
+          transition: 'top 300ms cubic-bezier(.2,.7,.2,1), left 300ms cubic-bezier(.2,.7,.2,1), transform 300ms cubic-bezier(.2,.7,.2,1)',
+          pointerEvents: 'none',
         }}
       >
-        <Logo size={32} />
+        <Logo size={heroInView ? 48 : 32} />
       </div>
-      <div
-        style={{
-          opacity: compact ? 1 : 0,
-          transform: compact ? 'translateY(0px)' : 'translateY(6px)',
-          transition: 'opacity 220ms ease, transform 220ms ease',
-          fontWeight: 700,
-        }}
-      >
-        {name}
-      </div>
-    </div>
+    </>
   );
 }

--- a/components/customer/Hero.tsx
+++ b/components/customer/Hero.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link';
 import React, { useEffect, useRef } from 'react';
 import { useRouter } from 'next/router';
 import OpenBadge from './OpenBadge';
-import Logo from '../branding/Logo';
 
 interface Props {
   restaurant: any;
@@ -33,7 +32,7 @@ export default function Hero({ restaurant, onVisibilityChange }: Props) {
       <Image src={bg} alt="hero" fill className="object-cover" />
       <div className="absolute inset-0 bg-gradient-to-b from-black/40 to-black/70" />
       <div className="relative z-10 flex flex-col items-center gap-4 px-4">
-        <Logo size={80} />
+        {/* slides: hero — logo provided by CollapsingHeader (single element) */}
         <h1 className="text-4xl font-light">{restaurant?.name}</h1>
         {restaurant?.website_description && (
           <p className="max-w-md text-white/90">{restaurant.website_description}</p>

--- a/components/customer/Slides.tsx
+++ b/components/customer/Slides.tsx
@@ -15,7 +15,7 @@ export default function Slides({
     if (!onHeroInView || !heroRef.current) return;
     const obs = new IntersectionObserver(
       ([entry]) => onHeroInView(entry.isIntersecting),
-      { root: rootRef.current, threshold: 0.66 }
+      { root: rootRef.current ?? undefined, threshold: 0.9 }
     );
     obs.observe(heroRef.current);
     return () => obs.disconnect();

--- a/pages/restaurant/index.tsx
+++ b/pages/restaurant/index.tsx
@@ -35,7 +35,8 @@ export default function RestaurantHomePage() {
     >
       {restaurant && (
         <>
-          <CollapsingHeader compact={!heroInView} />
+          {/* slides: header hidden on hero; same logo animates into header */}
+          <CollapsingHeader heroInView={heroInView} />
           <Slides onHeroInView={setHeroInView}>
             <Hero restaurant={restaurant} />
             <section


### PR DESCRIPTION
## Summary
- Replace collapsing header with single logo that transitions from hero center into slim sticky header
- Tighten hero visibility detection and wire home page/footer to use heroInView
- Remove duplicate logo from hero and hide footer when hero is visible

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_689b5ec78a0883258df23b82bde9abf9