### PR TITLE
feat: add debug flag to restaurant home

### DIFF
--- a/components/dev/DebugFlag.tsx
+++ b/components/dev/DebugFlag.tsx
@@ -1,0 +1,33 @@
+// dev: debug flag (auto-hides after 3s)
+import React, { useEffect, useState } from 'react';
+
+export default function DebugFlag({ label }: { label: string }) {
+  const [show, setShow] = useState(true);
+
+  useEffect(() => {
+    const t = setTimeout(() => setShow(false), 3000);
+    return () => clearTimeout(t);
+  }, []);
+
+  if (!show) return null;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 8,
+        left: 8,
+        zIndex: 9999,
+        background: 'rgba(220, 38, 38, 0.95)',
+        color: '#fff',
+        fontSize: 12,
+        fontWeight: 700,
+        padding: '4px 6px',
+        borderRadius: 6,
+        boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
+      }}
+    >
+      {label}
+    </div>
+  );
+}

--- a/pages/restaurant/index.tsx
+++ b/pages/restaurant/index.tsx
@@ -5,6 +5,7 @@ import Hero from '@/components/customer/Hero';
 import Slides from '@/components/customer/Slides';
 import Logo from '@/components/branding/Logo';
 import { useBrand } from '@/components/branding/BrandProvider';
+import DebugFlag from '@/components/dev/DebugFlag';
 import { supabase } from '@/utils/supabaseClient';
 import { useCart } from '@/context/CartContext';
 
@@ -19,6 +20,12 @@ export default function RestaurantHomePage() {
   const pc = Math.min(1, Math.max(0, progress)); // 0..1 scroll progress
   const { cart } = useCart();
   const cartCount = cart.items.reduce((sum, it) => sum + it.quantity, 0);
+
+  useEffect(() => {
+    // dev: prove this file renders in prod
+    // eslint-disable-next-line no-console
+    console.log('[Home] pages/restaurant/index.tsx mounted');
+  }, []);
 
   useEffect(() => {
     if (!router.isReady || !restaurantId) return;
@@ -42,6 +49,7 @@ export default function RestaurantHomePage() {
       hideFooter={heroInView}
       hideHeader
     >
+      <DebugFlag label="HOME-A" />
       {restaurant && (
         <>
           {/* Slim header that grows with scroll progress */}


### PR DESCRIPTION
## Summary
- add reusable DebugFlag component for temporary notices
- log mount and show debug flag on /restaurant home page

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_689b8b84fefc8325aecf7dfb45fdf819