### PR TITLE
feat: improve hero header transition

### DIFF
--- a/components/CustomerLayout.tsx
+++ b/components/CustomerLayout.tsx
@@ -35,7 +35,7 @@ export default function CustomerLayout({
       <TopBar hidden={hideHeader} />
 
       <main
-        className={`min-h-screen pb-24 ${hideHeader ? '' : 'pt-14'}`}
+        className={`min-h-screen ${hideFooter ? '' : 'pb-24'} ${hideHeader ? '' : 'pt-14'}`}
         style={{ background: 'var(--surface)', color: 'var(--ink)' }}
       >
         {children}

--- a/components/customer/CollapsingHeader.tsx
+++ b/components/customer/CollapsingHeader.tsx
@@ -5,35 +5,35 @@ import { useBrand } from '@/components/branding/BrandProvider';
 
 export default function CollapsingHeader({ heroInView }: { heroInView: boolean }) {
   const { name } = useBrand();
+  const headerVisible = !heroInView;
 
-  // Header shell only shows AFTER hero; while hero is visible, the shell is transparent/invisible.
-  // The Logo element is ONE node that we position/transform between center-of-hero and top-left header.
   return (
     <>
-      {/* Slim header shell (becomes visible only after hero) */}
+      {/* Slim header shell — height 0 on hero (no white bar) */}
       <div
         aria-label="Brand header"
         style={{
           position: 'sticky',
           top: 0,
           zIndex: 20,
-          height: 56,
+          height: headerVisible ? 56 : 0,
+          overflow: 'hidden',
           display: 'flex',
           alignItems: 'center',
           gap: 12,
-          padding: '8px 16px',
-          backdropFilter: heroInView ? 'none' : 'saturate(180%) blur(8px)',
-          background: heroInView ? 'transparent' : 'color-mix(in oklab, var(--brand) 18%, white)',
-          boxShadow: heroInView ? 'none' : '0 2px 12px rgba(0,0,0,0.08)',
-          transition: 'background 220ms ease, box-shadow 220ms ease',
+          padding: headerVisible ? '8px 16px' : '0px 16px',
+          background: headerVisible ? 'color-mix(in oklab, var(--brand) 18%, white)' : 'transparent',
+          backdropFilter: headerVisible ? 'saturate(180%) blur(8px)' : 'none',
+          boxShadow: headerVisible ? '0 2px 12px rgba(0,0,0,0.08)' : 'none',
+          transition:
+            'height 240ms ease, background 220ms ease, box-shadow 220ms ease, padding 200ms ease',
         }}
       >
-        {/* Title fades in only after hero */}
         <div
           style={{
-            opacity: heroInView ? 0 : 1,
-            transform: heroInView ? 'translateY(6px)' : 'translateY(0)',
-            transition: 'opacity 220ms ease, transform 220ms ease',
+            opacity: headerVisible ? 1 : 0,
+            transform: headerVisible ? 'translateY(0)' : 'translateY(6px)',
+            transition: 'opacity 200ms ease, transform 200ms ease',
             fontWeight: 700,
           }}
         >
@@ -41,21 +41,23 @@ export default function CollapsingHeader({ heroInView }: { heroInView: boolean }
         </div>
       </div>
 
-      {/* SINGLE shared logo element — visually centered on hero, then animates to header-left */}
+      {/* SINGLE shared logo: centered on hero at ~34vh; docks to header-left after scroll */}
       <div
         style={{
           position: 'fixed',
           zIndex: 30,
-          // Center over hero vs. dock to header
-          top: heroInView ? '50vh' : 12,
+          top: heroInView ? 'var(--hero-logo-top, 34vh)' : 12,
           left: heroInView ? '50vw' : 16,
-          transform: heroInView ? 'translate(-50%, -50%) scale(1.6)' : 'translate(0,0) scale(1)',
+          transform: heroInView
+            ? 'translate(-50%, -50%) scale(1.6)'
+            : 'translate(0,0) scale(1)',
           transformOrigin: 'left center',
-          transition: 'top 300ms cubic-bezier(.2,.7,.2,1), left 300ms cubic-bezier(.2,.7,.2,1), transform 300ms cubic-bezier(.2,.7,.2,1)',
+          transition:
+            'top 320ms cubic-bezier(.2,.7,.2,1), left 320ms cubic-bezier(.2,.7,.2,1), transform 320ms cubic-bezier(.2,.7,.2,1)',
           pointerEvents: 'none',
         }}
       >
-        <Logo size={heroInView ? 48 : 32} />
+        <Logo size={heroInView ? 56 : 32} />
       </div>
     </>
   );

--- a/components/customer/Hero.tsx
+++ b/components/customer/Hero.tsx
@@ -28,10 +28,13 @@ export default function Hero({ restaurant, onVisibilityChange }: Props) {
   if (restaurant?.id) params.set('restaurant_id', restaurant.id);
   const orderHref = `/restaurant/menu?${params.toString()}`;
   return (
-    <section ref={ref} className="relative h-full w-full flex items-center justify-center text-center text-white">
+    <section ref={ref} className="relative h-full w-full text-center text-white">
       <Image src={bg} alt="hero" fill className="object-cover" />
       <div className="absolute inset-0 bg-gradient-to-b from-black/40 to-black/70" />
-      <div className="relative z-10 flex flex-col items-center gap-4 px-4">
+      <div
+        className="relative z-10 flex flex-col items-center gap-4 px-4"
+        style={{ paddingTop: 'calc(var(--hero-logo-top, 34vh) + 48px)' }}
+      >
         {/* slides: hero — logo provided by CollapsingHeader (single element) */}
         <h1 className="text-4xl font-light">{restaurant?.name}</h1>
         {restaurant?.website_description && (

--- a/components/customer/Slides.tsx
+++ b/components/customer/Slides.tsx
@@ -15,7 +15,7 @@ export default function Slides({
     if (!onHeroInView || !heroRef.current) return;
     const obs = new IntersectionObserver(
       ([entry]) => onHeroInView(entry.isIntersecting),
-      { root: rootRef.current ?? undefined, threshold: 0.9 }
+      { root: rootRef.current ?? undefined, threshold: 0.98 }
     );
     obs.observe(heroRef.current);
     return () => obs.disconnect();


### PR DESCRIPTION
## Summary
- hide brand header while hero is visible and animate single logo between hero and slim header
- delay header reveal until hero nearly scrolled away
- space hero content below floating logo and remove footer spacer when hidden

## Testing
- `npm run test:ci >/tmp/unit.log 2>&1 && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_689b6209ecb8832585d2d0a3f7545d16