### PR TITLE
Add displayOrderNo helper for friendly order numbers

### DIFF
--- a/components/customer/OrderDetailsModal.tsx
+++ b/components/customer/OrderDetailsModal.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import OrderProgress from '@/components/customer/OrderProgress';
 import { useRouter } from 'next/router';
+import { displayOrderNo } from '@/lib/orderDisplay';
 
 export default function OrderDetailsModal({ order, onClose }: { order: any; onClose: () => void; }) {
   if (!order) return null;
@@ -11,7 +12,7 @@ export default function OrderDetailsModal({ order, onClose }: { order: any; onCl
     // TODO: wire to real cancel/refund endpoint (Stripe Connect later).
     alert('Cancel & refund requested. (Stripe wiring coming soon.)');
   };
-  const shortNo = order?.number || order?.display_number || (order?.id ? String(order.id).slice(0,6) : '—');
+  const shortNo = displayOrderNo(order);
   const placed = order?.created_at_human || (order?.created_at ? new Date(order.created_at).toLocaleString(undefined, { weekday:'short', day:'2-digit', month:'short', hour:'2-digit', minute:'2-digit' }) : '');
   const [anim, setAnim] = useState<'enter'|'exit'|''>('');
   useEffect(()=>{ setAnim('enter'); },[]);
@@ -21,7 +22,7 @@ export default function OrderDetailsModal({ order, onClose }: { order: any; onCl
       {/* Desktop: centered dialog; Mobile: bottom sheet */}
       <div className={`w-full md:max-w-xl bg-white rounded-t-2xl md:rounded-2xl p-4 md:p-6 shadow-xl ${anim==='enter'?'ordersheet-enter ordersheet-enter-active':anim==='exit'?'ordersheet-exit ordersheet-exit-active':''}`} onClick={e=>e.stopPropagation()}>
         <div className="flex items-center justify-between">
-          <h3 className="text-lg md:text-xl font-bold">Order #{shortNo}</h3>
+          <h3 className="text-lg md:text-xl font-bold">Order {shortNo}</h3>
           <button onClick={closeWithAnim} aria-label="Close" className="p-2 rounded-md hover:bg-gray-100">✕</button>
         </div>
         {/* status pill + placed time */}

--- a/lib/orderDisplay.ts
+++ b/lib/orderDisplay.ts
@@ -1,0 +1,15 @@
+export function displayOrderNo(order: any): string {
+  // prefer explicit short/sequence numbers if present
+  const n =
+    order?.number ??
+    order?.display_number ??
+    order?.short_number ??
+    order?.order_no ??
+    order?.sequence ??
+    null;
+  if (n) return `#${String(n)}`;
+  // fallback: derive from id deterministically so it stays stable
+  const id = String(order?.id ?? '');
+  const tail = id.replace(/[^0-9]/g,'').slice(-4) || id.slice(0,6);
+  return `#${tail}`;
+}

--- a/pages/restaurant/orders.tsx
+++ b/pages/restaurant/orders.tsx
@@ -4,6 +4,7 @@ import { useUser } from '@/lib/useUser'
 import { useRouter } from 'next/router'
 import CustomerLayout from '../../components/CustomerLayout'
 import OrderDetailsModal from '@/components/customer/OrderDetailsModal'
+import { displayOrderNo } from '@/lib/orderDisplay'
 
 export default function OrdersPage() {
   const router = useRouter()
@@ -195,10 +196,10 @@ export default function OrdersPage() {
                     openOrder(order)
                   }
                 }}
-                aria-label={`Open details for order ${String(order.short_order_number ?? order.id).slice(0, 4)}`}
+                aria-label={`Open details for order ${displayOrderNo(order)}`}
               >
                 <div className="flex items-baseline justify-between">
-                  <div className="text-base font-semibold">Order #{String(order.short_order_number ?? order.id).slice(0, 4)}</div>
+                  <div className="text-base font-semibold">Order {displayOrderNo(order)}</div>
                   {order.status && (
                     <span className="ml-2 text-xs rounded-full px-2 py-0.5 pill capitalize">
                       {String(order.status).replace(/_/g, ' ')}


### PR DESCRIPTION
## Summary
- add helper to format friendly order numbers with fallbacks
- use helper in restaurant orders list
- use helper in order details modal

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_689ca390e454832580738e1650bd773e