### PR TITLE
feat: centralize brand theming with provider

### DIFF
--- a/components/CustomerLayout.tsx
+++ b/components/CustomerLayout.tsx
@@ -1,6 +1,5 @@
 import Head from 'next/head';
 import { ReactNode } from 'react';
-import BrandProvider from './branding/BrandProvider'; // brand: provider mount
 import TopBar from './customer/TopBar';
 import FooterNav from './customer/FooterNav';
 
@@ -22,7 +21,7 @@ export default function CustomerLayout({
   hideFooter,
 }: CustomerLayoutProps) {
   return (
-    <BrandProvider restaurant={restaurant}> {/* brand: provider mount */}
+    <>
       {includePwaMeta && (
         <Head>
           <title>OrderFast – Restaurant</title>
@@ -42,6 +41,6 @@ export default function CustomerLayout({
       </main>
 
       {!hideFooter ? <FooterNav cartCount={cartCount} /> : null} {/* slides: footer hides on hero */}
-    </BrandProvider>
+    </>
   );
 }

--- a/components/branding/BrandProvider.tsx
+++ b/components/branding/BrandProvider.tsx
@@ -3,74 +3,45 @@ import React, { createContext, useContext, useMemo } from 'react';
 import { useRouter } from 'next/router';
 
 type BrandCtx = {
-  brand: string; // e.g. hsl(330 90% 50%)
-  brand600: string;
-  brand700: string;
-  name: string;
-  initials: string;
-  logoUrl?: string | null;
+  brand: string; brand600: string; brand700: string;
+  name: string; initials: string; logoUrl?: string | null;
 };
-const BrandContext = createContext<BrandCtx | null>(null);
+const Ctx = createContext<BrandCtx | null>(null);
 
-function deriveHslFromName(name: string) {
-  let h = 0;
-  for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) >>> 0;
+const hashHSL = (name: string) => {
+  let h = 0; for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) >>> 0;
   const hue = h % 360, s = 86, l = 52;
   return {
     brand: `hsl(${hue} ${s}% ${l}%)`,
     brand600: `hsl(${hue} ${s}% ${Math.max(38, l - 14)}%)`,
     brand700: `hsl(${hue} ${s}% ${Math.max(30, l - 22)}%)`,
   };
-}
-
-export const defaultBrand = (name = 'Restaurant'): BrandCtx => {
-  const { brand, brand600, brand700 } = deriveHslFromName(name);
-  const initials = (name || 'R').split(' ').map(p => p[0]).join('').slice(0, 2).toUpperCase();
-  return { brand, brand600, brand700, name, initials, logoUrl: null };
 };
 
 export const useBrand = (): BrandCtx => {
-  // SSR-safe: if no provider, return a deterministic default.
-  return useContext(BrandContext) ?? defaultBrand();
+  // SSR-safe default if provider is missing
+  return React.useContext(Ctx) ?? { ...hashHSL('Restaurant'), name: 'Restaurant', initials: 'R', logoUrl: null };
 };
-
-// kept for BrandProvider internals
-function hsl(str: string) {
-  return deriveHslFromName(str);
-}
 
 export const BrandProvider: React.FC<{ restaurant?: any; children: React.ReactNode; }> = ({ restaurant, children }) => {
   const router = useRouter();
   const qp = (k: string) => (router?.query?.[k] as string) || '';
-
   const name = (restaurant?.name as string) || qp('name') || 'Restaurant';
   const logoUrl = (restaurant?.logo_url as string) || qp('logo') || null;
-  const colorFromDb = (restaurant?.brand_color as string) || qp('brand') || '';
+  const color = (restaurant?.brand_color as string) || qp('brand') || '';
+  const colors = color ? { brand: color, brand600: color, brand700: color } : hashHSL(name);
+  const initials = name.split(' ').map(p => p[0]).join('').slice(0, 2).toUpperCase() || 'R';
 
-  const { brand, brand600, brand700 } = colorFromDb
-    ? { brand: colorFromDb, brand600: colorFromDb, brand700: colorFromDb }
-    : hsl(name);
-
-  const initials = (name || 'R')
-    .split(' ')
-    .map(p => p[0])
-    .join('')
-    .slice(0, 2)
-    .toUpperCase();
-
-  const value = useMemo(() => ({ brand, brand600, brand700, name, initials, logoUrl }), [brand, brand600, brand700, name, initials, logoUrl]);
+  const value = useMemo(() => ({ ...colors, name, initials, logoUrl }), [colors.brand, colors.brand600, colors.brand700, name, initials, logoUrl]);
 
   return (
-    <BrandContext.Provider value={value}>
+    <Ctx.Provider value={value}>
       <div
         data-brand-root
         style={{
-          // Core design tokens
-          // buttons/badges/FAB/active nav use these
-          // ink/surface/card/muted keep sensible defaults
-          ['--brand' as any]: brand,
-          ['--brand-600' as any]: brand600,
-          ['--brand-700' as any]: brand700,
+          ['--brand' as any]: value.brand,
+          ['--brand-600' as any]: value.brand600,
+          ['--brand-700' as any]: value.brand700,
           ['--ink' as any]: '#111827',
           ['--surface' as any]: '#ffffff',
           ['--card' as any]: '#ffffff',
@@ -79,7 +50,7 @@ export const BrandProvider: React.FC<{ restaurant?: any; children: React.ReactNo
       >
         {children}
       </div>
-    </BrandContext.Provider>
+    </Ctx.Provider>
   );
 };
 


### PR DESCRIPTION
## Summary
- centralize brand color, logo, and initials in an SSR-safe BrandProvider
- mount BrandProvider only for `/restaurant` pages and remove ad-hoc provider from CustomerLayout

## Testing
- `npm run test:ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c8055947083258e85d51b1c1c7670