### PR TITLE
feat: add menu header hero and tap animations

### DIFF
--- a/components/MenuItemCard.tsx
+++ b/components/MenuItemCard.tsx
@@ -102,7 +102,7 @@ export default function MenuItemCard({
   return (
     <>
       <div
-        className="rounded-2xl border border-gray-100 p-4 flex gap-4 active:opacity-95"
+        className="tapcard rounded-2xl border border-gray-100 p-4 flex gap-4 active:opacity-95 hover:shadow-sm transition-shadow"
         onClick={handleClick}
         role="button"
         tabIndex={0}

--- a/pages/restaurant/menu.tsx
+++ b/pages/restaurant/menu.tsx
@@ -171,6 +171,16 @@ export default function RestaurantMenuPage() {
     const { name } = useBrand();
     const [activeCat, setActiveCat] = useState<string | undefined>(undefined);
     const sectionsRef = useRef<Record<string, HTMLElement | null>>({});
+    const qp = router?.query || {};
+    const headerImg =
+      restaurant?.header_image ||
+      restaurant?.hero_image ||
+      (typeof qp.header === 'string' ? qp.header : '') ||
+      '';
+    const title =
+      restaurant?.name ||
+      (typeof qp.name === 'string' ? qp.name : name) ||
+      'Menu';
 
     useEffect(() => {
       if (!Array.isArray(categories) || categories.length === 0) return;
@@ -200,13 +210,24 @@ export default function RestaurantMenuPage() {
     return (
       <div className="px-4 pb-28 max-w-6xl mx-auto">
         <div className="pt-4 space-y-8 scroll-smooth">
-          <div className="text-center space-y-4">
-            <Logo size={96} className="mx-auto" />
-            <h1 className="text-3xl font-bold">{name}</h1>
-            {restaurant.website_description && (
-              <p className="text-gray-600">{restaurant.website_description}</p>
-            )}
+          {/* Menu header hero */}
+          <div className="mt-3">
+            <div className="menu-hero">
+              {headerImg ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={headerImg} alt="" loading="lazy" />
+              ) : null}
+              <div className="menu-hero-inner">
+                <div className="menu-hero-title">
+                  <Logo size={28} />
+                  <span>{title}</span>
+                </div>
+              </div>
+            </div>
           </div>
+          {restaurant.website_description && (
+            <p className="text-gray-600 text-center">{restaurant.website_description}</p>
+          )}
 
           <div className="relative">
             <div className="relative">

--- a/styles/brand.css
+++ b/styles/brand.css
@@ -12,6 +12,16 @@
 [data-brand-root] .chip-active{background:color-mix(in oklab, var(--brand) 18%, white);color:var(--brand);box-shadow:0 0 0 1px color-mix(in oklab, var(--brand) 40%, white) inset}
 .no-scrollbar{scrollbar-width:none}.no-scrollbar::-webkit-scrollbar{display:none}
 
+[data-brand-root] .tapcard{transition:transform .14s ease, box-shadow .14s ease}
+[data-brand-root] .tapcard:active{transform:scale(.98); box-shadow:0 6px 20px rgba(0,0,0,.08)}
+
+/* menu header hero */
+[data-brand-root] .menu-hero{position:relative; height:200px; border-radius:20px; overflow:hidden; background:#f3f4f6}
+[data-brand-root] .menu-hero::before{content:""; position:absolute; inset:0; background:linear-gradient(to top, rgba(0,0,0,.35), rgba(0,0,0,.05))}
+[data-brand-root] .menu-hero img{position:absolute; inset:0; width:100%; height:100%; object-fit:cover}
+[data-brand-root] .menu-hero .menu-hero-inner{position:relative; z-index:1; height:100%; display:flex; flex-direction:column; align-items:flex-start; justify-content:flex-end; padding:16px}
+[data-brand-root] .menu-hero .menu-hero-title{display:flex; align-items:center; gap:10px; color:#fff; text-shadow:0 1px 2px rgba(0,0,0,.35); font-weight:800; font-size:20px}
+
 /* Optional glass effect for headers/nav */
 [data-brand-root] .brand-glass {
   backdrop-filter: saturate(160%) blur(12px);


### PR DESCRIPTION
## Summary
- add tapcard and menu hero styles
- animate MenuItemCard wrapper on tap
- show menu header image with logo/title on menu page

## Testing
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689cd27dcdbc83258099928deb5ad344