### PR TITLE
feat: add PlateLick icon for menu placeholder and footer

### DIFF
--- a/components/MenuItemCard.tsx
+++ b/components/MenuItemCard.tsx
@@ -3,6 +3,7 @@ import { useCart } from '../context/CartContext';
 import { getAddonsForItem } from '../utils/getAddonsForItem';
 import type { AddonGroup } from '../utils/types';
 import AddonGroups, { validateAddonSelections } from './AddonGroups';
+import PlateLick from '@/components/icons/PlateLick';
 
 interface MenuItem {
   id: number;
@@ -113,15 +114,7 @@ export default function MenuItemCard({
             />
           ) : (
             <div className="w-[84px] h-[84px] rounded-xl bg-gray-100 flex items-center justify-center text-gray-400 flex-shrink-0">
-              <svg width="28" height="28" viewBox="0 0 24 24" fill="none">
-                <path
-                  d="M4 7h16M7 7l2 10h6l2-10"
-                  stroke="currentColor"
-                  strokeWidth="1.7"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
+              <PlateLick size={40} />
             </div>
           )}
           <div className="flex-1 min-w-0">

--- a/components/customer/FooterNav.tsx
+++ b/components/customer/FooterNav.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { Home, Utensils, ListOrdered, Menu } from 'lucide-react';
-import PlateIcon from '@/components/icons/PlateIcon';
+import PlateLick from '@/components/icons/PlateLick';
 import React from 'react';
 
 interface Props {
@@ -51,7 +51,7 @@ export default function FooterNav({ cartCount = 0, hidden }: Props) {
             title={cartLabel}
             className="relative w-14 h-14 rounded-full fab flex items-center justify-center shadow-lg"
           >
-            <PlateIcon size={24} />
+            <PlateLick size={22} />
             {cartCount > 0 && (
               <span className="absolute -top-1 -right-1 bg-red-500 text-white text-[10px] font-bold w-5 h-5 rounded-full flex items-center justify-center">
                 {cartCount}

--- a/components/icons/PlateLick.tsx
+++ b/components/icons/PlateLick.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+/** Plate with tongue (brand-aware). Uses currentColor for outlines and var(--brand) for the tongue. */
+export default function PlateLick({ size = 32, className = '' }: { size?: number; className?: string }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 64 64"
+      role="img"
+      aria-label="Plate"
+      className={className}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <defs>
+        <style>{`
+          .stroke { stroke: currentColor; stroke-width: 3; fill: none; }
+          .tongue { fill: var(--brand, #16a34a); }
+        `}</style>
+      </defs>
+      {/* outer plate */}
+      <circle cx="32" cy="32" r="28" className="stroke" />
+      {/* inner rim */}
+      <circle cx="32" cy="32" r="20" className="stroke" />
+      {/* tongue (accent) */}
+      <path className="tongue" d="M45 40c0 6-5 11-11 11s-11-5-11-11c0-1.2 1.1-2 2.2-1.6 2.7.9 5.7 1.4 8.8 1.4s6.1-.5 8.8-1.4c1.1-.4 2.2.4 2.2 1.6Z" />
+      {/* smile */}
+      <path d="M21 36c3.2 2.4 7.1 3.8 11 3.8s7.8-1.4 11-3.8" className="stroke" strokeLinecap="round" />
+    </svg>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add reusable brand-aware PlateLick icon
- use PlateLick as placeholder art in menu items without images
- replace footer FAB icon with PlateLick

## Testing
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689cc28f040c8325a7fb56cd4015941a