### PR TITLE
fix(menu): include dietary flags in customer query & persist item_addon_links on admin save (no UI changes)

### DIFF
--- a/components/AddItemModal.tsx
+++ b/components/AddItemModal.tsx
@@ -5,6 +5,7 @@ import { Trash2 } from 'lucide-react';
 import { supabase } from '../utils/supabaseClient';
 import CategoryMultiSelect from './CategoryMultiSelect';
 import AddonMultiSelect from './AddonMultiSelect';
+import { updateItemAddonLinks } from '../utils/updateItemAddonLinks';
 
 interface AddItemModalProps {
   showModal: boolean;
@@ -249,6 +250,11 @@ export default function AddItemModal({
             category_id: String(cid),
           }))
         );
+      }
+      try {
+        await updateItemAddonLinks(String(data.id), selectedAddons);
+      } catch (err: any) {
+        alert('Failed to update addon links: ' + (err?.message || err));
       }
     }
 

--- a/pages/restaurant/menu.tsx
+++ b/pages/restaurant/menu.tsx
@@ -44,6 +44,7 @@ interface Item {
   description: string | null;
   price: number;
   image_url: string | null;
+  is_vegan: boolean | null;
   is_vegetarian: boolean | null;
   is_18_plus: boolean | null;
   available?: boolean | null;
@@ -103,7 +104,7 @@ export default function RestaurantMenuPage() {
         .from("menu_categories")
         .select(
           `id,name,description,image_url,sort_order,restaurant_id,menu_items!inner(
-            id,name,description,price,image_url,is_vegetarian,is_18_plus,stock_status,available,category_id,sort_order,
+            id,name,description,price,image_url,is_vegetarian,is_vegan,is_18_plus,stock_status,available,category_id,sort_order,
             menu_item_categories(category_id)
           )`,
         )
@@ -139,6 +140,7 @@ export default function RestaurantMenuPage() {
               price: it.price,
               image_url: it.image_url,
               is_vegetarian: it.is_vegetarian,
+              is_vegan: it.is_vegan,
               is_18_plus: it.is_18_plus,
               available: it.available,
               stock_status: it.stock_status,


### PR DESCRIPTION
## Summary
- include is_vegetarian, is_vegan, and is_18_plus in customer menu query
- update admin item save flow to replace item_addon_links

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689dd5fb2ad48325a00387cd31786de8