### PR TITLE
fix(restaurant): robust restaurant id resolution from query/brand to prevent “No restaurant specified”

### DIFF
--- a/lib/resolveRestaurantId.ts
+++ b/lib/resolveRestaurantId.ts
@@ -1,0 +1,29 @@
+export default function resolveRestaurantId(
+  router: any,
+  brand: unknown,
+  fallback?: unknown
+): string | undefined {
+  // Accept several possible query keys
+  const qp = (router?.query ?? {}) as Record<string, unknown>;
+  const fromQuery =
+    (typeof qp.restaurant_id === 'string' && qp.restaurant_id) ||
+    (typeof qp.id === 'string' && qp.id) ||
+    (typeof qp.r === 'string' && qp.r) ||
+    undefined;
+
+  // Accept brand context if it carries the id
+  let fromBrand: string | undefined = undefined;
+  if (brand && typeof brand === 'object') {
+    const b = brand as any;
+    if (typeof b.restaurant_id === 'string' && b.restaurant_id) fromBrand = b.restaurant_id;
+    else if (typeof b.restaurantId === 'string' && b.restaurantId) fromBrand = b.restaurantId;
+    else if (typeof b.id === 'string' && b.id) fromBrand = b.id;
+  }
+
+  // Optional explicit fallback (e.g., preloaded restaurant object/id)
+  const fromFallback =
+    (typeof fallback === 'string' && fallback) ||
+    ((fallback && typeof fallback === 'object' && typeof (fallback as any).id === 'string') ? (fallback as any).id : undefined);
+
+  return fromQuery || fromBrand || fromFallback;
+}

--- a/pages/restaurant/index.tsx
+++ b/pages/restaurant/index.tsx
@@ -7,6 +7,7 @@ import { useBrand } from '@/components/branding/BrandProvider';
 import { supabase } from '@/utils/supabaseClient';
 import { useCart } from '@/context/CartContext';
 import LandingHero from '@/components/customer/home/LandingHero';
+import resolveRestaurantId from '@/lib/resolveRestaurantId';
 
 function getBrandAccentHex(brand: unknown): string | undefined {
   if (!brand || typeof brand !== 'object') return undefined;
@@ -21,13 +22,12 @@ function getBrandAccentHex(brand: unknown): string | undefined {
 
 export default function RestaurantHomePage() {
   const router = useRouter();
-  const { restaurant_id } = router.query;
-  const restaurantId = Array.isArray(restaurant_id) ? restaurant_id[0] : restaurant_id;
+  const brand = useBrand();
   const [restaurant, setRestaurant] = useState<any | null>(null);
   const { cart } = useCart();
   const cartCount = cart.items.reduce((sum, it) => sum + it.quantity, 0);
   const [heroInView, setHeroInView] = useState(true);
-  const brand = useBrand();
+  const restaurantId = resolveRestaurantId(router, brand, restaurant);
 
   useEffect(() => {
     // dev: prove this file renders in prod

--- a/pages/restaurant/menu.tsx
+++ b/pages/restaurant/menu.tsx
@@ -8,6 +8,7 @@ import { useCart } from "../../context/CartContext";
 import CustomerLayout from "../../components/CustomerLayout";
 import { useBrand } from "../../components/branding/BrandProvider";
 import MenuHeader from '@/components/customer/menu/MenuHeader';
+import resolveRestaurantId from '@/lib/resolveRestaurantId';
 
 
 interface Restaurant {
@@ -41,10 +42,7 @@ interface Item {
 
 export default function RestaurantMenuPage() {
   const router = useRouter();
-  const { restaurant_id } = router.query;
-  const restaurantId = Array.isArray(restaurant_id)
-    ? restaurant_id[0]
-    : restaurant_id;
+  const brand = useBrand();
 
   const [restaurant, setRestaurant] = useState<Restaurant | null>(null);
   const [categories, setCategories] = useState<Category[]>([]);
@@ -58,6 +56,7 @@ export default function RestaurantMenuPage() {
   const [showTop, setShowTop] = useState(false);
   const { cart } = useCart();
   const itemCount = cart.items.reduce((sum, it) => sum + it.quantity, 0);
+  const restaurantId = resolveRestaurantId(router, brand, restaurant);
 
   useEffect(() => {
     const onScroll = () => {
@@ -159,7 +158,7 @@ export default function RestaurantMenuPage() {
     return <div className="p-6 text-center text-[var(--muted)]">Loading...</div>;
   }
 
-  if (!restaurant) {
+  if (!restaurantId) {
     return (
       <div className="p-6 text-center text-red-500">
         No restaurant specified
@@ -168,7 +167,6 @@ export default function RestaurantMenuPage() {
   }
 
   const Inner = () => {
-    const brand = useBrand();
     const [mounted, setMounted] = useState(false);
     useEffect(() => setMounted(true), []);
     const [activeCat, setActiveCat] = useState<string | undefined>(undefined);


### PR DESCRIPTION
## Summary
- resolve restaurant ID from router query, brand context, or fallback via shared helper
- use helper in restaurant menu and home pages and guard missing IDs

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d6cb64f2883258fc5bc7daa861bbe