### PR TITLE
feat: brand color columns and customer navigation fix

### DIFF
--- a/components/branding/BrandProvider.tsx
+++ b/components/branding/BrandProvider.tsx
@@ -3,8 +3,12 @@ import React, { createContext, useContext, useMemo } from 'react';
 import { useRouter } from 'next/router';
 
 type BrandCtx = {
-  brand: string; brand600: string; brand700: string;
-  name: string; initials: string; logoUrl?: string | null;
+  brand: string;
+  brand600: string;
+  brand700: string;
+  name: string;
+  initials: string;
+  logoUrl?: string | null;
   logoShape?: string | null;
 };
 const Ctx = createContext<BrandCtx | null>(null);
@@ -30,12 +34,19 @@ export const BrandProvider: React.FC<{ restaurant?: any; children: React.ReactNo
   const name = (restaurant?.website_title as string) || (restaurant?.name as string) || qp('name') || 'Restaurant';
   const logoUrl = (restaurant?.logo_url as string) || qp('logo') || null;
   const logoShape = (restaurant?.logo_shape as string) || null;
-  const color =
+  const primary =
     (restaurant?.brand_primary_color as string) ||
     (restaurant?.brand_color as string) ||
     qp('brand') ||
     '';
-  const colors = color ? { brand: color, brand600: color, brand700: color } : hashHSL(name);
+  const secondary = (restaurant?.brand_secondary_color as string) || '';
+  const colors = primary
+    ? {
+        brand: primary,
+        brand600: secondary || primary,
+        brand700: secondary || primary,
+      }
+    : hashHSL(name);
   const initials = name.split(' ').map(p => p[0]).join('').slice(0, 2).toUpperCase() || 'R';
 
   const value = useMemo(() => ({ ...colors, name, initials, logoUrl, logoShape }), [colors.brand, colors.brand600, colors.brand700, name, initials, logoUrl, logoShape]);

--- a/components/customer/FooterNav.tsx
+++ b/components/customer/FooterNav.tsx
@@ -50,7 +50,7 @@ export default function FooterNav({ cartCount = 0, hidden }: Props) {
   if (hidden) return null;
 
   return (
-    <nav role="navigation" className="fixed bottom-2 left-1/2 -translate-x-1/2 w-[calc(100%-1rem)] md:hidden z-[40]">
+    <nav role="navigation" className="fixed bottom-2 left-1/2 -translate-x-1/2 w-[calc(100%-1rem)] md:hidden z-40">
       <div className="relative brand-glass rounded-2xl h-14 flex items-center justify-around px-4">
         <NavLink href="/" Icon={Home} label="Home" />
         <NavLink href="menu" Icon={Utensils} label="Menu" />

--- a/supabase/migrations/20250923120000_add_brand_colors_logo_shape.sql
+++ b/supabase/migrations/20250923120000_add_brand_colors_logo_shape.sql
@@ -1,0 +1,18 @@
+ALTER TABLE public.restaurants
+  ADD COLUMN IF NOT EXISTS brand_primary_color text,
+  ADD COLUMN IF NOT EXISTS brand_secondary_color text,
+  ADD COLUMN IF NOT EXISTS brand_color_extracted boolean DEFAULT false,
+  ADD COLUMN IF NOT EXISTS website_title text,
+  ADD COLUMN IF NOT EXISTS menu_description text,
+  ADD COLUMN IF NOT EXISTS logo_shape text;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname='restaurants_logo_shape_check'
+  ) THEN
+    ALTER TABLE public.restaurants
+      ADD CONSTRAINT restaurants_logo_shape_check
+      CHECK (logo_shape IS NULL OR logo_shape IN ('square','round','rectangular'));
+  END IF;
+END$$;


### PR DESCRIPTION
## Summary
- add migration ensuring brand color fields and logo shape check
- restore customer footer navigation links
- wire brand_secondary_color into branding provider

## Testing
- `npm run test:ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4afc248208325bae212b2a1de9a14