### PR TITLE
feat: enlarge hero logo and adjust spacing

### DIFF
--- a/pages/restaurant/index.tsx
+++ b/pages/restaurant/index.tsx
@@ -16,6 +16,8 @@ export default function RestaurantHomePage() {
   const [progress, setProgress] = useState(0); // 0..1 scroll over hero
   const { name } = useBrand();
   const [viewport, setViewport] = useState({ w: 0, h: 0 });
+  // clamp once for cleaner math
+  const pc = Math.min(1, Math.max(0, progress));
   const { cart } = useCart();
   const cartCount = cart.items.reduce((sum, it) => sum + it.quantity, 0);
 
@@ -40,12 +42,12 @@ export default function RestaurantHomePage() {
   const headerHeight = 56 * progress;
   const headerPadding = 8 * progress;
   const brandBg = progress === 0 ? 'transparent' : 'color-mix(in oklab, var(--brand) 18%, white)';
-  const logoTopStart = viewport.h * 0.34;
+  const logoTopStart = viewport.h * 0.4;
   const logoLeftStart = viewport.w * 0.5;
-  const logoTop = logoTopStart + (12 - logoTopStart) * progress;
-  const logoLeft = logoLeftStart + (16 - logoLeftStart) * progress;
-  const translate = -50 * (1 - progress);
-  const logoScale = 1.6 - 0.6 * progress;
+  const logoTop = logoTopStart + (12 - logoTopStart) * pc;
+  const logoLeft = logoLeftStart + (16 - logoLeftStart) * pc;
+  const translate = -50 * (1 - pc);
+  const logoScale = 1 + 2 * (1 - pc);
 
   return (
     <CustomerLayout
@@ -90,18 +92,23 @@ export default function RestaurantHomePage() {
             style={{
               position: 'fixed',
               zIndex: 30,
+              /* Start a bit lower and bigger (≈96px from 32px base), then dock to (12px,16px). */
               top: `${logoTop}px`,
               left: `${logoLeft}px`,
               transform: `translate(${translate}%, ${translate}%) scale(${logoScale})`,
               transformOrigin: 'left center',
+              transition: 'top 200ms cubic-bezier(.2,.7,.2,1), left 200ms cubic-bezier(.2,.7,.2,1), transform 200ms cubic-bezier(.2,.7,.2,1)',
               pointerEvents: 'none',
             }}
           >
+            {/* Final docked size is 32; at hero we scale up to approx 96 via transform */}
             <Logo size={32} />
           </div>
 
           <Slides onProgress={setProgress}>
-            <Hero restaurant={restaurant} />
+            <div style={{ '--hero-logo-top': '40vh' } as React.CSSProperties}>
+              <Hero restaurant={restaurant} />
+            </div>
             <section
               className="flex items-center justify-center h-full w-full"
               style={{ background: 'var(--surface)', color: 'var(--ink)' }}


### PR DESCRIPTION
## Summary
- scale the home hero logo larger and center it before docking
- clamp scroll progress for cleaner math
- reserve extra space beneath the hero logo for the title

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_689b831b6678832586a5397c82a7317a