### PR TITLE
feat: show cancelled order details

### DIFF
--- a/components/customer/OrderDetailsModal.tsx
+++ b/components/customer/OrderDetailsModal.tsx
@@ -1,13 +1,16 @@
 import React, { useEffect, useState } from 'react';
 import OrderProgress from '@/components/customer/OrderProgress';
+import { randomCancelledMessage } from '@/lib/uiCopy';
+import { extractCancelReason, displayOrderNo } from '@/lib/orderDisplay';
 import { useRouter } from 'next/router';
-import { displayOrderNo } from '@/lib/orderDisplay';
 
 export default function OrderDetailsModal({ order, onClose }: { order: any; onClose: () => void; }) {
   if (!order) return null;
   const router = useRouter();
   const qp = router?.query || {};
-  const canCancel = !['accepted','ready','completed','cancelled'].includes((order?.status || 'pending').toLowerCase());
+  const status = String(order?.status || 'pending').toLowerCase();
+  const canCancel = !['accepted','ready','completed','cancelled'].includes(status);
+  const { reason, note } = extractCancelReason(order);
   const onCancel = async () => {
     // TODO: wire to real cancel/refund endpoint (Stripe Connect later).
     alert('Cancel & refund requested. (Stripe wiring coming soon.)');
@@ -30,8 +33,24 @@ export default function OrderDetailsModal({ order, onClose }: { order: any; onCl
           <span className="pill">{(order?.status || 'Pending')}</span>
           <span className="text-gray-500">Placed: {placed}</span>
         </div>
-        {/* progress */}
-        <div className="mt-3"><OrderProgress status={(order?.status || 'pending').toLowerCase()} /></div>
+        {/* progress OR cancelled view */}
+        {status === 'cancelled' ? (
+          <div className="mt-4 flex flex-col items-center text-center gap-4">
+            <img src="/illustrations/plate-cancelled.svg" alt="" width="320" height="160" loading="lazy" />
+            <div className="space-y-1">
+              <p className="text-base font-semibold">Order cancelled</p>
+              <p className="text-gray-600">{randomCancelledMessage()}</p>
+              {(reason || note) && (
+                <div className="mt-2 text-sm text-gray-700 bg-gray-50 border border-gray-200 rounded-lg px-3 py-2 text-left">
+                  {reason && <div><span className="font-medium">Reason: </span>{reason}</div>}
+                  {note && <div className="mt-1"><span className="font-medium">Note: </span>{note}</div>}
+                </div>
+              )}
+            </div>
+          </div>
+        ) : (
+          <div className="mt-3"><OrderProgress status={status} /></div>
+        )}
 
         {/* Basket */}
         <div className="mt-4">
@@ -110,21 +129,25 @@ export default function OrderDetailsModal({ order, onClose }: { order: any; onCl
           {/* footer buttons */}
           <div className="mt-5 flex flex-col md:flex-row gap-2">
             <button className="md:flex-1 border rounded-lg py-3" onClick={closeWithAnim}>Close</button>
-            <a
-              className="md:flex-1 btn-primary text-center py-3 rounded-lg"
-              href={`/restaurant/track?order_id=${order?.id}&restaurant_id=${qp.restaurant_id ?? ''}${qp.user_id ? `&user_id=${qp.user_id}`:''}`}
-            >
-              Track Order
-            </a>
-            <button
-              className={`md:flex-1 rounded-lg py-3 ${canCancel ? 'border border-red-500 text-red-600' : 'border text-gray-400 cursor-not-allowed'}`}
-              onClick={canCancel ? onCancel : undefined}
-              disabled={!canCancel}
-              aria-disabled={!canCancel}
-              title={canCancel ? 'Cancel & Refund' : 'Cannot cancel after acceptance'}
-            >
-              Cancel & Refund
-            </button>
+            {status !== 'cancelled' && (
+              <>
+                <a
+                  className="md:flex-1 btn-primary text-center py-3 rounded-lg"
+                  href={`/restaurant/track?order_id=${order?.id}&restaurant_id=${qp.restaurant_id ?? ''}${qp.user_id ? `&user_id=${qp.user_id}`:''}`}
+                >
+                  Track Order
+                </a>
+                <button
+                  className={`md:flex-1 rounded-lg py-3 ${canCancel ? 'border border-red-500 text-red-600' : 'border text-gray-400 cursor-not-allowed'}`}
+                  onClick={canCancel ? onCancel : undefined}
+                  disabled={!canCancel}
+                  aria-disabled={!canCancel}
+                  title={canCancel ? 'Cancel & Refund' : 'Cannot cancel after acceptance'}
+                >
+                  Cancel & Refund
+                </button>
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/lib/orderDisplay.ts
+++ b/lib/orderDisplay.ts
@@ -13,3 +13,22 @@ export function displayOrderNo(order: any): string {
   const tail = id.replace(/[^0-9]/g,'').slice(-4) || id.slice(0,6);
   return `#${tail}`;
 }
+
+export function extractCancelReason(order: any): { reason?: string; note?: string } {
+  const reason =
+    order?.cancel_reason ??
+    order?.cancellation_reason ??
+    order?.reject_reason ??
+    order?.rejection_reason ??
+    order?.reason ??
+    undefined;
+  const note =
+    order?.cancel_comment ??
+    order?.cancellation_note ??
+    order?.reject_comment ??
+    order?.rejection_comment ??
+    order?.comment ??
+    order?.note ??
+    undefined;
+  return { reason, note };
+}

--- a/lib/uiCopy.ts
+++ b/lib/uiCopy.ts
@@ -13,3 +13,14 @@ export const plateQuips = [
 export function randomEmptyPlateMessage() {
   return plateQuips[Math.floor(Math.random() * plateQuips.length)];
 }
+
+export const cancelledQuips = [
+  "This one’s been cancelled — sorry about that.",
+  "We’re sorry — your order was cancelled. We’ll make it right.",
+  "Order cancelled. Thanks for your patience and understanding.",
+  "This plate won’t be served today — our apologies.",
+  "Cancelled — sorry for the hassle. Hope to see you again soon."
+];
+export function randomCancelledMessage() {
+  return cancelledQuips[Math.floor(Math.random() * cancelledQuips.length)];
+}

--- a/public/illustrations/plate-cancelled.svg
+++ b/public/illustrations/plate-cancelled.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="640" height="320" viewBox="0 0 640 320" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#f9f9f9"/><stop offset="1" stop-color="#efefef"/>
+    </linearGradient>
+  </defs>
+  <rect width="640" height="320" rx="24" fill="white"/>
+  <ellipse cx="320" cy="258" rx="180" ry="18" fill="#000" opacity=".06"/>
+  <circle cx="320" cy="160" r="120" fill="url(#g)" stroke="#e2e2e2" stroke-width="8"/>
+  <circle cx="320" cy="160" r="86" fill="white" stroke="#e8e8e8" stroke-width="6"/>
+  <!-- sad face -->
+  <path d="M270 190c22-20 58-20 80 0" stroke="#c5c5c5" stroke-width="8" stroke-linecap="round" fill="none"/>
+  <circle cx="294" cy="150" r="6" fill="#c5c5c5"/>
+  <circle cx="346" cy="150" r="6" fill="#c5c5c5"/>
+</svg>


### PR DESCRIPTION
## Summary
- add sad-plate illustration and cancelled-order quips
- extract cancellation reason/note from order objects
- show apology view for cancelled orders in customer modal

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689caa536f9883259acd8a675075d6be