### PR TITLE
fix(menu-builder): upsert via table and debounce saves

### DIFF
--- a/__tests__/menuBuilderApi.test.ts
+++ b/__tests__/menuBuilderApi.test.ts
@@ -5,7 +5,10 @@ import publishHandler from '../pages/api/publish-menu';
 import { supaServer } from '../lib/supaServer';
 
 describe('menu builder API', () => {
-  if (!process.env.SUPABASE_SERVICE_ROLE_KEY || !process.env.NEXT_PUBLIC_SUPABASE_URL) {
+  if (
+    !process.env.SUPABASE_SERVICE_ROLE_KEY ||
+    !(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL)
+  ) {
     test.skip('Supabase env not configured', () => {});
     return;
   }
@@ -26,9 +29,10 @@ describe('menu builder API', () => {
       method: 'PUT',
       body: { restaurantId: rid, draft },
     });
-    await menuHandler(req, res);
-    expect(res._getStatusCode()).toBe(200);
-    expect(JSON.parse(res._getData()).ok).toBe(true);
+      await menuHandler(req, res);
+      expect(res._getStatusCode()).toBe(200);
+      const saved = JSON.parse(res._getData());
+      expect(saved.draft).toBeDefined();
 
     ({ req, res } = createMocks({ method: 'POST', body: { restaurantId: rid } }));
     await publishHandler(req, res);

--- a/lib/supaServer.ts
+++ b/lib/supaServer.ts
@@ -1,9 +1,10 @@
 import { createClient } from '@supabase/supabase-js';
 
 export function supaServer() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
   const service = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (!url || !service) throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  if (!url || !service)
+    throw new Error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
   return createClient(url, service, { auth: { persistSession: false } });
 }
 


### PR DESCRIPTION
## Summary
- use server-side Supabase credentials and resolve tenant id per request
- read/write drafts through `menu_drafts` table with onConflict
- debounce autosave and cancel in-flight requests in menu builder UI

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_68a351232b5483258a9dcacff684a9c6