### PR TITLE
fix(customer): polish menu cover, header logo, and item modal

### DIFF
--- a/components/MenuItemCard.tsx
+++ b/components/MenuItemCard.tsx
@@ -7,6 +7,17 @@ import AddonGroups, { validateAddonSelections } from './AddonGroups';
 import PlateAdd from '@/components/icons/PlateAdd';
 import { useBrand } from '@/components/branding/BrandProvider';
 
+function formatPrice(amount: number, currency = 'GBP') {
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: 'currency',
+      currency,
+    }).format(amount);
+  } catch {
+    return `£${Number(amount).toFixed(2)}`;
+  }
+}
+
 interface MenuItem {
   id: number;
   name: string;
@@ -65,6 +76,8 @@ export default function MenuItemCard({
   const price =
     typeof item?.price === 'number' ? item.price : Number(item?.price || 0);
   const imageUrl = item?.image_url || undefined;
+  const currency = 'GBP';
+  const formattedPrice = formatPrice(price / 100, currency);
   const badges: string[] = [];
   if (item?.is_vegan) badges.push('Vegan');
   if (item?.is_vegetarian) badges.push('Vegetarian');
@@ -157,13 +170,7 @@ export default function MenuItemCard({
               alt={item?.name || ''}
               className="w-full h-44 md:h-56 object-cover"
             />
-            <div
-              className="pointer-events-none absolute inset-x-0 bottom-0 h-20"
-              style={{
-                background:
-                  'linear-gradient(to top, rgba(0,0,0,0.45), rgba(0,0,0,0.00))',
-              }}
-            />
+            <div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-black/45 to-transparent" />
             <div className="absolute inset-x-0 bottom-0 p-4 md:p-5 flex flex-col items-start">
               <div className="w-full flex items-end justify-between">
                 <div className="text-white drop-shadow-md text-lg md:text-xl font-semibold">
@@ -171,10 +178,7 @@ export default function MenuItemCard({
                 </div>
                 {typeof price === 'number' && (
                   <div className="text-white/95 drop-shadow-md font-semibold">
-                    {((price) / 100).toLocaleString(undefined, {
-                      style: 'currency',
-                      currency: 'GBP',
-                    })}
+                    {formattedPrice}
                   </div>
                 )}
               </div>
@@ -248,11 +252,9 @@ export default function MenuItemCard({
         <div className="flex-1 overflow-y-auto px-4 md:px-6 py-3 space-y-4">
           {loading ? (
             <p className="text-center text-gray-500">Loading...</p>
-          ) : groups.length === 0 ? (
-            <p className="text-center text-gray-500">No add-ons available</p>
-          ) : (
+          ) : groups.length > 0 ? (
             <AddonGroups addons={groups} onChange={setSelections} />
-          )}
+          ) : null}
           <textarea
             className="w-full border rounded p-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
             style={{ ['--tw-ring-color' as any]: accent } as React.CSSProperties}
@@ -354,7 +356,7 @@ export default function MenuItemCard({
                 )}
               </div>
               <div className="price font-semibold text-gray-900 whitespace-nowrap text-sm sm:text-base">
-                ${ (price / 100).toFixed(2) }
+                {formattedPrice}
               </div>
             </div>
             {item.description && (

--- a/components/customer/TopBar.tsx
+++ b/components/customer/TopBar.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import RestaurantLogo from '../branding/RestaurantLogo';
 import { useBrand } from '../branding/BrandProvider';
 import Skeleton from '../ui/Skeleton';
 
@@ -15,18 +14,33 @@ export default function TopBar({ hidden, restaurant }: Props) {
   const shape = restaurant?.logo_shape || 'round';
   const logoUrl = restaurant?.logo_url ?? null;
   const loading = !restaurant;
+
+  const dims =
+    shape === 'rectangular'
+      ? 'h-8 sm:h-10 w-[3.2rem] sm:w-[4rem]'
+      : 'h-8 w-8 sm:h-10 sm:w-10';
+  const rounding =
+    shape === 'round'
+      ? 'rounded-full'
+      : shape === 'square'
+      ? 'rounded-lg'
+      : 'rounded-md';
+  const wrapper = `${dims} ${rounding} overflow-visible p-0.5`;
   return (
     <header className="brand-glass fixed top-0 left-0 right-0 h-14 flex items-center px-4 z-40">
       {loading ? (
-        <RestaurantLogo isSkeleton size={28} shape="round" alt="" />
+        <Skeleton className={wrapper.replace('overflow-visible p-0.5', '')} />
       ) : (
-        <RestaurantLogo
-          src={logoUrl || undefined}
-          alt={title}
-          shape={shape}
-          size={28}
-          loading="eager"
-        />
+        <div className={wrapper}>
+          {logoUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={logoUrl}
+              alt={title}
+              className={`h-full w-full object-contain ${rounding}`}
+            />
+          ) : null}
+        </div>
       )}
       {loading ? (
         <Skeleton className="ml-2 h-5 w-40 rounded-md" />

--- a/components/customer/menu/MenuHeader.tsx
+++ b/components/customer/menu/MenuHeader.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { useBrand } from '@/components/branding/BrandProvider';
 
 type MenuHeaderProps = {
   title: string;
@@ -15,13 +15,14 @@ export default function MenuHeader({
   title,
   subtitle,
   imageUrl,
-  logoUrl,
+  logoUrl, // eslint-disable-line @typescript-eslint/no-unused-vars
   accentHex,
   focalX,
   focalY,
 }: MenuHeaderProps) {
   const [collapsed, setCollapsed] = useState(false);
   const [mounted, setMounted] = useState(false);
+  const brand = useBrand();
 
   useEffect(() => {
     setMounted(true);
@@ -47,17 +48,19 @@ export default function MenuHeader({
       ? `linear-gradient(180deg, ${accentHex}22, ${accentHex}11, #00000022)`
       : 'linear-gradient(180deg, rgba(0,0,0,0.10), rgba(0,0,0,0.06), rgba(0,0,0,0.08))';
 
-    return (
-      <section
-        aria-label="Restaurant header"
-        className={[
-          'relative w-full overflow-hidden rounded-2xl',
-          'transition-all duration-500 ease-out will-change-transform will-change-opacity',
-          collapsed ? 'h-20 md:h-24 mt-2' : 'h-48 md:h-80 mt-0',
-          mounted ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-2',
-        ].join(' ')}
-      >
-      {/* Background image/gradient */}
+  const finalTitle = brand?.name || title;
+  const finalSubtitle = subtitle ?? '';
+
+  return (
+    <section
+      aria-label="Restaurant header"
+      className={[
+        'relative w-full overflow-hidden',
+        'transition-all duration-500 ease-out will-change-transform will-change-opacity',
+        collapsed ? 'h-20 md:h-24' : 'h-48 md:h-80',
+        mounted ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-2',
+      ].join(' ')}
+    >
       {imageUrl ? (
         <img
           src={imageUrl}
@@ -71,49 +74,25 @@ export default function MenuHeader({
       ) : (
         <div className="absolute inset-0 bg-gradient-to-br from-gray-200 via-gray-100 to-gray-200" />
       )}
-      {/* Overlay for contrast */}
-      <div
-        className="absolute inset-0"
-        style={{ backgroundImage: overlay }}
-      />
-      {/* Optional faint watermark logo */}
-      {logoUrl ? (
-        <img
-          src={logoUrl}
-          alt=""
-          aria-hidden="true"
-          className="absolute right-4 bottom-4 h-8 w-8 md:h-10 md:w-10 opacity-60 blur-[0.2px]"
-        />
-      ) : null}
-      {/* Foreground content */}
-      <div className="relative h-full w-full px-4 md:px-6 flex items-end">
-        <div className="pb-3 md:pb-4">
-          <div className={[
-            'inline-flex items-center rounded-full backdrop-blur-sm',
-            'bg-white/40 text-gray-800',
-            'px-2.5 py-0.5 text-xs font-medium shadow-sm',
-            'transition-opacity duration-300',
-            collapsed ? 'opacity-0 pointer-events-none' : 'opacity-100',
-          ].join(' ')}>
-            Menu
+      <div className="absolute inset-0" style={{ backgroundImage: overlay }} />
+      <div className="relative h-full w-full flex items-end justify-center">
+        <div className="pb-6 md:pb-8">
+          <div className="relative max-w-[20rem] sm:max-w-[24rem] mx-auto text-center">
+            <div
+              className="absolute -inset-2 sm:-inset-3 rounded-2xl bg-black/12 md:bg-black/10 backdrop-blur-lg shadow-md"
+              aria-hidden="true"
+            />
+            <div className="relative px-4 py-2 sm:px-5 sm:py-3 flex flex-col items-center text-center">
+              <h1 className="text-white drop-shadow-[0_1px_1px_rgba(0,0,0,0.6)] text-xl sm:text-2xl font-semibold">
+                {finalTitle}
+              </h1>
+              {finalSubtitle ? (
+                <p className="mt-1 text-white/90 text-sm sm:text-base leading-relaxed line-clamp-2">
+                  {finalSubtitle}
+                </p>
+              ) : null}
+            </div>
           </div>
-          <h1
-            className={[
-              'mt-1 font-semibold text-gray-900 drop-shadow-sm',
-              'transition-transform duration-300',
-              collapsed ? 'text-lg md:text-xl translate-y-0' : 'text-2xl md:text-4xl translate-y-[1px]',
-            ].join(' ')}
-          >
-            {title}
-          </h1>
-          {subtitle ? (
-            <p className={[
-              'text-gray-700/90 transition-opacity duration-300',
-              collapsed ? 'opacity-0 h-0 -mt-1 overflow-hidden' : 'opacity-100 text-sm md:text-base',
-            ].join(' ')}>
-              {subtitle}
-            </p>
-          ) : null}
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- show website title and menu description on menu cover with frosted tile for legibility
- adjust header logo wrappers to avoid cropping for round, square and rectangular logos
- improve item modal readability with gradient, consistent price formatting, and hidden empty add-ons

## Testing
- `npm test -- --watchAll=false`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68af249eaff08325ac2d0cbf59c1e6f5