### PR TITLE
Allow OrderProgress to accept string status

### DIFF
--- a/components/customer/OrderProgress.tsx
+++ b/components/customer/OrderProgress.tsx
@@ -28,8 +28,8 @@ function normalizeStatus(s: string): OrderStatus {
   return 'created';
 }
 
-export default function OrderProgress({ status }: { status: OrderStatus }) {
-  const norm = normalizeStatus(String(status));
+export default function OrderProgress({ status }: { status: string }) {
+  const norm = normalizeStatus(status);
   if (norm === 'cancelled') return null; // handled by a different UI
   const idx = Math.max(0, STEPS.findIndex(s => s.key === norm));
   const pulse = norm !== 'completed';


### PR DESCRIPTION
## Summary
- let `OrderProgress` accept a generic string status and normalize internally

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_689cacf48148832590b174b653f289ee