### PR TITLE
fix: exclude archived rows from live menu queries

### DIFF
--- a/components/StockTabLoader.tsx
+++ b/components/StockTabLoader.tsx
@@ -28,7 +28,8 @@ SELECT
   i.stock_status,
   i.stock_return_date
 FROM menu_categories c
-JOIN menu_items i ON i.category_id = c.id;`;
+JOIN menu_items i ON i.category_id = c.id
+WHERE c.archived_at IS NULL AND i.archived_at IS NULL;`;
       const { data, error } = await supabase.rpc('sql', { query });
       if (error) {
         console.error('Failed to fetch stock data', error);

--- a/pages/dashboard/menu-builder.tsx
+++ b/pages/dashboard/menu-builder.tsx
@@ -234,11 +234,13 @@ export default function MenuBuilder() {
         .from('menu_categories')
         .select('*')
         .eq('restaurant_id', rid)
+        .is('archived_at', null)
         .order('sort_order', { ascending: true });
       const { data: itemData } = await supabase
         .from('menu_items')
         .select('id,name,category_id,stock_status,stock_return_date')
-        .eq('restaurant_id', rid);
+        .eq('restaurant_id', rid)
+        .is('archived_at', null);
       const mappedCats = (catData || []).map((c) => ({
         id: String(c.id),
         name: c.name,
@@ -255,13 +257,15 @@ export default function MenuBuilder() {
       const { data: groups } = await supabase
         .from('addon_groups')
         .select('id')
-        .eq('restaurant_id', rid);
+        .eq('restaurant_id', rid)
+        .is('archived_at', null);
       let mappedAddons: StockTabProps['addons'] = [];
       if (groups && groups.length) {
         const { data: opts } = await supabase
           .from('addon_options')
           .select('id,name,group_id,stock_status,stock_return_date')
-          .in('group_id', groups.map((g) => g.id));
+          .in('group_id', groups.map((g) => g.id))
+          .is('archived_at', null);
         mappedAddons = (opts || []).map((o) => ({
           id: String(o.id),
           name: o.name,
@@ -434,12 +438,14 @@ export default function MenuBuilder() {
       .from('menu_categories')
       .select('*')
       .eq('restaurant_id', rid)
+      .is('archived_at', null)
       .order('sort_order', { ascending: true });
 
     const { data: itemsData, error: itemsError } = await supabase
       .from('menu_items')
       .select('*')
       .eq('restaurant_id', rid)
+      .is('archived_at', null)
       .order('sort_order', { ascending: true });
 
     let itemsWithAddons = itemsData || [];

--- a/pages/restaurant/menu.tsx
+++ b/pages/restaurant/menu.tsx
@@ -135,9 +135,14 @@ export default function RestaurantMenuPage() {
         const { data: addData, error: addonErr } = await supabase
           .from('item_addon_links')
           .select(
-            'item_id, addon_groups(id,name,multiple_choice,required,max_group_select,max_option_quantity, addon_options(id,name,price,is_vegetarian,is_vegan,is_18_plus,image_url))'
+            `item_id, addon_groups!inner(
+              id,name,multiple_choice,required,max_group_select,max_option_quantity,
+              addon_options!inner(id,name,price,is_vegetarian,is_vegan,is_18_plus,image_url)
+            )`
           )
-          .in('item_id', liveItemIds);
+          .in('item_id', liveItemIds)
+          .is('addon_groups.archived_at', null)
+          .is('addon_groups.addon_options.archived_at', null);
         if (addonErr) console.error('Failed to fetch addons', addonErr);
         addonRows = addData || [];
       }

--- a/utils/getAddonsForItem.ts
+++ b/utils/getAddonsForItem.ts
@@ -10,9 +10,14 @@ export async function getAddonsForItem(
   const { data, error } = await supabase
     .from('item_addon_links')
     .select(
-      'addon_groups(id,name,required,multiple_choice,max_group_select,max_option_quantity, addon_options(id,name,price,is_vegetarian,is_vegan,is_18_plus,image_url))'
+      `addon_groups!inner(
+        id,name,required,multiple_choice,max_group_select,max_option_quantity,
+        addon_options!inner(id,name,price,is_vegetarian,is_vegan,is_18_plus,image_url)
+      )`
     )
-    .eq('item_id', itemId);
+    .eq('item_id', itemId)
+    .is('addon_groups.archived_at', null)
+    .is('addon_groups.addon_options.archived_at', null);
 
   if (error) throw error;
 


### PR DESCRIPTION
## Summary
- filter out archived categories and items in live menu builder queries
- ignore archived addon groups and options in customer menu and helper
- skip archived menu rows in stock tab SQL loader

## Testing
- `npm test`
- Attempted to verify Supabase queries but got `TypeError: fetch failed`

------
https://chatgpt.com/codex/tasks/task_e_68a35734b55883258f7d7bc85dcba64f