### PR TITLE
fix: menu cover description and logo/badge styling

### DIFF
--- a/components/MenuItemCard.tsx
+++ b/components/MenuItemCard.tsx
@@ -8,14 +8,17 @@ import PlateAdd from '@/components/icons/PlateAdd';
 import { useBrand } from '@/components/branding/BrandProvider';
 import { formatPrice } from '@/lib/orderDisplay';
 
-function readableText(hex?: string | null) {
-  if (!hex) return '#000';
-  const h = hex.replace('#', '');
-  const r = parseInt(h.length === 3 ? h[0] + h[0] : h.slice(0, 2), 16);
-  const g = parseInt(h.length === 3 ? h[1] + h[1] : h.slice(2, 4), 16);
-  const b = parseInt(h.length === 3 ? h[2] + h[2] : h.slice(4, 6), 16);
-  const yiq = (r * 299 + g * 587 + b * 114) / 1000;
-  return yiq >= 145 ? '#000' : '#fff';
+function contrast(c?: string) {
+  try {
+    if (!c) return '#fff';
+    const h = c.replace('#', '');
+    const r = parseInt(h.length === 3 ? h[0] + h[0] : h.slice(0, 2), 16);
+    const g = parseInt(h.length === 3 ? h[1] + h[1] : h.slice(2, 4), 16);
+    const b = parseInt(h.length === 3 ? h[2] + h[2] : h.slice(4, 6), 16);
+    return (r * 299 + g * 587 + b * 114) / 1000 >= 145 ? '#000' : '#fff';
+  } catch {
+    return '#fff';
+  }
 }
 
 interface MenuItem {
@@ -50,8 +53,27 @@ export default function MenuItemCard({
   const brand = useBrand?.();
   const accent =
     typeof brand?.brand === 'string' && brand.brand ? brand.brand : undefined;
-  const secondary =
-    typeof brand?.brand600 === 'string' && brand.brand600 ? brand.brand600 : undefined;
+  const sec = 'var(--brand-secondary, var(--brand-primary))';
+  const [secText, setSecText] = useState('#fff');
+  const [mix, setMix] = useState(false);
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const v = getComputedStyle(document.documentElement)
+        .getPropertyValue('--brand-secondary')
+        ?.trim();
+      setSecText(contrast(v));
+      setMix(
+        !!(window.CSS && CSS.supports && CSS.supports('color', `color-mix(in oklab, ${sec} 50%, transparent)`))
+      );
+    }
+  }, []);
+  const badgeStyles = mix
+    ? {
+        background: `color-mix(in oklab, ${sec} 18%, transparent)`,
+        borderColor: `color-mix(in oklab, ${sec} 60%, transparent)`,
+        color: secText,
+      }
+    : { background: `${sec}1A`, borderColor: sec, color: secText };
   const logo = brand?.logoUrl;
   const [mounted, setMounted] = useState(false);
   const [modalAnim, setModalAnim] = useState(false);
@@ -186,20 +208,17 @@ export default function MenuItemCard({
               </div>
               {badges.length > 0 && (
                 <div className="mt-2 flex gap-2">
-                  {badges.map((b) => (
-                    <span
-                      key={b}
-                      className="px-2 py-0.5 rounded-full text-xs font-medium"
-                      style={{
-                        backgroundColor: secondary || 'var(--brand-secondary)',
-                        color: readableText(secondary),
-                      }}
-                    >
-                      {b}
-                    </span>
-                  ))}
-                </div>
-              )}
+                {badges.map((b) => (
+                  <span
+                    key={b}
+                    className="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium border"
+                    style={badgeStyles}
+                  >
+                    {b}
+                  </span>
+                ))}
+              </div>
+            )}
             </div>
           </div>
         )}
