### PR TITLE
Fix draft menu save and publish flow

### DIFF
--- a/lib/supaBrowser.ts
+++ b/lib/supaBrowser.ts
@@ -1,14 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 
-export function getBrowserClient() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-  if (!url || !key) {
-    if (process.env.NODE_ENV !== 'production') {
-      console.error('Supabase client env missing');
-    }
-    throw new Error('Supabase client env missing');
-  }
-  return createClient(url, key);
-}
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+if (!url || !anon) throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY');
+export const supaBrowser = () => createClient(url, anon);
 

--- a/lib/supaServer.ts
+++ b/lib/supaServer.ts
@@ -1,24 +1,9 @@
 import { createClient } from '@supabase/supabase-js';
 
-export function getServerClient() {
+export function supaServer() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (!url || !key) {
-    if (process.env.NODE_ENV !== 'production') {
-      console.error('[supaServer] missing env');
-    }
-    throw new Error('missing_env');
-  }
-  return createClient(url, key, { auth: { persistSession: false } });
+  const service = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !service) throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  return createClient(url, service, { auth: { persistSession: false } });
 }
-
-// Pre-initialized service-role client for server usage (may be null if env missing)
-let supa: ReturnType<typeof getServerClient> | null = null;
-try {
-  supa = getServerClient();
-} catch {
-  supa = null;
-}
-export const supaServer = supa;
-
 

