### PR TITLE
feat: swap cart icon for plate and add empty-state quips

### DIFF
--- a/components/CartDrawer.tsx
+++ b/components/CartDrawer.tsx
@@ -3,6 +3,8 @@ import { useRouter } from 'next/router';
 import { useCart } from '../context/CartContext';
 import { XMarkIcon, ShoppingCartIcon } from '@heroicons/react/24/outline';
 import { Trash2 } from 'lucide-react';
+import PlateIcon from '@/components/icons/PlateIcon';
+import { randomEmptyPlateMessage } from '@/lib/uiCopy';
 
 interface CartDrawerProps {
   /**
@@ -19,7 +21,7 @@ function CartContent({ onClose }: { onClose?: () => void }) {
   return (
     <>
       <div className="p-4 flex justify-between items-center border-b">
-        <h2 className="text-lg font-semibold">Your Cart</h2>
+        <h2 className="text-lg font-semibold">Your Plate</h2>
         {onClose && (
           <button onClick={onClose} aria-label="Close" className="text-gray-500">
             <XMarkIcon className="w-5 h-5" />
@@ -31,7 +33,10 @@ function CartContent({ onClose }: { onClose?: () => void }) {
         style={onClose ? { maxHeight: 'calc(100vh - 9rem)' } : undefined}
       >
         {cart.items.length === 0 ? (
-          <p className="text-center text-gray-500">Your cart is empty.</p>
+          <div className="flex flex-col items-center gap-2 py-6">
+            <PlateIcon size={64} className="text-gray-300" />
+            <p className="text-center text-gray-500">{randomEmptyPlateMessage()}</p>
+          </div>
         ) : (
           cart.items.map((item) => {
             const addonsTotal = (item.addons || []).reduce(

--- a/components/customer/FooterNav.tsx
+++ b/components/customer/FooterNav.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { Home, Utensils, ListOrdered, Menu, ShoppingCart } from 'lucide-react';
+import { Home, Utensils, ListOrdered, Menu } from 'lucide-react';
+import PlateIcon from '@/components/icons/PlateIcon';
 import React from 'react';
 
 interface Props {
@@ -50,7 +51,7 @@ export default function FooterNav({ cartCount = 0, hidden }: Props) {
             title={cartLabel}
             className="relative w-14 h-14 rounded-full fab flex items-center justify-center shadow-lg"
           >
-            <ShoppingCart className="w-6 h-6" />
+            <PlateIcon size={24} />
             {cartCount > 0 && (
               <span className="absolute -top-1 -right-1 bg-red-500 text-white text-[10px] font-bold w-5 h-5 rounded-full flex items-center justify-center">
                 {cartCount}

--- a/components/icons/PlateIcon.tsx
+++ b/components/icons/PlateIcon.tsx
@@ -1,0 +1,10 @@
+export default function PlateIcon({ size=24, className='' }:{size?:number; className?:string}) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 64 64" className={className} fill="none" stroke="currentColor" strokeWidth="4" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="32" cy="32" r="28"/>
+      <circle cx="32" cy="32" r="18"/>
+      <path d="M46 50c-4 3-9 5-14 5"/>
+      <path d="M50 36v4"/>
+    </svg>
+  );
+}

--- a/lib/uiCopy.ts
+++ b/lib/uiCopy.ts
@@ -1,0 +1,15 @@
+export const plateQuips = [
+  "Your plate is empty — let’s fix that.",
+  "Nothing on the plate… yet.",
+  "This plate’s looking a bit hungry.",
+  "Empty plate, full possibilities.",
+  "Let’s put something tasty on that plate.",
+  "Plate status: spotless. Add food!",
+  "Your plate called. It wants snacks.",
+  "So clean you can see your reflection.",
+  "Chef’s waiting. What’s first?",
+  "Add a dish to start your feast."
+];
+export function randomEmptyPlateMessage() {
+  return plateQuips[Math.floor(Math.random() * plateQuips.length)];
+}


### PR DESCRIPTION
## Summary
- add custom PlateIcon component and quippy helper
- update footer FAB and cart drawer to use plate imagery
- show random plate quip when cart is empty

## Testing
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689c8c1ec09c8325851408c13f07def9