### PR TITLE
feat: add responsive grid to menu items

### DIFF
--- a/pages/restaurant/menu.tsx
+++ b/pages/restaurant/menu.tsx
@@ -207,7 +207,7 @@ export default function RestaurantMenuPage() {
     }
 
     return (
-      <div className="max-w-screen-sm mx-auto px-4 pb-28">
+      <div className="px-4 pb-28 max-w-6xl mx-auto">
         <div className="pt-4 space-y-8 scroll-smooth">
           <div className="text-center space-y-4">
             <Logo size={96} className="mx-auto" />
@@ -267,7 +267,7 @@ export default function RestaurantMenuPage() {
                     className="space-y-4"
                   >
                     <h2 className="text-xl font-semibold text-left">{cat.name}</h2>
-                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                    <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-3">
                       {catItems.map((item) => (
                         <MenuItemCard
                           key={item.id}


### PR DESCRIPTION
## Summary
- expand menu layout width to max-w-6xl
- add responsive grid with 2 columns on large screens and 3 on extra-large

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_689cccbda6f48325bf4e3448d584cdf2