--- a/pages/api/menu-builder.ts
+++ b/pages/api/menu-builder.ts
@@ -1,243 +1,57 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { supaServer } from '@/lib/supaServer';
 
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse
-) {
-  const restaurantId =
-    req.method === 'GET'
-      ? (req.query.restaurant_id as string | undefined)
-      : (req.body?.restaurantId as string | undefined);
+type DraftPayload = {
+  categories: Array<{ id?: string; tempId?: string; name: string; description?: string|null; sort_order?: number; image_url?: string|null }>;
+  items: Array<{
+    id?: string; tempId?: string; name: string; description?: string|null; price?: number|null;
+    image_url?: string|null; is_vegetarian?: boolean; is_vegan?: boolean; is_18_plus?: boolean;
+    stock_status?: string|null; available?: boolean; category_id?: string; sort_order?: number
+  }>;
+  links?: Array<{ item_id: string; group_id: string }>; // IMPORTANT: group_id (schema uses group_id)
+};
 
-  if (!restaurantId) {
-    return res.status(400).json({ error: 'missing_restaurant_id' });
-  }
-
-  const supabase = supaServer;
-  let step = '';
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const supabase = supaServer();
 
   try {
     if (req.method === 'GET') {
-      step = 'load-draft';
+      const restaurantId = (req.query.restaurant_id as string) || (req.query.rid as string);
+      if (!restaurantId) return res.status(400).json({ error: 'restaurant_id is required' });
+
       const { data, error } = await supabase
         .from('menu_builder_drafts')
-        .select('data')
+        .select('payload')
         .eq('restaurant_id', restaurantId)
-        .order('updated_at', { ascending: false })
-        .limit(1)
         .maybeSingle();
-      if (error) throw { step, error };
-      const draft = data?.data || null;
-      if (req.query.withAddons === '1') {
-        step = 'load-addon-groups';
-        const { data: groups, error: grpErr } = await supabase
-          .from('addon_groups')
-          .select('*')
-          .eq('restaurant_id', restaurantId)
-          .order('id');
-        if (grpErr) throw { step, error: grpErr };
-        step = 'load-addon-links';
-        const { data: linksData, error: linkErr } = await supabase
-          .from('item_addon_links')
-          .select('item_id,group_id,menu_items!inner(restaurant_id)')
-          .eq('menu_items.restaurant_id', restaurantId);
-        if (linkErr) throw { step, error: linkErr };
-        const addonLinks = (linksData || []).map((r: any) => ({
-          item_id: r.item_id,
-          group_id: r.group_id,
-        }));
-        return res
-          .status(200)
-          .json({ draft, addonGroups: groups || [], addonLinks });
+
+      if (error) {
+        console.error('[draft:load]', error);
+        return res.status(500).json({ where: 'draft_load', error: error.message, code: error.code, details: error.details });
       }
-      return res.status(200).json({ draft });
+      return res.status(200).json({ payload: data?.payload ?? null });
     }
 
     if (req.method === 'PUT') {
-      step = 'save-draft';
-      const data = req.body?.data;
-      if (!data || typeof data !== 'object') {
-        return res.status(400).json({ error: 'missing_data' });
-      }
+      const { restaurantId, draft } = req.body as { restaurantId?: string; draft?: DraftPayload };
+      if (!restaurantId || !draft) return res.status(400).json({ error: 'restaurantId and draft are required' });
+
       const { error } = await supabase
         .from('menu_builder_drafts')
-        .upsert(
-          {
-            restaurant_id: restaurantId,
-            data,
-            updated_at: new Date().toISOString(),
-          },
-          { onConflict: 'restaurant_id' }
-        );
-      if (error) throw { step, error };
+        .upsert({ restaurant_id: restaurantId, payload: draft, updated_at: new Date().toISOString() }, { onConflict: 'restaurant_id' });
+
+      if (error) {
+        console.error('[draft:save]', error);
+        return res.status(500).json({ where: 'draft_save', error: error.message, code: error.code, details: error.details });
+      }
       return res.status(200).json({ ok: true });
     }
 
-    if (req.method === 'POST') {
-      let archivedItems = 0;
-      let archivedCats = 0;
-      let insertedCats = 0;
-      let insertedItems = 0;
-      let insertedLinks = 0;
-
-      step = 'load-draft';
-      const { data: draftRow, error: draftErr } = await supabase
-        .from('menu_builder_drafts')
-        .select('data')
-        .eq('restaurant_id', restaurantId)
-        .order('updated_at', { ascending: false })
-        .limit(1)
-        .maybeSingle();
-      if (draftErr) throw { step, error: draftErr };
-      if (!draftRow || !draftRow.data) {
-        return res.status(400).json({ error: 'no_draft' });
-      }
-      const draft = draftRow.data as any;
-
-      step = 'load-live';
-      const { data: existingItems, error: itemsErr } = await supabase
-        .from('menu_items')
-        .select('id')
-        .eq('restaurant_id', restaurantId)
-        .is('archived_at', null);
-      if (itemsErr) throw { step, error: itemsErr };
-      const { data: existingCats, error: catsErr } = await supabase
-        .from('menu_categories')
-        .select('id')
-        .eq('restaurant_id', restaurantId)
-        .is('archived_at', null);
-      if (catsErr) throw { step, error: catsErr };
-
-      const now = new Date().toISOString();
-
-      if (existingItems?.length) {
-        step = 'archive-live';
-        const { error: archItemsErr } = await supabase
-          .from('menu_items')
-          .update({ archived_at: now })
-          .in('id', existingItems.map((r: any) => r.id));
-        if (archItemsErr) throw { step, error: archItemsErr };
-        archivedItems = existingItems.length;
-
-        const { error: delLinksErr } = await supabase
-          .from('item_addon_links')
-          .delete()
-          .in('item_id', existingItems.map((r: any) => r.id));
-        if (delLinksErr) throw { step: 'insert-links', error: delLinksErr };
-      }
-
-      if (existingCats?.length) {
-        step = 'archive-live';
-        const { error: archCatsErr } = await supabase
-          .from('menu_categories')
-          .update({ archived_at: now })
-          .in('id', existingCats.map((r: any) => r.id));
-        if (archCatsErr) throw { step, error: archCatsErr };
-        archivedCats = existingCats.length;
-      }
-
-      const catIdMap = new Map<string, number>();
-      if (Array.isArray(draft.categories)) {
-        step = 'insert-cats';
-        for (const c of draft.categories) {
-          const { data: inserted, error } = await supabase
-            .from('menu_categories')
-            .insert({
-              restaurant_id: restaurantId,
-              name: c.name,
-              description: c.description,
-              sort_order: c.sort_order,
-              image_url: c.image_url,
-            })
-            .select('id')
-            .single();
-          if (error || !inserted) throw { step, error };
-          catIdMap.set(String(c.id ?? c.tempId), inserted.id);
-          insertedCats++;
-        }
-      }
-
-      if (Array.isArray(draft.items)) {
-        step = 'insert-items';
-        for (const it of draft.items) {
-          const catId = it.category_id
-            ? catIdMap.get(String(it.category_id)) || null
-            : null;
-          const { data: inserted, error } = await supabase
-            .from('menu_items')
-            .insert({
-              restaurant_id: restaurantId,
-              name: it.name,
-              description: it.description,
-              price: it.price,
-              image_url: it.image_url,
-              is_vegetarian: it.is_vegetarian,
-              is_vegan: it.is_vegan,
-              is_18_plus: it.is_18_plus,
-              stock_status: it.stock_status,
-              available: it.available,
-              sort_order: it.sort_order,
-              out_of_stock_until: it.out_of_stock_until,
-              stock_return_date: it.stock_return_date,
-              category_id: catId,
-            })
-            .select('id')
-            .single();
-          if (error || !inserted) throw { step, error };
-          insertedItems++;
-
-          if (Array.isArray(it.addons)) {
-            for (const gid of it.addons) {
-              step = 'insert-links';
-              const { error: linkErr } = await supabase
-                .from('item_addon_links')
-                .insert({ item_id: inserted.id, group_id: gid });
-              if (linkErr) throw { step, error: linkErr };
-              insertedLinks++;
-            }
-          }
-        }
-      }
-
-      if (process.env.NODE_ENV !== 'production') {
-        console.debug('[publish-menu]', {
-          archivedCats,
-          archivedItems,
-          insertedCats,
-          insertedItems,
-          insertedLinks,
-        });
-      }
-
-      return res.status(200).json({
-        ok: true,
-        counts: {
-          archivedCats,
-          archivedItems,
-          insertedCats,
-          insertedItems,
-          insertedLinks,
-        },
-      });
-    }
-
-    res.setHeader('Allow', 'GET,PUT,POST');
-    return res.status(405).json({ error: 'method_not_allowed' });
-  } catch (err: any) {
-    const stepName = err.step || step;
-    const supErr = err.error || err;
-    console.error(err);
-    if (process.env.NODE_ENV !== 'production') {
-      console.error('[api/menu-builder]', stepName, supErr);
-      if (req.method === 'POST') {
-        console.error('[publish-menu]', stepName, supErr);
-      }
-      return res
-        .status(500)
-        .json({ error: supErr?.message || 'server_error', hint: stepName });
-    }
-    return res.status(500).json({ error: 'server_error' });
+    res.setHeader('Allow', ['GET', 'PUT']);
+    return res.status(405).end('Method Not Allowed');
+  } catch (e: any) {
+    console.error('[draft:unhandled]', e);
+    return res.status(500).json({ where: 'draft_unhandled', error: e?.message || 'server_error' });
   }
 }
 

--- a/pages/api/publish-menu.ts
+++ b/pages/api/publish-menu.ts
@@ -1,0 +1,212 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { supaServer } from '@/lib/supaServer';
+
+type DraftPayload = {
+  categories: Array<{ id?: string; tempId?: string; name: string; description?: string|null; sort_order?: number; image_url?: string|null }>;
+  items: Array<{
+    id?: string; tempId?: string; name: string; description?: string|null; price?: number|null;
+    image_url?: string|null; is_vegetarian?: boolean; is_vegan?: boolean; is_18_plus?: boolean;
+    stock_status?: string|null; available?: boolean; category_id?: string; sort_order?: number
+  }>;
+  links?: Array<{ item_id: string; group_id: string }>; // IMPORTANT: group_id
+};
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const supabase = supaServer();
+
+  try {
+    const { restaurantId } = req.body as { restaurantId?: string };
+    if (!restaurantId) return res.status(400).json({ error: 'restaurantId is required' });
+
+    // 1) Load draft
+    const { data: draftRow, error: loadErr } = await supabase
+      .from('menu_builder_drafts')
+      .select('payload')
+      .eq('restaurant_id', restaurantId)
+      .maybeSingle();
+    if (loadErr) {
+      console.error('[publish:loadDraft]', loadErr);
+      return res.status(500).json({ where: 'load_draft', error: loadErr.message, code: loadErr.code, details: loadErr.details });
+    }
+    const draft = draftRow?.payload as DraftPayload | undefined;
+    if (!draft) return res.status(400).json({ error: 'No draft to publish' });
+
+    // Counters
+    let deletedLinks = 0, deletedItems = 0, deletedCats = 0;
+    let archivedLinks = 0, archivedItems = 0, archivedCats = 0;
+    let insertedCats = 0, insertedItems = 0, insertedLinks = 0;
+
+    // 2) Try HARD-DELETE current live data (links -> items -> categories)
+    try {
+      const { data: liveItems, error: liveErr } = await supabase
+        .from('menu_items')
+        .select('id')
+        .eq('restaurant_id', restaurantId)
+        .is('archived_at', null);
+      if (liveErr) throw liveErr;
+      const liveItemIds = (liveItems ?? []).map((r: any) => r.id);
+
+      if (liveItemIds.length > 0) {
+        const { data: delLinks, error: delLinksErr } = await supabase
+          .from('item_addon_links')
+          .delete()
+          .in('item_id', liveItemIds)
+          .select('id');
+        if (delLinksErr) throw delLinksErr;
+        deletedLinks = delLinks?.length ?? 0;
+      }
+
+      const { data: delItems, error: delItemsErr } = await supabase
+        .from('menu_items')
+        .delete()
+        .eq('restaurant_id', restaurantId)
+        .is('archived_at', null)
+        .select('id');
+      if (delItemsErr) throw delItemsErr;
+      deletedItems = delItems?.length ?? 0;
+
+      const { data: delCats, error: delCatsErr } = await supabase
+        .from('menu_categories')
+        .delete()
+        .eq('restaurant_id', restaurantId)
+        .is('archived_at', null)
+        .select('id');
+      if (delCatsErr) throw delCatsErr;
+      deletedCats = delCats?.length ?? 0;
+
+    } catch (hardDeleteErr: any) {
+      // FK violation (due to order_items) → ARCHIVE instead (so customer never sees old rows)
+      console.error('[publish:hardDeleteFallback]', hardDeleteErr);
+
+      const { data: archItems, error: archItemsErr } = await supabase
+        .from('menu_items')
+        .update({ archived_at: new Date().toISOString() })
+        .eq('restaurant_id', restaurantId)
+        .is('archived_at', null)
+        .select('id');
+      if (archItemsErr) {
+        console.error('[publish:archiveItems]', archItemsErr);
+        return res.status(500).json({ where: 'archive_items', error: archItemsErr.message, code: archItemsErr.code, details: archItemsErr.details });
+      }
+      const archivedItemIds = archItems?.map((r: any) => r.id) ?? [];
+      archivedItems = archivedItemIds.length;
+
+      if (archivedItemIds.length > 0) {
+        const { data: delLinks, error: delLinksErr } = await supabase
+          .from('item_addon_links')
+          .delete()
+          .in('item_id', archivedItemIds)
+          .select('id');
+        if (delLinksErr) {
+          console.error('[publish:deleteLinksForArchived]', delLinksErr);
+          return res.status(500).json({ where: 'delete_archived_links', error: delLinksErr.message, code: delLinksErr.code, details: delLinksErr.details });
+        }
+        archivedLinks = delLinks?.length ?? 0;
+      }
+
+      const { data: archCats, error: archCatsErr } = await supabase
+        .from('menu_categories')
+        .update({ archived_at: new Date().toISOString() })
+        .eq('restaurant_id', restaurantId)
+        .is('archived_at', null)
+        .select('id');
+      if (archCatsErr) {
+        console.error('[publish:archiveCats]', archCatsErr);
+        return res.status(500).json({ where: 'archive_categories', error: archCatsErr.message, code: archCatsErr.code, details: archCatsErr.details });
+      }
+      archivedCats = archCats?.length ?? 0;
+    }
+
+    // 3) Insert categories (set restaurant_id explicitly; keep sort_order)
+    const catIdMap = new Map<string, string>();
+    for (const [idx, c] of (draft.categories ?? []).entries()) {
+      const { data: inserted, error } = await supabase
+        .from('menu_categories')
+        .insert({
+          restaurant_id: restaurantId, // schema allows, even without FK constraint
+          name: c.name,
+          description: c.description ?? null,
+          sort_order: c.sort_order ?? idx,
+          image_url: c.image_url ?? null,
+          archived_at: null,
+        })
+        .select('id')
+        .single();
+
+      if (error || !inserted) {
+        console.error('[publish:insertCategory]', error);
+        return res.status(500).json({ where: 'insert_category', error: error?.message || 'Insert category failed', code: error?.code, details: error?.details });
+      }
+      const key = (c.tempId ?? c.id) as string | undefined;
+      if (key) catIdMap.set(key, inserted.id);
+      insertedCats++;
+    }
+
+    // 4) Insert items (map category_id if provided; allow null if schema allows)
+    const itemIdMap = new Map<string, string>();
+    for (const [idx, it] of (draft.items ?? []).entries()) {
+      const mappedCat = it.category_id ? (catIdMap.get(it.category_id) ?? null) : null;
+
+      const { data: inserted, error } = await supabase
+        .from('menu_items')
+        .insert({
+          restaurant_id: restaurantId,
+          category_id: mappedCat, // schema shows nullable
+          name: it.name,
+          description: it.description ?? null,
+          price: it.price ?? null,
+          image_url: it.image_url ?? null,
+          is_vegetarian: it.is_vegetarian ?? false,
+          is_vegan: it.is_vegan ?? false,
+          is_18_plus: it.is_18_plus ?? false,
+          available: it.available ?? true,
+          out_of_stock_until: null,
+          sort_order: it.sort_order ?? idx,
+          out_of_stock: false,
+          stock_status: it.stock_status ?? 'in_stock',
+          stock_return_date: null,
+          archived_at: null,
+        })
+        .select('id')
+        .single();
+
+      if (error || !inserted) {
+        console.error('[publish:insertItem]', error);
+        return res.status(500).json({ where: 'insert_item', error: error?.message || 'Insert item failed', code: error?.code, details: error?.details });
+      }
+      const key = (it.tempId ?? it.id) as string | undefined;
+      if (key) itemIdMap.set(key, inserted.id);
+      insertedItems++;
+    }
+
+    // 5) Insert item_addon_links (schema uses group_id)
+    for (const l of (draft.links ?? [])) {
+      const newItemId = itemIdMap.get(l.item_id) || l.item_id;
+      if (!newItemId || !l.group_id) continue;
+      const { error } = await supabase
+        .from('item_addon_links')
+        .insert({ item_id: newItemId, group_id: l.group_id });
+      if (error) {
+        console.error('[publish:insertLink]', error);
+        return res.status(500).json({ where: 'insert_link', error: error.message, code: error.code, details: error.details });
+      }
+      insertedLinks++;
+    }
+
+    return res.status(200).json({
+      deleted:  { categories: deletedCats, items: deletedItems, links: deletedLinks },
+      archived: { categories: archivedCats, items: archivedItems, links: archivedLinks },
+      inserted: { categories: insertedCats, items: insertedItems, links: insertedLinks },
+    });
+
+  } catch (e: any) {
+    console.error('[publish:unhandled]', e);
+    return res.status(500).json({ where: 'unhandled', error: e?.message || 'server_error' });
+  }
+}
+

