### PR TITLE
feat(slides): add dynamic homepage slides and dashboard manager

### DIFF
--- a/components/SlideModal.tsx
+++ b/components/SlideModal.tsx
@@ -1,0 +1,151 @@
+import React, { useEffect, useState } from 'react';
+import { toast } from '@/components/ui/toast';
+import { supabase } from '@/utils/supabaseClient';
+
+type SlideModalProps = {
+  open: boolean;
+  onClose: () => void;
+  initial: { restaurant_id: string } & Partial<{
+    id: string;
+    type: string;
+    title: string | null;
+    subtitle: string | null;
+    media_url: string | null;
+    cta_label: string | null;
+    cta_href: string | null;
+    is_active: boolean;
+    visible_from: string | null;
+    visible_until: string | null;
+    config_json: any;
+  }>;
+  onSaved: () => void;
+};
+
+export default function SlideModal({ open, onClose, initial, onSaved }: SlideModalProps) {
+  const [type, setType] = useState(initial.type || 'hero');
+  const [title, setTitle] = useState(initial.title || '');
+  const [subtitle, setSubtitle] = useState(initial.subtitle || '');
+  const [mediaUrl, setMediaUrl] = useState(initial.media_url || '');
+  const [ctaLabel, setCtaLabel] = useState(initial.cta_label || '');
+  const [ctaHref, setCtaHref] = useState(initial.cta_href || '');
+  const [isActive, setIsActive] = useState(initial.is_active ?? true);
+  const [visibleFrom, setVisibleFrom] = useState(initial.visible_from || '');
+  const [visibleUntil, setVisibleUntil] = useState(initial.visible_until || '');
+  const [config, setConfig] = useState(() => JSON.stringify(initial.config_json || {}, null, 2));
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setType(initial.type || 'hero');
+    setTitle(initial.title || '');
+    setSubtitle(initial.subtitle || '');
+    setMediaUrl(initial.media_url || '');
+    setCtaLabel(initial.cta_label || '');
+    setCtaHref(initial.cta_href || '');
+    setIsActive(initial.is_active ?? true);
+    setVisibleFrom(initial.visible_from || '');
+    setVisibleUntil(initial.visible_until || '');
+    setConfig(JSON.stringify(initial.config_json || {}, null, 2));
+  }, [open, initial]);
+
+  async function handleSave() {
+    if (!initial.restaurant_id) {
+      toast.error('Missing restaurant id');
+      return;
+    }
+    if (visibleFrom && visibleUntil && new Date(visibleUntil) < new Date(visibleFrom)) {
+      toast.error('End date must be after start date');
+      return;
+    }
+    let parsedConfig: any = null;
+    try {
+      parsedConfig = config ? JSON.parse(config) : null;
+    } catch (e) {
+      toast.error('config_json must be valid JSON');
+      return;
+    }
+    const payload = {
+      type,
+      title: title || null,
+      subtitle: subtitle || null,
+      media_url: mediaUrl || null,
+      cta_label: ctaLabel || null,
+      cta_href: ctaHref || null,
+      is_active: isActive,
+      visible_from: visibleFrom || null,
+      visible_until: visibleUntil || null,
+      config_json: parsedConfig,
+    };
+    setSaving(true);
+    try {
+      if (initial.id) {
+        const { error } = await supabase
+          .from('restaurant_slides')
+          .update(payload)
+          .eq('id', initial.id);
+        if (error) throw error;
+      } else {
+        const { data: maxRow, error: mErr } = await supabase
+          .from('restaurant_slides')
+          .select('sort_order')
+          .eq('restaurant_id', initial.restaurant_id)
+          .order('sort_order', { ascending: false })
+          .limit(1)
+          .maybeSingle();
+        if (mErr) throw mErr;
+        const nextOrder = (maxRow?.sort_order ?? -1) + 1;
+        const { error } = await supabase
+          .from('restaurant_slides')
+          .insert({ ...payload, restaurant_id: initial.restaurant_id, sort_order: nextOrder });
+        if (error) throw error;
+      }
+      toast.success('Slide saved');
+      onSaved();
+      onClose();
+    } catch (e: any) {
+      console.error(e);
+      toast.error(e.message || 'Failed to save slide');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4" role="dialog" aria-modal="true">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <div className="relative w-full max-w-lg rounded-2xl bg-white p-4 shadow-lg space-y-3">
+        <h2 className="text-xl font-semibold">{initial.id ? 'Edit Slide' : 'New Slide'}</h2>
+        <label className="block text-sm font-medium">Type</label>
+        <select value={type} onChange={e => setType(e.target.value)} className="w-full rounded border px-3 py-2">
+          {['hero','menu_highlight','gallery','reviews','about','location_hours','cta_banner','custom_builder'].map(t => (
+            <option key={t} value={t}>{t}</option>
+          ))}
+        </select>
+        <label className="block text-sm font-medium">Title</label>
+        <input value={title} onChange={e => setTitle(e.target.value)} className="w-full rounded border px-3 py-2" />
+        <label className="block text-sm font-medium">Subtitle</label>
+        <input value={subtitle} onChange={e => setSubtitle(e.target.value)} className="w-full rounded border px-3 py-2" />
+        <label className="block text-sm font-medium">Media URL</label>
+        <input value={mediaUrl} onChange={e => setMediaUrl(e.target.value)} className="w-full rounded border px-3 py-2" />
+        <label className="block text-sm font-medium">CTA Label</label>
+        <input value={ctaLabel} onChange={e => setCtaLabel(e.target.value)} className="w-full rounded border px-3 py-2" />
+        <label className="block text-sm font-medium">CTA Href</label>
+        <input value={ctaHref} onChange={e => setCtaHref(e.target.value)} className="w-full rounded border px-3 py-2" />
+        <label className="block text-sm font-medium flex items-center gap-2">
+          <input type="checkbox" checked={isActive} onChange={e => setIsActive(e.target.checked)} /> Active
+        </label>
+        <label className="block text-sm font-medium">Visible From</label>
+        <input type="datetime-local" value={visibleFrom} onChange={e => setVisibleFrom(e.target.value)} className="w-full rounded border px-3 py-2" />
+        <label className="block text-sm font-medium">Visible Until</label>
+        <input type="datetime-local" value={visibleUntil} onChange={e => setVisibleUntil(e.target.value)} className="w-full rounded border px-3 py-2" />
+        <label className="block text-sm font-medium">Config JSON</label>
+        <textarea value={config} onChange={e => setConfig(e.target.value)} rows={4} className="w-full rounded border px-3 py-2 font-mono" />
+        <div className="flex justify-end gap-2 pt-2">
+          <button onClick={onClose} className="px-4 py-2 rounded border">Cancel</button>
+          <button onClick={handleSave} disabled={saving} className="px-4 py-2 rounded bg-emerald-600 text-white disabled:opacity-50">{saving ? 'Saving…' : 'Save'}</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/SlidesSection.tsx
+++ b/components/SlidesSection.tsx
@@ -1,0 +1,149 @@
+import React, { useEffect, useState } from 'react';
+import { DndContext, PointerSensor, useSensor, useSensors, DragEndEvent, closestCenter } from '@dnd-kit/core';
+import { SortableContext, useSortable, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { supabase } from '@/utils/supabaseClient';
+import { toast } from '@/components/ui/toast';
+import SlideModal from './SlideModal';
+
+type SlideRow = {
+  id: string;
+  type: string;
+  title: string | null;
+  sort_order: number | null;
+  is_active: boolean;
+  visible_from: string | null;
+  visible_until: string | null;
+};
+
+function RowHandle({ id, children }: { id: string; children: React.ReactNode }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id });
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : undefined,
+  };
+  return (
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners} className="flex items-center gap-3 p-2" >
+      {children}
+    </div>
+  );
+}
+
+export default function SlidesSection({ restaurantId }: { restaurantId: string }) {
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
+  const [slides, setSlides] = useState<SlideRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editRow, setEditRow] = useState<SlideRow | null>(null);
+
+  async function load() {
+    setLoading(true);
+    const { data, error } = await supabase
+      .from('restaurant_slides')
+      .select('id,type,title,sort_order,is_active,visible_from,visible_until')
+      .eq('restaurant_id', restaurantId)
+      .order('sort_order', { ascending: true })
+      .order('created_at', { ascending: true });
+    if (error) {
+      console.error(error);
+      toast.error('Failed to load slides');
+    } else {
+      setSlides(data || []);
+    }
+    setLoading(false);
+  }
+
+  useEffect(() => { if (restaurantId) load(); }, [restaurantId]);
+
+  async function toggle(row: SlideRow) {
+    const prev = slides;
+    setSlides(prev.map(s => s.id === row.id ? { ...s, is_active: !row.is_active } : s));
+    const { error } = await supabase
+      .from('restaurant_slides')
+      .update({ is_active: !row.is_active })
+      .eq('id', row.id);
+    if (error) {
+      console.error(error);
+      toast.error('Failed to update');
+      setSlides(prev);
+    }
+  }
+
+  async function handleDragEnd(e: DragEndEvent) {
+    const { active, over } = e;
+    if (!over || active.id === over.id) return;
+    const oldIndex = slides.findIndex(s => s.id === active.id);
+    const newIndex = slides.findIndex(s => s.id === over.id);
+    const reordered = arrayMove(slides, oldIndex, newIndex).map((s, i) => ({ ...s, sort_order: i }));
+    setSlides(reordered);
+    const updates = reordered.map(s => supabase.from('restaurant_slides').update({ sort_order: s.sort_order }).eq('id', s.id));
+    const results = await Promise.all(updates);
+    const err = results.find(r => (r as any).error);
+    if (err) {
+      console.error(err);
+      toast.error('Failed to reorder');
+      load();
+    } else {
+      toast.success('Order updated');
+    }
+  }
+
+  async function remove(row: SlideRow) {
+    if (!confirm('Delete this slide?')) return;
+    const prev = slides;
+    setSlides(prev.filter(s => s.id !== row.id));
+    const { error } = await supabase.from('restaurant_slides').delete().eq('id', row.id);
+    if (error) {
+      console.error(error);
+      toast.error('Failed to delete');
+      setSlides(prev);
+    }
+  }
+
+  return (
+    <section className="mt-8">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-lg font-semibold">Homepage Slides</h3>
+        <button onClick={() => { setEditRow(null); setModalOpen(true); }} className="px-3 py-2 rounded bg-emerald-600 text-white">+ New Slide</button>
+      </div>
+      {loading ? (
+        <div className="text-sm text-neutral-500">Loading…</div>
+      ) : slides.length === 0 ? (
+        <div className="rounded border p-4 text-sm text-neutral-500">No slides yet.</div>
+      ) : (
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={slides.map(s => s.id)} strategy={verticalListSortingStrategy}>
+            <ul className="divide-y rounded border">
+              {slides.map(s => (
+                <RowHandle key={s.id} id={s.id}>
+                  <div className="w-4 cursor-grab text-neutral-400">☰</div>
+                  <div className="flex-1">
+                    <div className="font-medium">{s.title || '(untitled)'}</div>
+                    <div className="text-xs text-neutral-500">{s.type}</div>
+                  </div>
+                  <label className="flex items-center gap-1 text-sm mr-2">
+                    <input type="checkbox" checked={s.is_active} onChange={() => toggle(s)} /> active
+                  </label>
+                  <div className="text-xs w-48 mr-2">
+                    {s.visible_from ? new Date(s.visible_from).toLocaleDateString() : ''}
+                    {s.visible_until ? ` – ${new Date(s.visible_until).toLocaleDateString()}` : ''}
+                  </div>
+                  <button onClick={() => { setEditRow(s); setModalOpen(true); }} className="px-2 py-1 rounded border mr-2">Edit</button>
+                  <button onClick={() => remove(s)} className="px-2 py-1 rounded border text-red-600">Delete</button>
+                </RowHandle>
+              ))}
+            </ul>
+          </SortableContext>
+        </DndContext>
+      )}
+
+      <SlideModal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        initial={editRow ? { ...editRow, restaurant_id: restaurantId } : { restaurant_id: restaurantId }}
+        onSaved={load}
+      />
+    </section>
+  );
+}

