### PR TITLE
feat: morph hero into header on scroll

### DIFF
--- a/components/customer/Slides.tsx
+++ b/components/customer/Slides.tsx
@@ -4,9 +4,11 @@ import React, { useEffect, useRef } from 'react';
 export default function Slides({
   children,
   onHeroInView,
+  onProgress,
 }: {
   children: React.ReactNode;
   onHeroInView?: (v: boolean) => void;
+  onProgress?: (p: number) => void; // 0..1 based on first slide scroll
 }) {
   const rootRef = useRef<HTMLDivElement>(null);
   const heroRef = useRef<HTMLDivElement>(null);
@@ -15,11 +17,25 @@ export default function Slides({
     if (!onHeroInView || !heroRef.current) return;
     const obs = new IntersectionObserver(
       ([entry]) => onHeroInView(entry.isIntersecting),
-      { root: rootRef.current ?? undefined, threshold: 0.98 }
+      { root: rootRef.current ?? undefined, threshold: 0.95 }
     );
     obs.observe(heroRef.current);
     return () => obs.disconnect();
   }, [onHeroInView]);
+
+  // progress: 0 at top of hero, 1 at exactly one viewport scrolled
+  useEffect(() => {
+    if (!onProgress || !rootRef.current) return;
+    const el = rootRef.current;
+    const handler = () => {
+      const h = el.clientHeight || 1;
+      const p = Math.max(0, Math.min(1, el.scrollTop / h));
+      onProgress(p);
+    };
+    handler();
+    el.addEventListener('scroll', handler, { passive: true });
+    return () => el.removeEventListener('scroll', handler);
+  }, [onProgress]);
 
   return (
     <div


### PR DESCRIPTION
## Summary
- report scroll progress from `Slides` component
- morph restaurant hero into sticky header and moving logo as you scroll

## Testing
- `npm run test:ci`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689b7ecefebc8325b1d5c97bd17342ad