### PR TITLE
fix(home): restore first slide; center content responsively; remove logo ring; add subtle text overlay (surgical)

### DIFF
--- a/components/customer/home/LandingHero.tsx
+++ b/components/customer/home/LandingHero.tsx
@@ -1,8 +1,11 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { supabase } from '@/utils/supabaseClient';
 import RestaurantLogo from '../../branding/RestaurantLogo';
 import Button from '../../ui/Button';
 import Skeleton from '../../ui/Skeleton';
+import OpenBadge from '../OpenBadge';
 
 type LandingHeroProps = {
   title: string;
@@ -12,6 +15,7 @@ type LandingHeroProps = {
   imageUrl?: string | null; // optional background image
   logoUrl?: string | null; // avatar/logo
   logoShape?: 'square' | 'round' | 'rectangular' | null;
+  isOpen?: boolean; // optional open state
 };
 
 export default function LandingHero({
@@ -22,7 +26,26 @@ export default function LandingHero({
   imageUrl,
   logoUrl,
   logoShape,
+  isOpen,
 }: LandingHeroProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState<boolean | null>(typeof isOpen === 'boolean' ? isOpen : null);
+
+  useEffect(() => {
+    if (open !== null) return;
+    const pick = (v: string | string[] | undefined) => (Array.isArray(v) ? v[0] : v);
+    const rid = pick(router.query.restaurant_id as any) || pick(router.query.id as any) || pick(router.query.r as any);
+    if (!rid) return;
+    supabase
+      .from('restaurants')
+      .select('is_open')
+      .eq('id', rid)
+      .maybeSingle()
+      .then(({ data }) => {
+        if (typeof data?.is_open === 'boolean') setOpen(data.is_open);
+      });
+  }, [open, router.query]);
+
   return (
     <section className="relative w-full min-h-[70vh] sm:min-h-[80vh] overflow-hidden rounded-2xl">
       <div
@@ -34,7 +57,7 @@ export default function LandingHero({
 
       {/* Centered content */}
       <div className="absolute inset-0 flex items-center justify-center p-4">
-        <div className="flex flex-col items-center text-center gap-4 sm:gap-5 max-w-md w-full">
+        <div className="flex flex-col items-center text-center gap-3 sm:gap-4 md:gap-5 max-w-md md:max-w-lg w-full">
           <RestaurantLogo
             src={logoUrl ?? undefined}
             alt={title}
@@ -46,7 +69,7 @@ export default function LandingHero({
           {/* Text + CTA with overlay */}
           <div className="relative w-full">
             <div
-              className="absolute -inset-3 sm:-inset-4 rounded-2xl bg-black/45 backdrop-blur-sm"
+              className="absolute -inset-3 sm:-inset-4 rounded-2xl bg-black/40 md:bg-black/35 backdrop-blur-[2px]"
               aria-hidden="true"
             />
             <div className="relative flex flex-col items-center gap-3 sm:gap-4">
@@ -54,6 +77,7 @@ export default function LandingHero({
               {subtitle ? (
                 <p className="text-white/90 text-sm sm:text-base leading-relaxed max-w-prose">{subtitle}</p>
               ) : null}
+              {open !== null && <OpenBadge isOpen={open} />}
               <Link href={ctaHref} aria-label="Order Now" className="relative">
                 <Button className="px-6 py-3 text-base sm:text-lg rounded-xl">{ctaLabel}</Button>
               </Link>


### PR DESCRIPTION
## Summary
- restore first homepage slide to full-bleed hero with Open/Closed badge
- center hero content and remove logo ring
- add small text backdrop for readability across breakpoints

## Testing
- `npm run test:ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acbf14fcd88325bf945727f105eb68