--- a/components/customer/home/LandingHero.tsx
+++ b/components/customer/home/LandingHero.tsx
@@ -23,6 +23,7 @@ type LandingHeroProps = {
   logoUrl?: string | null; // avatar/logo
   logoShape?: 'square' | 'round' | 'rectangular' | null;
   isOpen?: boolean; // optional open state
+  onCtaClick?: () => void;
 };
 
 export default function LandingHero({
@@ -34,6 +35,7 @@ export default function LandingHero({
   logoUrl,
   logoShape,
   isOpen,
+  onCtaClick,
 }: LandingHeroProps) {
   const router = useRouter();
   const [open, setOpen] = useState<boolean | null>(typeof isOpen === 'boolean' ? isOpen : null);
@@ -131,6 +133,7 @@ export default function LandingHero({
               )}
               <Link href={ctaHref} aria-label="Order Now" className="relative">
                 <Button
+                  onClick={onCtaClick}
                   className="rounded-full px-5 py-2 sm:px-6 sm:py-2.5 text-sm sm:text-base font-medium tracking-tight shadow-md hover:shadow-lg transition-all duration-150 ease-out hover:scale-[1.02] active:scale-[0.99] border-0 focus:outline-none focus:ring-2 focus:ring-white/40"
                   style={{
                     backgroundColor: primary || 'var(--brand-primary, #111827)',

--- a/components/customer/home/RestaurantSlides.tsx
+++ b/components/customer/home/RestaurantSlides.tsx
@@ -1,0 +1,231 @@
+import React, { useEffect, useRef, useState } from 'react';
+import Slides from '../Slides';
+import LandingHero from './LandingHero';
+import PageRenderer, { Block } from '@/components/PageRenderer';
+import { supabase } from '@/utils/supabaseClient';
+import { trackSlideEvent } from '@/utils/analytics';
+
+export type RestaurantSlide = {
+  id: string;
+  restaurant_id: string;
+  type: 'hero' | 'menu_highlight' | 'gallery' | 'reviews' | 'about' | 'location_hours' | 'cta_banner' | 'custom_builder';
+  title: string | null;
+  subtitle: string | null;
+  media_url: string | null;
+  cta_label: string | null;
+  cta_href: string | null;
+  sort_order: number | null;
+  config_json: any;
+};
+
+export default function RestaurantSlides({ restaurantId, restaurant, onHeroInView }: { restaurantId: string; restaurant: any | null; onHeroInView?: (v: boolean) => void }) {
+  const [slides, setSlides] = useState<RestaurantSlide[]>([]);
+  const slideRefs = useRef<Record<string, HTMLElement | null>>({});
+
+  useEffect(() => {
+    if (!restaurantId) return;
+    const now = new Date().toISOString();
+    supabase
+      .from('restaurant_slides')
+      .select('id,restaurant_id,type,title,subtitle,media_url,cta_label,cta_href,sort_order,config_json')
+      .eq('restaurant_id', restaurantId)
+      .eq('is_active', true)
+      .or(`visible_from.is.null,visible_from.lte.${now}`)
+      .or(`visible_until.is.null,visible_until.gte.${now}`)
+      .order('sort_order', { ascending: true })
+      .order('created_at', { ascending: true })
+      .then(({ data }) => setSlides(data || []));
+  }, [restaurantId]);
+
+  useEffect(() => {
+    if (slides.length === 0) return;
+    const obs = new IntersectionObserver(
+      entries => {
+        entries.forEach(e => {
+          if (e.isIntersecting && e.intersectionRatio >= 0.6) {
+            const id = e.target.getAttribute('data-id');
+            const type = e.target.getAttribute('data-type');
+            if (id && type) trackSlideEvent('slide_impression', { slide_id: id, slide_type: type });
+          }
+        });
+      },
+      { threshold: 0.6 }
+    );
+    Object.values(slideRefs.current).forEach(el => el && obs.observe(el));
+    return () => obs.disconnect();
+  }, [slides]);
+
+  useEffect(() => {
+    if (!('requestIdleCallback' in window)) return;
+    (window as any).requestIdleCallback(() => {
+      slides.forEach(s => {
+        if (s.media_url) {
+          const img = new Image();
+          img.src = s.media_url;
+        }
+      });
+    });
+  }, [slides]);
+
+  if (slides.length === 0) {
+    return (
+      <div className="h-screen flex flex-col items-center justify-center text-center p-4 gap-4">
+        <p className="text-lg">Nothing here yet.</p>
+        <a
+          href={`/restaurant/menu?restaurant_id=${restaurantId}`}
+          className="px-4 py-2 rounded bg-emerald-600 text-white"
+        >
+          View Menu
+        </a>
+      </div>
+    );
+  }
+
+  function renderSlide(s: RestaurantSlide) {
+    const trackClick = () => trackSlideEvent('slide_cta_click', { slide_id: s.id, slide_type: s.type, cta_href: s.cta_href });
+    switch (s.type) {
+      case 'hero':
+        return (
+          <LandingHero
+            title={s.title || ''}
+            subtitle={s.subtitle || undefined}
+            imageUrl={s.media_url || undefined}
+            ctaLabel={s.cta_label || undefined}
+            ctaHref={s.cta_href || `/restaurant/menu?restaurant_id=${restaurantId}`}
+            onCtaClick={trackClick}
+          />
+        );
+      case 'menu_highlight':
+        return (
+          <section className="flex h-full flex-col items-center justify-center gap-4 p-4 text-center">
+            <h2 className="text-2xl font-bold">{s.title}</h2>
+            {s.subtitle && <p className="max-w-prose">{s.subtitle}</p>}
+            <a
+              href={s.cta_href || `/restaurant/menu?restaurant_id=${restaurantId}`}
+              onClick={trackClick}
+              className="px-4 py-2 rounded bg-emerald-600 text-white"
+            >
+              {s.cta_label || 'View Menu'}
+            </a>
+          </section>
+        );
+      case 'gallery': {
+        const imgs: string[] = s.config_json?.images || [];
+        return (
+          <section className="flex h-full flex-col justify-center overflow-hidden">
+            <div className="flex gap-2 overflow-x-auto p-4">
+              {imgs.map((url, i) => (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img key={i} src={url} alt={s.title || ''} className="h-60 w-auto object-cover" loading="lazy" />
+              ))}
+            </div>
+          </section>
+        );
+      }
+      case 'reviews': {
+        const reviews: any[] = s.config_json?.reviews || [];
+        return (
+          <section className="flex h-full flex-col items-center justify-center gap-4 p-4 text-center">
+            <h2 className="text-2xl font-bold">{s.title || 'Reviews'}</h2>
+            {reviews.length ? (
+              <ul className="space-y-4 max-w-prose">
+                {reviews.map((r, i) => (
+                  <li key={i} className="text-sm">"{r.quote}" – {r.author}</li>
+                ))}
+              </ul>
+            ) : (
+              <p>{s.subtitle || 'No reviews yet.'}</p>
+            )}
+          </section>
+        );
+      }
+      case 'about':
+        return (
+          <section className="flex h-full flex-col items-center justify-center gap-4 p-4 text-center">
+            {s.media_url && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={s.media_url} alt={s.title || ''} className="max-h-60 object-cover" loading="lazy" />
+            )}
+            <h2 className="text-2xl font-bold">{s.title}</h2>
+            {s.subtitle && <p className="max-w-prose">{s.subtitle}</p>}
+          </section>
+        );
+      case 'location_hours': {
+        const address = restaurant?.address;
+        return (
+          <section className="flex h-full flex-col items-center justify-center gap-4 p-4 text-center">
+            <h2 className="text-2xl font-bold">{s.title || 'Find Us'}</h2>
+            {address ? <p>{address}</p> : <p>Please check our contact page for details.</p>}
+            <a
+              href={s.cta_href || `/restaurant/contact?restaurant_id=${restaurantId}`}
+              onClick={trackClick}
+              className="px-4 py-2 rounded bg-emerald-600 text-white"
+            >
+              {s.cta_label || 'Contact Us'}
+            </a>
+          </section>
+        );
+      }
+      case 'cta_banner':
+        return (
+          <section className="flex h-full flex-col items-center justify-center gap-4 p-4 text-center bg-emerald-600 text-white">
+            <h2 className="text-2xl font-bold">{s.title}</h2>
+            {s.subtitle && <p className="max-w-prose">{s.subtitle}</p>}
+            {s.cta_label && (
+              <a
+                href={s.cta_href || '#'}
+                onClick={trackClick}
+                className="px-4 py-2 rounded bg-white text-emerald-700"
+              >
+                {s.cta_label}
+              </a>
+            )}
+          </section>
+        );
+      case 'custom_builder':
+        return <CustomBuilder slideId={s.id} />;
+      default:
+        return null;
+    }
+  }
+
+  return (
+    <Slides onHeroInView={onHeroInView}>
+      {slides.map(s => (
+        <div
+          key={s.id}
+          data-id={s.id}
+          data-type={s.type}
+          ref={el => (slideRefs.current[s.id] = el)}
+          style={{ height: '100dvh', scrollSnapAlign: 'start' }}
+        >
+          {renderSlide(s)}
+        </div>
+      ))}
+    </Slides>
+  );
+}
+
+function CustomBuilder({ slideId }: { slideId: string }) {
+  const [blocks, setBlocks] = useState<Block[]>([]);
+  useEffect(() => {
+    supabase
+      .from('restaurant_slide_blocks')
+      .select('id,block_type,content_json,sort_order')
+      .eq('slide_id', slideId)
+      .order('sort_order', { ascending: true })
+      .then(({ data }) => {
+        const mapped: Block[] = (data || []).map(b => ({
+          id: b.id,
+          type: b.block_type === 'two_column' ? 'two-col' : (b.block_type as any),
+          ...(b.content_json || {}),
+        }));
+        setBlocks(mapped);
+      });
+  }, [slideId]);
+  return (
+    <section className="p-4 max-w-3xl mx-auto flex items-center justify-center h-full">
+      <PageRenderer blocks={blocks} />
+    </section>
+  );
+}

--- a/pages/dashboard/website/slides.tsx
+++ b/pages/dashboard/website/slides.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import DashboardLayout from '../../../components/DashboardLayout';
+import SlidesSection from '../../../components/SlidesSection';
+import { supabase } from '../../../utils/supabaseClient';
+
+export default function SlidesPage() {
+  const router = useRouter();
+  const [restaurantId, setRestaurantId] = useState<string | null>(null);
+  useEffect(() => {
+    const load = async () => {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) {
+        router.push('/login');
+        return;
+      }
+      const { data: ru } = await supabase
+        .from('restaurant_users')
+        .select('restaurant_id')
+        .eq('user_id', session.user.id)
+        .maybeSingle();
+      if (ru?.restaurant_id) setRestaurantId(ru.restaurant_id);
+    };
+    load();
+  }, [router]);
+
+  return (
+    <DashboardLayout>
+      {!restaurantId ? (
+        <div className="p-4 text-sm text-neutral-500">Loading…</div>
+      ) : (
+        <SlidesSection restaurantId={restaurantId} />
+      )}
+    </DashboardLayout>
+  );
+}

--- a/pages/restaurant/index.tsx
+++ b/pages/restaurant/index.tsx
@@ -1,13 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import CustomerLayout from '@/components/CustomerLayout';
-import Slides from '@/components/customer/Slides';
 import DebugFlag from '@/components/dev/DebugFlag';
 import { useBrand } from '@/components/branding/BrandProvider';
 import { supabase } from '@/utils/supabaseClient';
 import { useCart } from '@/context/CartContext';
-import LandingHero from '@/components/customer/home/LandingHero';
 import resolveRestaurantId from '@/lib/resolveRestaurantId';
+import RestaurantSlides from '@/components/customer/home/RestaurantSlides';
 
 export default function RestaurantHomePage({ initialBrand }: { initialBrand: any | null }) {
   const router = useRouter();
@@ -34,16 +33,6 @@ export default function RestaurantHomePage({ initialBrand }: { initialBrand: any
       .then(({ data }) => setRestaurant(data));
   }, [router.isReady, restaurantId]);
 
-  const coverImg = restaurant?.cover_image_url || '';
-
-  // derive restaurant id from query so CTA retains context
-  const rid = (() => {
-    const qp = router?.query ?? {};
-    const v: any = (qp as any).restaurant_id ?? (qp as any).id ?? (qp as any).r;
-    return Array.isArray(v) ? v[0] : v;
-  })();
-  const orderHref = rid ? `/restaurant/menu?restaurant_id=${String(rid)}` : '/restaurant/menu';
-
   return (
       <CustomerLayout
         cartCount={cartCount}
@@ -51,43 +40,7 @@ export default function RestaurantHomePage({ initialBrand }: { initialBrand: any
         hideHeader={heroInView}
       >
       {process.env.NEXT_PUBLIC_DEBUG === '1' && <DebugFlag label="HOME-A" />}
-      <Slides onHeroInView={setHeroInView}>
-        {/* Slide 1 — HERO */}
-        <LandingHero
-          title={restaurant?.website_title || restaurant?.name || 'Restaurant'}
-          subtitle={restaurant?.website_description ?? null}
-          ctaLabel="Order Now"
-          ctaHref={orderHref}
-          imageUrl={coverImg || undefined}
-          logoUrl={restaurant?.logo_url ?? null}
-          logoShape={restaurant?.logo_shape ?? null}
-        />
-
-        {/* Slide 2 — Opening Hours & Address */}
-        <section className="flex h-full flex-col items-center justify-center gap-3 p-4 text-center">
-          <h2 className="text-xl font-bold">Opening Hours & Address</h2>
-          <p>Opening hours will be displayed here.</p>
-          <p>Address details will be displayed here.</p>
-        </section>
-
-        {/* Slide 3 — Menu Preview */}
-        <section className="flex h-full flex-col items-center justify-center gap-3 p-4 text-center">
-          <h2 className="text-xl font-bold">Menu Preview</h2>
-          <p>Menu preview coming soon.</p>
-        </section>
-
-        {/* Slide 4 — Gallery */}
-        <section className="flex h-full flex-col items-center justify-center gap-3 p-4 text-center">
-          <h2 className="text-xl font-bold">Gallery</h2>
-          <p>Photos will be displayed here.</p>
-        </section>
-
-        {/* Slide 5 — Contact Us */}
-        <section className="flex h-full flex-col items-center justify-center gap-3 p-4 text-center">
-          <h2 className="text-xl font-bold">Contact Us</h2>
-          <p>Phone, email, and contact form will be displayed here.</p>
-        </section>
-      </Slides>
+      <RestaurantSlides restaurantId={restaurantId} restaurant={restaurant} onHeroInView={setHeroInView} />
       </CustomerLayout>
   );
 }

--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -1,0 +1,10 @@
+import { supabase } from './supabaseClient';
+
+export async function trackSlideEvent(event: 'slide_impression' | 'slide_cta_click', payload: Record<string, any>) {
+  try {
+    await supabase.from('analytics_events').insert({ event, payload });
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn('analytics event failed', e);
+  }
+}


### PR DESCRIPTION
## Summary
- load restaurant slides from Supabase and render full-screen snap sections
- add dashboard slide manager with drag-and-drop ordering and status toggle
- emit basic analytics events for slide impressions and CTA clicks

## Testing
- `npm run build`
- `npm run test:ci` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b89ebd7b288325b5ecbd0a1505cc8d