### PR TITLE
feat: add sticky category chip bar

### DIFF
--- a/components/customer/CategoryChips.tsx
+++ b/components/customer/CategoryChips.tsx
@@ -3,17 +3,26 @@ import React from 'react';
 export type Chip = { id?: string; name: string };
 export default function CategoryChips({
   categories,
-  onSelect,
   activeId,
-}: { categories: Chip[]; onSelect?: (c: Chip)=>void; activeId?: string }) {
+  onSelect,
+  offset = 64,
+}: {
+  categories: Chip[];
+  activeId?: string;
+  onSelect?: (c: Chip) => void;
+  offset?: number;
+}) {
   return (
-    <div style={{position:'sticky',top:56,zIndex:10,background:'white'}}>
-      <div className="no-scrollbar" style={{display:'flex',gap:8,overflowX:'auto',padding:'8px 4px 12px 4px'}}>
-        {categories.map(c=>(
+    <div style={{ position: 'sticky', top: offset, zIndex: 10, background: 'white' }}>
+      <div
+        className="no-scrollbar"
+        style={{ display: 'flex', gap: 8, overflowX: 'auto', padding: '8px 4px 12px 4px' }}
+      >
+        {categories.map((c) => (
           <button
             key={c.id || c.name}
-            className={`chip ${activeId && (activeId===String(c.id)) ? 'chip-active' : ''}`}
-            onClick={()=>onSelect?.(c)}
+            className={`chip ${activeId && activeId === String(c.id) ? 'chip-active' : ''}`}
+            onClick={() => onSelect?.(c)}
           >
             {c.name}
           </button>

--- a/styles/brand.css
+++ b/styles/brand.css
@@ -7,6 +7,7 @@
 [data-brand-root] .link-brand { color: var(--brand); }
 [data-brand-root] .chip{display:inline-flex;align-items:center;gap:.5rem;border-radius:9999px;padding:.5rem .9rem;background:#f4f4f5;color:#111827;font-weight:600;white-space:nowrap}
 [data-brand-root] .chip-active{background:color-mix(in oklab, var(--brand) 18%, white);color:var(--brand);box-shadow:0 0 0 1px color-mix(in oklab, var(--brand) 40%, white) inset}
+.no-scrollbar{scrollbar-width:none}.no-scrollbar::-webkit-scrollbar{display:none}
 
 /* Optional glass effect for headers/nav */
 [data-brand-root] .brand-glass {


### PR DESCRIPTION
## Summary
- add brand-tinted chip styles and hidden scrollbars
- create sticky, scrollable `CategoryChips` component
- use chip bar on menu page with active highlight and smooth scrolling

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_689cbc60f84c83258571c83fa5e2f19c