### PR TITLE
polish(menu): add micro-animations for cohesive feel

### DIFF
--- a/components/MenuItemCard.tsx
+++ b/components/MenuItemCard.tsx
@@ -4,6 +4,7 @@ import { getAddonsForItem } from '../utils/getAddonsForItem';
 import type { AddonGroup } from '../utils/types';
 import AddonGroups, { validateAddonSelections } from './AddonGroups';
 import PlateAdd from '@/components/icons/PlateAdd';
+import { useBrand } from '@/components/branding/BrandProvider';
 
 interface MenuItem {
   id: number;
@@ -34,6 +35,7 @@ export default function MenuItemCard({
     Record<string, Record<string, number>>
   >({});
   const { addToCart } = useCart();
+  const brand = useBrand();
 
   const price = typeof item?.price === 'number' ? item.price : Number(item?.price || 0);
 
@@ -102,7 +104,7 @@ export default function MenuItemCard({
   return (
     <>
       <div
-        className="tapcard rounded-2xl border border-gray-100 p-4 flex gap-4 active:opacity-95 hover:shadow-sm transition-shadow"
+        className="tapcard rounded-2xl border border-gray-100 p-4 flex gap-4 active:opacity-95 transition-transform duration-200 ease-out hover:scale-[1.02] hover:shadow-md active:scale-[0.98]"
         onClick={handleClick}
         role="button"
         tabIndex={0}
@@ -159,7 +161,8 @@ export default function MenuItemCard({
           <div className="mt-2 flex justify-end">
             <button
               type="button"
-              className="btn-icon min-w-[40px] min-h-[40px] transition duration-150 ease-out hover:scale-[1.05] hover:shadow-sm active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-current"
+              className="btn-icon min-w-[40px] min-h-[40px] transition-transform duration-150 ease-out hover:scale-[1.05] active:scale-[0.95] focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+              style={{ '--tw-ring-color': brand.brand }}
               onClick={(e) => {
                 e.stopPropagation();
                 handleClick();

--- a/components/customer/menu/MenuHeader.tsx
+++ b/components/customer/menu/MenuHeader.tsx
@@ -17,6 +17,11 @@ export default function MenuHeader({
   accentHex,
 }: MenuHeaderProps) {
   const [collapsed, setCollapsed] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   useEffect(() => {
     let ticking = false;
@@ -42,15 +47,16 @@ export default function MenuHeader({
       ? `linear-gradient(180deg, ${accentHex}22, ${accentHex}11, #00000022)`
       : 'linear-gradient(180deg, rgba(0,0,0,0.10), rgba(0,0,0,0.06), rgba(0,0,0,0.08))';
 
-  return (
-    <section
-      aria-label="Restaurant header"
-      className={[
-        'relative w-full overflow-hidden rounded-2xl',
-        'transition-[height,margin] duration-300 ease-out',
-        collapsed ? 'h-20 md:h-24 mt-2' : 'h-48 md:h-80 mt-0',
-      ].join(' ')}
-    >
+    return (
+      <section
+        aria-label="Restaurant header"
+        className={[
+          'relative w-full overflow-hidden rounded-2xl',
+          'transition-[height,margin,opacity,transform] duration-500 ease-out',
+          collapsed ? 'h-20 md:h-24 mt-2' : 'h-48 md:h-80 mt-0',
+          mounted ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-2',
+        ].join(' ')}
+      >
       {/* Background image/gradient */}
       <div
         className={[

--- a/pages/restaurant/menu.tsx
+++ b/pages/restaurant/menu.tsx
@@ -169,6 +169,8 @@ export default function RestaurantMenuPage() {
 
   const Inner = () => {
     const brand = useBrand();
+    const [mounted, setMounted] = useState(false);
+    useEffect(() => setMounted(true), []);
     const [activeCat, setActiveCat] = useState<string | undefined>(undefined);
     const sectionsRef = useRef<Record<string, HTMLElement | null>>({});
     const qp = router?.query || {};
@@ -250,18 +252,27 @@ export default function RestaurantMenuPage() {
 
           {/* sticky category chips */}
           {Array.isArray(categories) && categories.length > 0 && (
-            <div className="sticky top-[60px] z-10 pt-2 pb-3 bg-white/70 backdrop-blur supports-[backdrop-filter]:backdrop-blur rounded-b-xl">
+            <div
+              className={`sticky top-[60px] z-10 pt-2 pb-3 bg-white/70 backdrop-blur supports-[backdrop-filter]:backdrop-blur rounded-b-xl transition-all duration-500 ease-out ${mounted ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-2'}`}
+              style={{ transitionDelay: '100ms' }}
+            >
               <div className="flex gap-3 overflow-x-auto no-scrollbar">
                 {categories.map((c: any) => (
                   <button
                     key={c.id}
                     onClick={() => onChipSelect(c)}
-                    className={`px-4 py-2 rounded-full border whitespace-nowrap transition-colors ${
+                    className={`px-4 py-2 rounded-full border whitespace-nowrap transition-all duration-200 ease-out hover:scale-[1.03] hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${
                       activeCat === String(c.id)
-                        ? 'bg-pink-100 border-pink-200 text-pink-700'
+                        ? 'scale-105 text-white'
                         : 'bg-gray-100 border-gray-200 text-gray-700'
                     }`}
                     aria-pressed={activeCat === String(c.id)}
+                    aria-current={activeCat === String(c.id) ? 'true' : undefined}
+                    style={
+                      activeCat === String(c.id)
+                        ? { '--tw-ring-color': brand.brand, backgroundColor: brand.brand, borderColor: brand.brand }
+                        : { '--tw-ring-color': brand.brand }
+                    }
                   >
                     {c.name}
                   </button>
@@ -299,12 +310,14 @@ export default function RestaurantMenuPage() {
                   >
                     <h2 className="text-xl font-semibold text-left">{cat.name}</h2>
                     <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-3">
-                      {catItems.map((item) => (
-                        <MenuItemCard
+                      {catItems.map((item, idx) => (
+                        <div
                           key={item.id}
-                          item={item}
-                          restaurantId={restaurantId as string}
-                        />
+                          className={`opacity-0 translate-y-2 transition-all duration-500 ease-out ${mounted ? 'opacity-100 translate-y-0' : ''}`}
+                          style={{ transitionDelay: `${idx * 75}ms` }}
+                        >
+                          <MenuItemCard item={item} restaurantId={restaurantId as string} />
+                        </div>
                       ))}
                     </div>
                   </section>


### PR DESCRIPTION
## Summary
- animate MenuHeader on mount for subtle fade-slide reveal
- add delayed fade/slide and interactive scaling to category chips
- smooth hover/tap animations for menu cards and Add buttons with brand-colored focus rings

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_689ce318929c8325a932c20bb59cc458