### PR TITLE
feat(menu): add collapsible MenuHeader on customer Menu page (UI-only, scoped)

### DIFF
--- a/components/customer/menu/MenuHeader.tsx
+++ b/components/customer/menu/MenuHeader.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { useEffect, useState } from 'react';
+
+type MenuHeaderProps = {
+  title: string;
+  subtitle?: string | null;
+  imageUrl?: string;         // header/hero image (optional)
+  logoUrl?: string | null;   // optional watermark/logo
+  accentHex?: string | null; // optional brand accent for overlay
+};
+
+export default function MenuHeader({
+  title,
+  subtitle,
+  imageUrl,
+  logoUrl,
+  accentHex,
+}: MenuHeaderProps) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  useEffect(() => {
+    let ticking = false;
+    const onScroll = () => {
+      if (!ticking) {
+        window.requestAnimationFrame(() => {
+          setCollapsed(window.scrollY > 48);
+          ticking = false;
+        });
+        ticking = true;
+      }
+    };
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const bgStyle: React.CSSProperties = imageUrl
+    ? { backgroundImage: `url(${imageUrl})` }
+    : {};
+
+  const overlay =
+    accentHex && /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(accentHex)
+      ? `linear-gradient(180deg, ${accentHex}22, ${accentHex}11, #00000022)`
+      : 'linear-gradient(180deg, rgba(0,0,0,0.10), rgba(0,0,0,0.06), rgba(0,0,0,0.08))';
+
+  return (
+    <section
+      aria-label="Restaurant header"
+      className={[
+        'relative w-full overflow-hidden rounded-2xl',
+        'transition-[height,margin] duration-300 ease-out',
+        collapsed ? 'h-20 md:h-24 mt-2' : 'h-48 md:h-80 mt-0',
+      ].join(' ')}
+    >
+      {/* Background image/gradient */}
+      <div
+        className={[
+          'absolute inset-0 bg-center bg-cover',
+          imageUrl ? '' : 'bg-gradient-to-br from-gray-200 via-gray-100 to-gray-200',
+          'opacity-100',
+        ].join(' ')}
+        style={bgStyle}
+      />
+      {/* Overlay for contrast */}
+      <div
+        className="absolute inset-0"
+        style={{ backgroundImage: overlay }}
+      />
+      {/* Optional faint watermark logo */}
+      {logoUrl ? (
+        <img
+          src={logoUrl}
+          alt=""
+          aria-hidden="true"
+          className="absolute right-4 bottom-4 h-8 w-8 md:h-10 md:w-10 opacity-60 blur-[0.2px]"
+        />
+      ) : null}
+      {/* Foreground content */}
+      <div className="relative h-full w-full px-4 md:px-6 flex items-end">
+        <div className="pb-3 md:pb-4">
+          <div className={[
+            'inline-flex items-center rounded-full backdrop-blur-sm',
+            'bg-white/40 text-gray-800',
+            'px-2.5 py-0.5 text-xs font-medium shadow-sm',
+            'transition-opacity duration-300',
+            collapsed ? 'opacity-0 pointer-events-none' : 'opacity-100',
+          ].join(' ')}>
+            Menu
+          </div>
+          <h1
+            className={[
+              'mt-1 font-semibold text-gray-900 drop-shadow-sm',
+              'transition-transform duration-300',
+              collapsed ? 'text-lg md:text-xl translate-y-0' : 'text-2xl md:text-4xl translate-y-[1px]',
+            ].join(' ')}
+          >
+            {title}
+          </h1>
+          {subtitle ? (
+            <p className={[
+              'text-gray-700/90 transition-opacity duration-300',
+              collapsed ? 'opacity-0 h-0 -mt-1 overflow-hidden' : 'opacity-100 text-sm md:text-base',
+            ].join(' ')}>
+              {subtitle}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/pages/restaurant/menu.tsx
+++ b/pages/restaurant/menu.tsx
@@ -6,8 +6,8 @@ import { supabase } from "../../utils/supabaseClient";
 import MenuItemCard from "../../components/MenuItemCard";
 import { useCart } from "../../context/CartContext";
 import CustomerLayout from "../../components/CustomerLayout";
-import Logo from "../../components/branding/Logo";
 import { useBrand } from "../../components/branding/BrandProvider";
+import MenuHeader from '@/components/customer/menu/MenuHeader';
 
 
 interface Restaurant {
@@ -168,7 +168,7 @@ export default function RestaurantMenuPage() {
   }
 
   const Inner = () => {
-    const { name } = useBrand();
+    const brand = useBrand();
     const [activeCat, setActiveCat] = useState<string | undefined>(undefined);
     const sectionsRef = useRef<Record<string, HTMLElement | null>>({});
     const qp = router?.query || {};
@@ -193,10 +193,6 @@ export default function RestaurantMenuPage() {
       ) ||
       (typeof (qp as any).header === 'string' ? ((qp as any).header as string) : '') ||
       '';
-    const title =
-      restaurant?.name ||
-      (typeof qp.name === 'string' ? qp.name : name) ||
-      'Menu';
 
     useEffect(() => {
       if (!Array.isArray(categories) || categories.length === 0) return;
@@ -227,20 +223,13 @@ export default function RestaurantMenuPage() {
       <div className="px-4 pb-28 max-w-6xl mx-auto">
         <div className="pt-4 space-y-8 scroll-smooth">
           {/* Menu header hero */}
-          <div className="mt-3">
-            <div className="menu-hero">
-              {headerImg ? (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img src={headerImg} alt="" loading="lazy" />
-              ) : null}
-              <div className="menu-hero-inner">
-                <div className="menu-hero-title">
-                  <Logo size={28} />
-                  <span>{title}</span>
-                </div>
-              </div>
-            </div>
-          </div>
+          <MenuHeader
+            title={restaurant?.name || 'Restaurant'}
+            subtitle={restaurant?.website_description ?? null}
+            imageUrl={headerImg || undefined}
+            logoUrl={restaurant?.logo_url ?? null}
+            accentHex={(brand?.brand as string) || undefined}
+          />
           {restaurant.website_description && (
             <p className="text-gray-600 text-center">{restaurant.website_description}</p>
           )}


### PR DESCRIPTION
## Summary
- replace static hero with new collapsible `MenuHeader` component on customer menu page
- create local `MenuHeader` supporting title, subtitle, image, logo watermark, and scroll-based collapse

## Testing
- `npm run test:ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cd9e992048325ab9af5224b7d07c1