### PR TITLE
fix: guard null menu description

### DIFF
--- a/pages/restaurant/menu.tsx
+++ b/pages/restaurant/menu.tsx
@@ -249,7 +249,7 @@ export default function RestaurantMenuPage() {
             logoUrl={restaurant?.logo_url ?? null}
             accentHex={(brand?.brand as string) || undefined}
           />
-          {restaurant.website_description && (
+          {restaurant?.website_description && (
             <p className="text-gray-600 text-center">{restaurant.website_description}</p>
           )}
 


### PR DESCRIPTION
## Summary
- guard restaurant website description access in menu page

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d81e99f788325961d057e4ed15c05