### PR TITLE
fix(menu-header): resolve build by making editor client-only, correcting env/runtime, and fixing types/imports

### DIFF
--- a/pages/dashboard/menu-builder.tsx
+++ b/pages/dashboard/menu-builder.tsx
@@ -373,9 +373,10 @@ export default function MenuBuilder() {
       .from('public-assets')
       .upload(path, imageFile, {
         upsert: true,
-        onUploadProgress: (e) => setUploadPct(Math.round((e?.progress || 0) * 100)),
       });
-    if (upErr) {
+    if (!upErr) {
+      setUploadPct(100);
+    } else {
       console.error('upload failed', upErr);
       setToastMessage('Upload failed');
       setUploadingHero(false);


### PR DESCRIPTION
## Summary
- remove unsupported `onUploadProgress` option from Supabase upload call
- update progress state only when upload succeeds

## Testing
- `pnpm exec tsc --noEmit`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a3633d81688325952481d7d270254e