### PR TITLE
Polish order details modal with animations and progress

### DIFF
--- a/components/customer/OrderProgress.tsx
+++ b/components/customer/OrderProgress.tsx
@@ -1,22 +1,32 @@
 import React from 'react';
+import '@/styles/orders.css';
 
-const STEPS = ['Created','Accepted','Ready','Completed'] as const;
+const STEPS = [
+  { key: 'created',  label: 'Created',  icon: '🧾' },
+  { key: 'accepted', label: 'Accepted', icon: '✅' },
+  { key: 'ready',    label: 'Ready',    icon: '📦' },
+  { key: 'completed',label: 'Completed',icon: '🏁' },
+] as const;
 
 type Status = 'created'|'accepted'|'ready'|'completed'|'cancelled'|'pending';
 
 export default function OrderProgress({ status }: { status: Status }) {
-  const idx = Math.max(0, STEPS.findIndex(s => s.toLowerCase() === (status === 'pending' ? 'created' : status)));
+  const norm = (status === 'pending' ? 'created' : status) as Status;
+  const idx = Math.max(0, STEPS.findIndex(s => s.key === norm) );
   return (
-    <div className="w-full px-2">
-      <div className="flex items-center justify-between text-xs font-medium">
+    <div className="w-full">
+      <div className="flex items-center gap-2">
         {STEPS.map((s,i)=> (
-          <div key={s} className="flex-1 flex items-center">
-            <div className={`h-2 rounded-full w-full ${i<=idx ? 'bg-[var(--brand)]' : 'bg-gray-200'}`} />
+          <div key={s.key} className="flex-1 flex items-center gap-2">
+            <div className={`h-2 w-full rounded-full ${i<=idx ? 'bg-[var(--brand)]' : 'bg-gray-200'}`} />
+            <div className={`text-xs ${i===idx ? 'text-[var(--brand)] order-step--active' : 'text-gray-400'}`} title={s.label}>
+              {s.icon}
+            </div>
           </div>
         ))}
       </div>
       <div className="mt-2 flex justify-between text-[11px] text-gray-500">
-        {STEPS.map(s => <span key={s}>{s}</span>)}
+        {STEPS.map(s => <span key={s.key}>{s.label}</span>)}
       </div>
     </div>
   );

--- a/styles/orders.css
+++ b/styles/orders.css
@@ -1,0 +1,6 @@
+@keyframes brandPulse { 0%{opacity:.4} 50%{opacity:1} 100%{opacity:.4} }
+.order-step--active { animation: brandPulse 1.2s ease-in-out infinite; }
+.ordersheet-enter { transform: translateY(16px); opacity: 0; }
+.ordersheet-enter-active { transform: translateY(0); opacity: 1; transition: transform 200ms ease, opacity 200ms ease; }
+.ordersheet-exit { transform: translateY(0); opacity: 1; }
+.ordersheet-exit-active { transform: translateY(16px); opacity: 0; transition: transform 180ms ease, opacity 180ms ease; }


### PR DESCRIPTION
## Summary
- add reusable order animations and pulse styles
- show friendly order number & formatted date in order details modal
- upgrade progress tracker with icons and pulsing active step

## Testing
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689c9e6d530c83258a528a9c16e5de62