### PR TITLE
feat: rename cart label to plate

### DIFF
--- a/components/customer/FooterNav.tsx
+++ b/components/customer/FooterNav.tsx
@@ -19,6 +19,9 @@ export default function FooterNav({ cartCount = 0, hidden }: Props) {
 
   const current = (router.asPath || '').split('?')[0];
 
+  // label for the middle action (UI copy only)
+  const cartLabel = 'Plate';
+
   const NavLink = ({ href, Icon, label }: any) => (
     <Link
       href={build(href)}
@@ -43,6 +46,8 @@ export default function FooterNav({ cartCount = 0, hidden }: Props) {
         <div className="absolute -top-6 left-1/2 -translate-x-1/2">
           <Link
             href={build('cart')}
+            aria-label={cartLabel}
+            title={cartLabel}
             className="relative w-14 h-14 rounded-full fab flex items-center justify-center shadow-lg"
           >
             <ShoppingCart className="w-6 h-6" />


### PR DESCRIPTION
## Summary
- update customer footer nav to show "Plate" instead of "Cart"
- add matching aria-label/title for screen readers

## Testing
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689c830f70a88325a1b7a0edb87af698