### PR TITLE
fix(ui): TS-safe custom CSS variable for Tailwind ring color in MenuItemCard

### DIFF
--- a/components/MenuItemCard.tsx
+++ b/components/MenuItemCard.tsx
@@ -162,7 +162,7 @@ export default function MenuItemCard({
             <button
               type="button"
               className="btn-icon min-w-[40px] min-h-[40px] transition-transform duration-150 ease-out hover:scale-[1.05] active:scale-[0.95] focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
-              style={{ '--tw-ring-color': brand.brand }}
+              style={{ ['--tw-ring-color' as any]: String(brand?.brand || 'currentColor') } as React.CSSProperties}
               onClick={(e) => {
                 e.stopPropagation();
                 handleClick();


### PR DESCRIPTION
## Summary
- cast custom `--tw-ring-color` CSS variable to satisfy TypeScript in `MenuItemCard`

## Testing
- `npm run build` *(fails: TypeScript error in pages/restaurant/menu.tsx unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_689ce7e3aef88325a10053a24f90793f