--- a/pages/restaurant/menu.tsx
+++ b/pages/restaurant/menu.tsx
@@ -107,7 +107,8 @@ export default function RestaurantMenuPage() {
         .from('menu_categories')
         .select('id,name,description,image_url,sort_order,restaurant_id')
         .eq('restaurant_id', restaurantId)
-        .order('sort_order', { ascending: true, nullsFirst: false })
+        .is('archived_at', null)
+        .order('sort_order', { ascending: true })
         .order('name', { ascending: true });
 
       const { data: itemData, error: itemErr } = await supabase
@@ -116,7 +117,8 @@ export default function RestaurantMenuPage() {
           'id,name,description,price,image_url,is_vegetarian,is_vegan,is_18_plus,available,out_of_stock_until,sort_order,stock_status,stock_return_date,category_id'
         )
         .eq('restaurant_id', restaurantId)
-        .order('sort_order', { ascending: true, nullsFirst: false })
+        .is('archived_at', null)
+        .order('sort_order', { ascending: true })
         .order('name', { ascending: true });
 
       const liveItemIds = (itemData || []).map((r: any) => r.id);

--- a/supabase/migrations/20250816_141000_add_archived_at.sql
+++ b/supabase/migrations/20250816_141000_add_archived_at.sql
@@ -1,0 +1,7 @@
+alter table if exists public.menu_items      add column if not exists archived_at timestamptz;
+alter table if exists public.menu_categories add column if not exists archived_at timestamptz;
+
+create index if not exists idx_menu_items_restaurant_live
+  on public.menu_items(restaurant_id, archived_at);
+create index if not exists idx_menu_categories_restaurant_live
+  on public.menu_categories(restaurant_id, archived_at);

--- a/supabase/migrations/20250816_141100_create_menu_builder_drafts.sql
+++ b/supabase/migrations/20250816_141100_create_menu_builder_drafts.sql
@@ -1,0 +1,21 @@
+create extension if not exists pgcrypto;
+
+create table if not exists public.menu_builder_drafts (
+  id uuid primary key default gen_random_uuid(),
+  restaurant_id uuid not null references public.restaurants(id) on delete cascade,
+  payload jsonb not null default '{}'::jsonb,
+  updated_at timestamptz not null default now()
+);
+
+create unique index if not exists idx_drafts_restaurant_id
+  on public.menu_builder_drafts(restaurant_id);
+
+alter table public.menu_builder_drafts enable row level security;
+
+-- Server API uses service role; allow it explicitly.
+drop policy if exists drafts_service_bypass on public.menu_builder_drafts;
+create policy drafts_service_bypass
+  on public.menu_builder_drafts for all
+  to service_role
+  using (true)
+  with check (true);


### PR DESCRIPTION
## Summary
- add dedicated supaBrowser/supaServer helpers
- support draft load/save and publishing via new API routes
- filter archived menu rows and hard-delete or archive on publish

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_68a08dfad3148325b940e7c318d1abcf