@@ -233,11 +252,8 @@ export default function MenuItemCard({
               {badges.map((b) => (
                 <span
                   key={b}
-                  className="px-2 py-0.5 rounded-full text-xs font-medium"
-                  style={{
-                    backgroundColor: secondary || 'var(--brand-secondary)',
-                    color: readableText(secondary),
-                  }}
+                  className="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium border"
+                  style={badgeStyles}
                 >
                   {b}
                 </span>
@@ -339,20 +355,17 @@ export default function MenuItemCard({
             )}
             {badges.length > 0 && (
               <div className="mt-1 flex flex-wrap gap-1">
-                {badges.map((b) => (
-                  <span
-                    key={b}
-                    className="px-2 py-0.5 rounded-full text-[10px] font-medium"
-                    style={{
-                      backgroundColor: secondary || 'var(--brand-secondary)',
-                      color: readableText(secondary),
-                    }}
-                  >
-                    {b}
-                  </span>
-                ))}
-              </div>
-            )}
+                  {badges.map((b) => (
+                    <span
+                      key={b}
+                      className="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium border"
+                      style={badgeStyles}
+                    >
+                      {b}
+                    </span>
+                  ))}
+                </div>
+              )}
             <div className="mt-2 flex justify-end">
               <button
                 type="button"

--- a/components/customer/TopBar.tsx
+++ b/components/customer/TopBar.tsx
@@ -25,7 +25,7 @@ export default function TopBar({ hidden, restaurant }: Props) {
       : shape === 'square'
       ? 'rounded-lg'
       : 'rounded-md';
-  const wrapper = `${dims} ${rounding} overflow-visible p-0.5`;
+  const wrapper = `relative ${dims} ${rounding} overflow-visible p-0.5`;
   return (
     <header className="brand-glass fixed top-0 left-0 right-0 h-14 flex items-center px-4 z-40">
       {loading ? (

--- a/components/customer/home/LandingHero.tsx
+++ b/components/customer/home/LandingHero.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { supabase } from '@/utils/supabaseClient';
-import RestaurantLogo from '../../branding/RestaurantLogo';
 import Button from '../../ui/Button';
 import Skeleton from '../../ui/Skeleton';
 
@@ -49,6 +48,18 @@ export default function LandingHero({
 
   const ctaText = readableText(primary);
 
+  const shape = logoShape || 'round';
+  const rounding =
+    shape === 'round'
+      ? 'rounded-full'
+      : shape === 'square'
+      ? 'rounded-lg'
+      : 'rounded-md';
+  const logoDims =
+    shape === 'rectangular'
+      ? { width: 72, height: 24 }
+      : { width: 72, height: 72 };
+
   useEffect(() => {
     if (open !== null) return;
     const pick = (v: string | string[] | undefined) => (Array.isArray(v) ? v[0] : v);
@@ -75,14 +86,18 @@ export default function LandingHero({
       {/* Centered content */}
       <div className="absolute inset-0 flex items-center justify-center p-4">
         <div className="flex flex-col items-center text-center gap-3 sm:gap-4 md:gap-5">
-          <div className="p-1">
-            <RestaurantLogo
-              src={logoUrl ?? undefined}
-              alt={title}
-              shape={logoShape ?? 'round'}
-              size={72}
-              className="object-contain ring-0 border-0 shadow-none"
-            />
+          <div
+            className={`relative overflow-visible p-0.5 ${rounding}`}
+            style={{ width: logoDims.width, height: logoDims.height }}
+          >
+            {logoUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={logoUrl}
+                alt={title}
+                className={`h-full w-full object-contain ${rounding}`}
+              />
+            ) : null}
           </div>
 
           <div className="relative max-w-[20rem] sm:max-w-[24rem] w-auto mx-auto">

--- a/pages/restaurant/menu.tsx
+++ b/pages/restaurant/menu.tsx
@@ -283,9 +283,15 @@ export default function RestaurantMenuPage({ initialBrand }: { initialBrand: any
               />
             );
           })()}
-          {restaurant?.menu_description && (
-            <p className="mt-4 text-gray-600 text-center">{restaurant.menu_description}</p>
-          )}
+          {(() => {
+            const desc =
+              restaurant?.menu_description ||
+              restaurant?.website_description ||
+              '';
+            return desc ? (
+              <p className="mt-3 text-[15px] leading-6 text-neutral-700 dark:text-neutral-300">{desc}</p>
+            ) : null;
+          })()}
 
           <div className="relative">
             <div className="relative">
@@ -358,24 +364,37 @@ export default function RestaurantMenuPage({ initialBrand }: { initialBrand: any
                     ref={(el) => (sectionsRef.current[cat.id] = el)}
                     style={{ scrollMarginTop: 76 }}
                   >
-                    <div className="mt-8 mb-3 flex items-center gap-3">
-                      <span className="inline-block h-1.5 w-8 rounded-full" style={{backgroundColor:'var(--brand-primary)'}} />
-                      <h2 className="text-xl font-semibold tracking-tight">{cat.name}</h2>
-                    </div>
-                    <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-3">
-                        {catItems.map((item, idx) => (
-                          <div
-                            key={item.id}
-                            className={`opacity-0 translate-y-2 transition-all duration-500 ease-out will-change-transform will-change-opacity ${mounted ? 'opacity-100 translate-y-0' : ''}`}
-                            style={{ transitionDelay: `${idx * 75}ms` }}
+                    {(() => {
+                      const isActive = activeCat === String(cat.id);
+                      return (
+                        <div className="mt-8 mb-3">
+                          <h2
+                            className="text-xl font-semibold tracking-tight pb-1 border-b-2"
+                            style={{
+                              borderColor: isActive
+                                ? 'var(--brand-secondary, var(--brand-primary))'
+                                : 'var(--brand-primary)',
+                            }}
                           >
-                            <MenuItemCard item={item} restaurantId={restaurantId as string} />
-                          </div>
-                        ))}
-                      </div>
-                    </section>
-                  );
-                })
+                            {cat.name}
+                          </h2>
+                        </div>
+                      );
+                    })()}
+                    <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-3">
+                      {catItems.map((item, idx) => (
+                        <div
+                          key={item.id}
+                          className={`opacity-0 translate-y-2 transition-all duration-500 ease-out will-change-transform will-change-opacity ${mounted ? 'opacity-100 translate-y-0' : ''}`}
+                          style={{ transitionDelay: `${idx * 75}ms` }}
+                        >
+                          <MenuItemCard item={item} restaurantId={restaurantId as string} />
+                        </div>
+                      ))}
+                    </div>
+                  </section>
+                );
+              })
               )}
           </div>
           {showTop && (


### PR DESCRIPTION
## Summary
- move menu description beneath cover image and underline category headers with primary/secondary brand colors
- wrap header/hero logos in padded non-clipping containers respecting logo shape
- style diet/age badges as secondary-color pills with contrast-aware text

## Testing
- `npm run test:ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68af3a2777208325bd5fed2ce28f73b3