### PR TITLE
Restore restaurant home placeholder slides

### DIFF
--- a/pages/restaurant/index.tsx
+++ b/pages/restaurant/index.tsx
@@ -49,22 +49,11 @@ export default function RestaurantHomePage() {
     >
       <DebugFlag label="HOME-A" />
       <Slides onHeroInView={setHeroInView}>
-        <section
-          style={{
-            height: '100%',
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'center',
-            textAlign: 'center',
-            padding: '0 16px',
-            gap: 12,
-            background: 'linear-gradient(180deg,#7a7a7a 0%,#3a3a3a 100%)',
-          }}
-        >
+        {/* Slide 1 — Hero */}
+        <section className="flex h-full flex-col items-center justify-center gap-3 p-4 text-center bg-gradient-to-b from-neutral-500 to-neutral-800">
           <Logo size={72} />
           <h1 className="text-4xl font-extrabold">{name}</h1>
-          {restaurant?.website_description && <p>{restaurant.website_description}</p>}
+          {restaurant?.website_description && <p className="desc">{restaurant.website_description}</p>}
           {typeof restaurant?.is_open === 'boolean' && (
             <OpenBadge isOpen={restaurant.is_open} />
           )}
@@ -72,10 +61,30 @@ export default function RestaurantHomePage() {
             Order Now
           </Link>
         </section>
-        <section
-          style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
-        >
-          Menu preview coming soon.
+
+        {/* Slide 2 — Opening hours & address */}
+        <section className="flex h-full flex-col items-center justify-center gap-3 p-4 text-center">
+          <h2 className="text-xl font-bold">Opening Hours & Address</h2>
+          <p>Opening hours will be displayed here.</p>
+          <p>Address details will be displayed here.</p>
+        </section>
+
+        {/* Slide 3 — Menu preview */}
+        <section className="flex h-full flex-col items-center justify-center gap-3 p-4 text-center">
+          <h2 className="text-xl font-bold">Menu Preview</h2>
+          <p>Menu preview coming soon.</p>
+        </section>
+
+        {/* Slide 4 — Gallery */}
+        <section className="flex h-full flex-col items-center justify-center gap-3 p-4 text-center">
+          <h2 className="text-xl font-bold">Gallery</h2>
+          <p>Photos will be displayed here.</p>
+        </section>
+
+        {/* Slide 5 — Contact info */}
+        <section className="flex h-full flex-col items-center justify-center gap-3 p-4 text-center">
+          <h2 className="text-xl font-bold">Contact Us</h2>
+          <p>Phone, email, and contact form will be displayed here.</p>
         </section>
       </Slides>
     </CustomerLayout>


### PR DESCRIPTION
## Summary
- Restore hero slide on /restaurant home with shared button styles
- Add placeholder slides for opening hours, menu preview, gallery, and contact info

## Testing
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689b914585b883259a0664d023f429a6