### PR TITLE
fix(home): make LandingHero fill full viewport height with 100svh + min-h-screen

### DIFF
--- a/components/customer/home/LandingHero.tsx
+++ b/components/customer/home/LandingHero.tsx
@@ -34,11 +34,12 @@ export default function LandingHero({
       aria-label="Restaurant hero"
       className={[
         'relative w-full overflow-hidden',
-        'min-h-[68vh] md:min-h-[72vh]',
+        'min-h-screen',
         'rounded-none md:rounded-3xl',
         'transition-all duration-500 ease-out',
         mounted ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-2'
       ].join(' ')}
+      style={{ minHeight: '100svh' }}
     >
       {/* Background */}
       <div
@@ -52,7 +53,7 @@ export default function LandingHero({
       <div className="absolute inset-0" style={{ backgroundImage: overlay }} />
 
       {/* Content */}
-      <div className="relative z-10 flex flex-col items-center justify-center text-center px-6 py-16 md:py-20">
+      <div className="relative z-10 flex min-h-full flex-col items-center justify-center text-center px-6 py-16 md:py-20">
         {/* Avatar */}
         <div className="relative">
           <div


### PR DESCRIPTION
## Summary
- ensure LandingHero always fills viewport with `min-h-screen` and dynamic `100svh` inline height
- center hero content by stretching wrapper to full height

## Testing
- `npm run test:ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cfef8e2f083259d357e24e1af9ac7