### PR TITLE
fix(nav): preserve restaurant_id across footer tabs and landing CTA to prevent lost context

### DIFF
--- a/components/customer/FooterNav.tsx
+++ b/components/customer/FooterNav.tsx
@@ -9,14 +9,20 @@ interface Props {
   hidden?: boolean;
 }
 
+function getRestaurantId(router: any): string | undefined {
+  const qp = (router?.query ?? {}) as Record<string, unknown>;
+  const pick = (v: unknown) => (Array.isArray(v) ? v[0] : v);
+  const raw =
+    pick(qp['restaurant_id']) ||
+    pick(qp['id']) ||
+    pick(qp['r']) ||
+    undefined;
+  return typeof raw === 'string' && raw.trim() ? raw : undefined;
+}
+
 export default function FooterNav({ cartCount = 0, hidden }: Props) {
   const router = useRouter();
-  const build = (path: string) => {
-    const p = new URLSearchParams(router.query as any);
-    const qs = p.toString();
-    if (path === '/') return `/restaurant?${qs}`;
-    return `/restaurant/${path}?${qs}`;
-  };
+  const rid = getRestaurantId(router);
 
   const current = (router.asPath || '').split('?')[0];
 
@@ -25,7 +31,10 @@ export default function FooterNav({ cartCount = 0, hidden }: Props) {
 
   const NavLink = ({ href, Icon, label }: any) => (
     <Link
-      href={build(href)}
+      href={{
+        pathname: href === '/' ? '/restaurant' : `/restaurant/${href}`,
+        query: rid ? { restaurant_id: rid } : {},
+      }}
       className={`flex flex-col items-center justify-center text-xs transition-all ${
         current === (href === '/' ? '/restaurant' : `/restaurant/${href}`)
           ? 'nav-active'
@@ -46,7 +55,7 @@ export default function FooterNav({ cartCount = 0, hidden }: Props) {
         <NavLink href="menu" Icon={Utensils} label="Menu" />
         <div className="absolute -top-6 left-1/2 -translate-x-1/2">
           <Link
-            href={build('cart')}
+            href={{ pathname: '/restaurant/cart', query: rid ? { restaurant_id: rid } : {} }}
             aria-label={cartLabel}
             title={cartLabel}
             className="relative w-14 h-14 rounded-full fab flex items-center justify-center shadow-lg"

--- a/pages/restaurant/index.tsx
+++ b/pages/restaurant/index.tsx
@@ -68,9 +68,11 @@ export default function RestaurantHomePage() {
     (typeof (qp as any).header === 'string' ? ((qp as any).header as string) : '') ||
     '';
 
-  const params = new URLSearchParams(router.query as any);
-  if (restaurant?.id) params.set('restaurant_id', restaurant.id);
-  const orderHref = `/restaurant/menu?${params.toString()}`;
+  const rid = (() => {
+    const qp = router?.query ?? {};
+    const v: any = (qp as any).restaurant_id ?? (qp as any).id ?? (qp as any).r;
+    return Array.isArray(v) ? v[0] : v;
+  })();
 
   return (
     <CustomerLayout
@@ -87,7 +89,12 @@ export default function RestaurantHomePage() {
           subtitle={restaurant?.website_description ?? null}
           isOpen={restaurant?.is_open ?? true}
           ctaLabel="Order Now"
-          onCta={() => router.push(orderHref)}
+          onCta={() =>
+            router.push({
+              pathname: '/restaurant/menu',
+              query: rid ? { restaurant_id: String(rid) } : {},
+            })
+          }
           imageUrl={headerImg || undefined}
           logoUrl={restaurant?.logo_url ?? null}
           accentHex={getBrandAccentHex(brand)}


### PR DESCRIPTION
## Summary
- plumb restaurant_id through FooterNav links so tab switches retain context
- ensure landing hero "Order Now" CTA forwards restaurant_id to menu

## Testing
- `npm run test:ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d8a92c1dc832582d06b64c0817a6e