### PR TITLE
feat: restore home logo and header animation

### DIFF
--- a/components/customer/Slides.tsx
+++ b/components/customer/Slides.tsx
@@ -8,7 +8,7 @@ export default function Slides({
 }: {
   children: React.ReactNode;
   onHeroInView?: (v: boolean) => void;
-  onProgress?: (p: number) => void; // 0..1 based on first slide scroll
+  onProgress?: (p: number) => void; // 0..1
 }) {
   const rootRef = useRef<HTMLDivElement>(null);
   const heroRef = useRef<HTMLDivElement>(null);
@@ -23,18 +23,13 @@ export default function Slides({
     return () => obs.disconnect();
   }, [onHeroInView]);
 
-  // progress: 0 at top of hero, 1 at exactly one viewport scrolled
   useEffect(() => {
     if (!onProgress || !rootRef.current) return;
     const el = rootRef.current;
-    const handler = () => {
-      const h = el.clientHeight || 1;
-      const p = Math.max(0, Math.min(1, el.scrollTop / h));
-      onProgress(p);
-    };
-    handler();
-    el.addEventListener('scroll', handler, { passive: true });
-    return () => el.removeEventListener('scroll', handler);
+    const h = () => onProgress(Math.max(0, Math.min(1, el.scrollTop / (el.clientHeight || 1))));
+    h();
+    el.addEventListener('scroll', h, { passive: true });
+    return () => el.removeEventListener('scroll', h);
   }, [onProgress]);
 
   return (

--- a/pages/restaurant/index.tsx
+++ b/pages/restaurant/index.tsx
@@ -4,6 +4,8 @@ import CustomerLayout from '@/components/CustomerLayout';
 import Slides from '@/components/customer/Slides';
 import Hero from '@/components/customer/Hero';
 import DebugFlag from '@/components/dev/DebugFlag';
+import Logo from '@/components/branding/Logo';
+import { useBrand } from '@/components/branding/BrandProvider';
 import { supabase } from '@/utils/supabaseClient';
 import { useCart } from '@/context/CartContext';
 
@@ -15,6 +17,8 @@ export default function RestaurantHomePage() {
   const { cart } = useCart();
   const cartCount = cart.items.reduce((sum, it) => sum + it.quantity, 0);
   const [heroInView, setHeroInView] = useState(true);
+  const [p, setP] = useState(0); // 0..1
+  const { name } = useBrand();
 
   useEffect(() => {
     // dev: prove this file renders in prod
@@ -40,7 +44,42 @@ export default function RestaurantHomePage() {
       hideHeader
     >
       <DebugFlag label="HOME-A" />
-      <Slides onHeroInView={setHeroInView}>
+      {/* Floating logo + slim header (appear after scroll) */}
+      <div
+        style={{
+          position: 'sticky',
+          top: 0,
+          zIndex: 20,
+          height: `${56 * Math.max(0, Math.min(1, (p - 0.9) / 0.1))}px`,
+          overflow: 'hidden',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          padding: p > 0.9 ? '8px 16px' : '0 16px',
+          background: p > 0.9 ? 'color-mix(in oklab, var(--brand) 18%, white)' : 'transparent',
+          backdropFilter: p > 0.9 ? 'saturate(180%) blur(8px)' : 'none',
+          boxShadow: p > 0.9 ? '0 2px 12px rgba(0,0,0,0.08)' : 'none',
+          transition: 'height 180ms ease, background 160ms ease, box-shadow 160ms ease, padding 160ms ease',
+        }}
+      >
+        <div style={{ opacity: p > 0.92 ? 1 : 0, transition: 'opacity 160ms ease', fontWeight: 700 }}>{name}</div>
+      </div>
+      <div
+        style={{
+          position: 'fixed',
+          zIndex: 30,
+          top: `calc(12px + (34vh - 12px) * ${1 - p})`,
+          left: `calc(16px + (50vw - 16px) * ${1 - p})`,
+          transform: `translate(${(-50) * (1 - p)}%, ${(-50) * (1 - p)}%) scale(${1 + 1.25 * (1 - p)})`,
+          transformOrigin: 'left center',
+          transition: 'top 180ms cubic-bezier(.2,.7,.2,1), left 180ms cubic-bezier(.2,.7,.2,1), transform 180ms cubic-bezier(.2,.7,.2,1)',
+          pointerEvents: 'none',
+        }}
+      >
+        <Logo size={32} />
+      </div>
+
+      <Slides onHeroInView={setHeroInView} onProgress={setP}>
         <Hero restaurant={restaurant} />
 
         {/* Slide 2 — Opening Hours & Address */}


### PR DESCRIPTION
## Summary
- teach Slides to report scroll progress
- animate floating logo into slim header after hero scroll on restaurant home

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_689c5d44c2388325ac41a0007e350322