### PR TITLE
Fix menu builder server publishing flow

### DIFF
--- a/lib/supaServer.ts
+++ b/lib/supaServer.ts
@@ -12,3 +12,13 @@ export function getServerClient() {
   return createClient(url, key, { auth: { persistSession: false } });
 }
 
+// Pre-initialized service-role client for server usage (may be null if env missing)
+let supa: ReturnType<typeof getServerClient> | null = null;
+try {
+  supa = getServerClient();
+} catch {
+  supa = null;
+}
+export const supaServer = supa;
+
+

--- a/supabase/migrations/20250724160000_rename_payload_to_data.sql
+++ b/supabase/migrations/20250724160000_rename_payload_to_data.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.menu_builder_drafts
+  RENAME COLUMN payload TO data;


### PR DESCRIPTION
## Summary
- use service-role Supabase client on server
- expose draft, addon groups and links via updated menu-builder API
- handle publish failures with descriptive hints in dev and rename draft payload column

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_68a0829ab2f483258d8a22c64ff4bfac