### PR TITLE
feat(more): polished More page with grouped sections and reusable card components

### DIFF
--- a/components/customer/more/MoreCard.tsx
+++ b/components/customer/more/MoreCard.tsx
@@ -1,0 +1,50 @@
+import Link from 'next/link'
+import { ReactNode, useEffect, useState } from 'react'
+
+interface MoreCardProps {
+  title: string
+  icon?: ReactNode
+  description?: string
+  href?: string
+  onClick?: () => void
+  index?: number
+}
+
+export default function MoreCard({ title, icon, description, href, onClick, index = 0 }: MoreCardProps) {
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => { setMounted(true) }, [])
+
+  const content = (
+    <div
+      className="rounded-xl shadow bg-white p-4 h-full hover:scale-[1.02] active:scale-95 transition-transform"
+    >
+      {icon && <div className="mb-2 text-gray-500">{icon}</div>}
+      <h3 className="font-semibold mb-1">{title}</h3>
+      {description && <p className="text-sm text-gray-500">{description}</p>}
+    </div>
+  )
+
+  return (
+    <div
+      className={`opacity-0 translate-y-2 transition-all duration-500 ease-out ${mounted ? 'opacity-100 translate-y-0' : ''}`}
+      style={{ transitionDelay: `${index * 75}ms` }}
+    >
+      {href ? (
+        <Link href={href} aria-label={title} className="block h-full" role="link">
+          {content}
+        </Link>
+      ) : (
+        <button
+          type="button"
+          onClick={onClick}
+          aria-label={title}
+          className="block text-left w-full h-full"
+          role="button"
+        >
+          {content}
+        </button>
+      )}
+    </div>
+  )
+}
+

--- a/components/customer/more/MoreSection.tsx
+++ b/components/customer/more/MoreSection.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react'
+
+interface MoreSectionProps {
+  title: string
+  children: ReactNode
+}
+
+export default function MoreSection({ title, children }: MoreSectionProps) {
+  return (
+    <section className="mt-8">
+      <h2 className="text-xs uppercase font-semibold text-gray-500 mb-3">{title}</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">{children}</div>
+    </section>
+  )
+}
+

--- a/pages/restaurant/more.tsx
+++ b/pages/restaurant/more.tsx
@@ -1,45 +1,52 @@
+import Link from 'next/link'
 import { useRouter } from 'next/router'
 import CustomerLayout from '../../components/CustomerLayout'
 import { useCart } from '../../context/CartContext'
+import { useBrand } from '@/components/branding/BrandProvider'
+import MoreCard from '@/components/customer/more/MoreCard'
+import MoreSection from '@/components/customer/more/MoreSection'
+import { UserIcon, ClipboardDocumentListIcon, InformationCircleIcon, ClockIcon, PhoneIcon } from '@heroicons/react/24/outline'
 
 export default function RestaurantMorePage() {
   const router = useRouter()
   const { cart } = useCart()
+  const brand = useBrand()
   const itemCount = cart.items.reduce((sum, it) => sum + it.quantity, 0)
+
+  const customPages: { title: string; slug: string }[] = []
 
   return (
     <CustomerLayout cartCount={itemCount}>
-    <div className="max-w-screen-sm mx-auto px-4 pb-24">
-      <h1 className="text-xl font-semibold mb-4">More</h1>
+      <div className="container mx-auto max-w-5xl px-4 py-8">
+        <h1 className="text-3xl font-bold">More</h1>
+        <div className="w-16 h-1 mt-2" style={{ backgroundColor: brand?.brand }} />
 
-      {/* Sections are placeholders. Do not fetch data yet. */}
-      <div className="space-y-4">
-        <section className="rounded-xl p-4 shadow" style={{ background: 'var(--card)', color: 'var(--ink)' }}>
-          <h2 className="font-medium mb-1">Account</h2>
-          <p className="text-sm text-gray-600">Sign in/out and order history (customer auth TBD).</p>
-        </section>
+        <MoreSection title="Your Account">
+          <MoreCard index={0} title="Account" description="Manage your details" href="/restaurant/account" icon={<UserIcon className="w-8 h-8 text-gray-500" />} />
+          <MoreCard index={1} title="Orders" description="View past orders" href="/restaurant/orders" icon={<ClipboardDocumentListIcon className="w-8 h-8 text-gray-500" />} />
+        </MoreSection>
 
-        <section className="rounded-xl p-4 shadow" style={{ background: 'var(--card)', color: 'var(--ink)' }}>
-          <h2 className="font-medium mb-1">About</h2>
-          <p className="text-sm text-gray-600">Restaurant description, address, phone (to be pulled from settings later).</p>
-        </section>
+        <MoreSection title="About">
+          <MoreCard index={0} title="About Us" description="Who we are" href="/restaurant/about" icon={<InformationCircleIcon className="w-8 h-8 text-gray-500" />} />
+          <MoreCard index={1} title="Opening Times" description="When we're open" href="/restaurant/opening-times" icon={<ClockIcon className="w-8 h-8 text-gray-500" />} />
+          <MoreCard index={2} title="Contact" description="Get in touch" href="/restaurant/contact" icon={<PhoneIcon className="w-8 h-8 text-gray-500" />} />
+        </MoreSection>
 
-        <section className="rounded-xl p-4 shadow" style={{ background: 'var(--card)', color: 'var(--ink)' }}>
-          <h2 className="font-medium mb-1">Opening Times</h2>
-          <p className="text-sm text-gray-600">Display hours; will read from restaurant settings in a later step.</p>
-        </section>
+        <MoreSection title="Extras">
+          {customPages.length ? (
+            customPages.map((p, i) => (
+              <MoreCard key={p.slug} index={i} title={p.title} onClick={() => router.push(`/restaurant/${p.slug}`)} />
+            ))
+          ) : (
+            <MoreCard index={0} title="Custom pages" description="Coming soon" />
+          )}
+        </MoreSection>
 
-        <section className="rounded-xl p-4 shadow" style={{ background: 'var(--card)', color: 'var(--ink)' }}>
-          <h2 className="font-medium mb-1">Pages</h2>
-          <p className="text-sm text-gray-600">Custom pages (from restaurant_pages) to be listed here in a later step.</p>
-        </section>
-
-        <section className="rounded-xl p-4 shadow" style={{ background: 'var(--card)', color: 'var(--ink)' }}>
-          <h2 className="font-medium mb-1">Contact</h2>
-          <p className="text-sm text-gray-600">Map, phone, email, social links—wired after settings UI is added.</p>
-        </section>
+        <div className="mt-8 text-xs text-gray-500 flex flex-col sm:flex-row gap-2">
+          <Link href="/restaurant/privacy" className="hover:text-gray-700">Privacy Policy</Link>
+          <Link href="/restaurant/terms" className="hover:text-gray-700">Terms</Link>
+        </div>
       </div>
-    </div>
     </CustomerLayout>
   )
 }


### PR DESCRIPTION
## Summary
- add animated `MoreCard` for linkable tiles
- add `MoreSection` wrapper for grouping cards
- rebuild restaurant "More" page with grouped sections and legal links

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d0bd3097c832596e8ab7f231fce2a