### PR TITLE
fix(customer-ui): restore Plate labels and modal footer layout

### DIFF
--- a/components/CartDrawer.tsx
+++ b/components/CartDrawer.tsx
@@ -117,7 +117,7 @@ function CartContent({ onClose }: { onClose?: () => void }) {
           onClick={clearCart}
           className="w-full px-4 py-2 bg-gray-200 rounded hover:bg-gray-300"
         >
-          Clear Cart
+          Clear Plate
         </button>
         <button
           type="button"

--- a/components/CartTest.tsx
+++ b/components/CartTest.tsx
@@ -29,7 +29,7 @@ export default function CartTest() {
           onClick={clearCart}
           className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300"
         >
-          Clear Cart
+          Clear Plate
         </button>
       </div>
     </div>

--- a/components/MenuItemCard.tsx
+++ b/components/MenuItemCard.tsx
@@ -178,11 +178,12 @@ export default function MenuItemCard({
               </button>
             </div>
             <button
-              aria-label="Confirm Add to Cart"
+              aria-label="Confirm Add to Plate"
               onClick={handleFinalAdd}
-              className="px-4 py-2 rounded hover:opacity-90 btn-primary"
+              className="px-4 py-2 rounded hover:opacity-90 btn-primary flex items-center gap-2"
             >
-              Add to Cart
+              <PlateAdd size={18} />
+              Add to Plate
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add PlateAdd icon and "Add to Plate" label in menu item modal footer
- rename cart clearing button to "Clear Plate"
- update test component label for plate clearing

## Testing
- `npm run test:ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689db50796948325996385a1e8c294a0