### PR TITLE
Fix Supabase env usage for menu builder and publishing

### DIFF
--- a/lib/menuBuilderDraft.ts
+++ b/lib/menuBuilderDraft.ts
@@ -9,25 +9,33 @@ export type MenuBuilderDraft = {
 
 export async function loadDraft(
   supabase: SupabaseClient,
+  userId: string,
   restaurantId: string
 ) {
   return supabase
     .from('menu_builder_drafts')
     .select('id, restaurant_id, payload, updated_at')
+    .eq('user_id', userId)
     .eq('restaurant_id', restaurantId)
-    .single();
+    .maybeSingle();
 }
 
 export async function saveDraft(
   supabase: SupabaseClient,
+  userId: string,
   restaurantId: string,
   payload: MenuBuilderDraft
 ) {
   return supabase
     .from('menu_builder_drafts')
     .upsert(
-      { restaurant_id: restaurantId, payload, updated_at: new Date().toISOString() },
-      { onConflict: 'restaurant_id' }
+      {
+        user_id: userId,
+        restaurant_id: restaurantId,
+        payload,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'user_id,restaurant_id' }
     )
     .select('id')
     .single();

--- a/lib/supabaseAdmin.ts
+++ b/lib/supabaseAdmin.ts
@@ -1,0 +1,13 @@
+import { createClient } from '@supabase/supabase-js';
+
+export function getSupabaseAdmin() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    if (process.env.NODE_ENV === 'development') {
+      console.error('Supabase admin env missing');
+    }
+    throw new Error('Missing service env');
+  }
+  return createClient(url, key, { auth: { persistSession: false } });
+}

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,0 +1,14 @@
+import { createBrowserSupabaseClient } from '@supabase/auth-helpers-nextjs';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  if (process.env.NODE_ENV === 'development') {
+    console.error('Supabase client (browser) env missing');
+  }
+  throw new Error('Supabase client env missing');
+}
+
+// Create a single browser client instance to be shared across the app
+export const supabase = createBrowserSupabaseClient();

--- a/supabase/migrations/20250723120000_create_menu_builder_drafts.sql
+++ b/supabase/migrations/20250723120000_create_menu_builder_drafts.sql
@@ -1,9 +1,25 @@
 CREATE TABLE IF NOT EXISTS public.menu_builder_drafts (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
   restaurant_id uuid NOT NULL REFERENCES public.restaurants(id) ON DELETE CASCADE,
   payload jsonb NOT NULL,
   updated_at timestamptz NOT NULL DEFAULT now()
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS menu_builder_drafts_restaurant_id_uidx
-  ON public.menu_builder_drafts(restaurant_id);
+CREATE UNIQUE INDEX IF NOT EXISTS menu_builder_drafts_user_restaurant_uidx
+  ON public.menu_builder_drafts(user_id, restaurant_id);
+
+ALTER TABLE public.menu_builder_drafts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "menu_builder_drafts_user"
+  ON public.menu_builder_drafts FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "menu_builder_drafts_insert"
+  ON public.menu_builder_drafts FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "menu_builder_drafts_update"
+  ON public.menu_builder_drafts FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);

--- a/utils/getAddonsForItem.ts
+++ b/utils/getAddonsForItem.ts
@@ -1,39 +1,47 @@
-import { supabase } from './supabaseClient';
+import { supabase } from '../lib/supabaseClient';
 import type { AddonGroup } from './types';
 
 /**
- * Fetch addon groups and options for a menu item via item_addon_links.
+ * Fetch addon groups and options for a menu item.
  */
 export async function getAddonsForItem(
   itemId: number | string
 ): Promise<AddonGroup[]> {
   const { data, error } = await supabase
-    .from('item_addon_links')
-    .select('group_id, addon_groups(*, addon_options(*))')
+    .from('view_addons_for_item')
+    .select('*')
     .eq('item_id', itemId);
 
   if (error) throw error;
 
+  const map = new Map<string, AddonGroup>();
+  (data || []).forEach((row: any) => {
+    const gid = String(row.addon_group_id);
+    if (!map.has(gid)) {
+      map.set(gid, {
+        id: gid,
+        group_id: gid,
+        name: row.addon_group_name,
+        required: row.required,
+        multiple_choice: row.multiple_choice,
+        max_group_select: row.max_group_select,
+        max_option_quantity: row.max_option_quantity,
+        addon_options: [],
+      });
+    }
+    if (row.addon_option_id) {
+      map.get(gid)!.addon_options.push({
+        id: String(row.addon_option_id),
+        name: row.addon_option_name,
+        price: row.price,
+        image_url: null,
+      });
+    }
+  });
+
   if (process.env.NODE_ENV === 'development') {
-    console.debug('[customer:addons]', { itemId, groups: data?.length || 0 });
+    console.debug('[customer:addons]', { itemId, groups: map.size });
   }
 
-  return (data || []).map((row: any) => {
-    const g = row.addon_groups || {};
-    return {
-      id: String(row.group_id || g.id),
-      group_id: String(row.group_id || g.id),
-      name: g.name,
-      required: g.required,
-      multiple_choice: g.multiple_choice,
-      max_group_select: g.max_group_select,
-      max_option_quantity: g.max_option_quantity,
-      addon_options: (g.addon_options || []).map((opt: any) => ({
-        id: String(opt.id),
-        name: opt.name,
-        price: opt.price,
-        image_url: opt.image_url ?? null,
-      })),
-    } as AddonGroup;
-  });
+  return Array.from(map.values());
 }

--- a/utils/supabaseClient.ts
+++ b/utils/supabaseClient.ts
@@ -1,12 +1,1 @@
-import { createBrowserSupabaseClient } from '@supabase/auth-helpers-nextjs';
-
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-if (!supabaseUrl || !supabaseAnonKey) {
-  console.error('Supabase environment variables are missing.');
-  throw new Error('Supabase is not configured');
-}
-
-// Create a single browser client instance to be shared across the app
-export const supabase = createBrowserSupabaseClient();
+export { supabase } from '../lib/supabaseClient';

--- a/utils/supabaseServer.ts
+++ b/utils/supabaseServer.ts
@@ -1,7 +1,5 @@
-import { createClient } from '@supabase/supabase-js';
+import { getSupabaseAdmin } from '../lib/supabaseAdmin';
 
 export function supaService() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY!;
-  return createClient(url, key, { auth: { persistSession: false } });
+  return getSupabaseAdmin();
 }


### PR DESCRIPTION
## Summary
- split Supabase browser and admin clients with strict env checks
- persist menu builder drafts per user+restaurant and publish with service client
- load addon links from view_addons_for_item to stop 404s

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f784f2d908325a0db93bedaa78437