### PR TITLE
Move order CSS import to global app layer

### DIFF
--- a/components/customer/OrderDetailsModal.tsx
+++ b/components/customer/OrderDetailsModal.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import OrderProgress from '@/components/customer/OrderProgress';
 import { useRouter } from 'next/router';
-import '@/styles/orders.css';
 
 export default function OrderDetailsModal({ order, onClose }: { order: any; onClose: () => void; }) {
   if (!order) return null;

--- a/components/customer/OrderProgress.tsx
+++ b/components/customer/OrderProgress.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import '@/styles/orders.css';
 
 const STEPS = [
   { key: 'created',  label: 'Created',  icon: '🧾' },

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,6 @@
 import '../styles/globals.css';
 import '@/styles/brand.css';
+import '@/styles/orders.css'; // global animations for order sheet & progress
 import type { AppProps } from 'next/app';
 import { useRouter } from 'next/router';
 import { BrandProvider } from '@/components/branding/BrandProvider';


### PR DESCRIPTION
## Summary
- centralize `orders.css` global animations by importing in `_app.tsx`
- remove component-level `orders.css` imports

## Testing
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689ca05fd2d08325bf1a773954e690a0