### PR TITLE
feat: rebuild dashboard slide editor

### DIFF
--- a/components/SlideModal.tsx
+++ b/components/SlideModal.tsx
@@ -1,242 +1,246 @@
-import React, { useEffect, useRef, useState } from 'react';
-import type { CSSProperties } from 'react';
-import { DndContext, closestCenter } from '@dnd-kit/core';
-import {
-  SortableContext,
-  verticalListSortingStrategy,
-  useSortable,
-  arrayMove,
-} from '@dnd-kit/sortable';
-import { CSS } from '@dnd-kit/utilities';
-import { supabase } from '@/utils/supabaseClient';
-import { toast } from '@/components/ui/toast';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import SlidesManager, {
+  type DeviceKind,
+  type Frame,
+  type SlideBlock,
+  type SlideCfg,
+  type SlidesManagerChangeOptions,
+} from './SlidesManager';
 import Button from '@/components/ui/Button';
-import { SlideRow } from '@/components/customer/home/SlidesContainer';
-import SlidesSection from '@/components/SlidesSection';
+import { supabase } from '@/utils/supabaseClient';
 import { STORAGE_BUCKET } from '@/lib/storage';
-import Skeleton from '@/components/ui/Skeleton';
-import { ChevronUpIcon, ChevronDownIcon } from '@heroicons/react/24/outline';
+import { SlideRow } from '@/components/customer/home/SlidesContainer';
 
-// slide config types
-export type SlideConfig = {
-  mode?: 'structured' | 'freeform';
-  background?: {
-    kind: 'color' | 'image' | 'video';
-    value?: string;
-    fit?: 'cover' | 'contain';
-    position?: 'center' | 'top' | 'bottom';
-    muted?: boolean;
-    loop?: boolean;
-    autoplay?: boolean;
-    overlay?: boolean;
-    overlayColor?: string;
-    overlayOpacity?: number;
-  };
-  blocks: (
-    | {
-        id: string;
-        type: 'heading';
-        text: string;
-        align?: 'left' | 'center' | 'right';
-        fontSize?: number;
-        fontFamily?: string;
-        color?: string;
-        overlay?: { color: string; opacity: number };
-        rotateDeg?: number;
-      }
-    | {
-        id: string;
-        type: 'subheading';
-        text: string;
-        align?: 'left' | 'center' | 'right';
-        fontSize?: number;
-        fontFamily?: string;
-        color?: string;
-        overlay?: { color: string; opacity: number };
-        rotateDeg?: number;
-      }
-    | { id: string; type: 'button'; text: string; href: string }
-    | {
-        id: string;
-        type: 'image';
-        url: string;
-        width?: number;
-        height?: number;
-        overlay?: { color: string; opacity: number };
-        rotateDeg?: number;
-      }
-    | { id: string; type: 'quote'; text: string; author?: string }
-    | { id: string; type: 'gallery'; images: string[] }
-    | { id: string; type: 'spacer'; size?: 'sm' | 'md' | 'lg' }
-  )[];
-  layout?: 'split';
-  positions?: Record<string, { xPct: number; yPct: number; wPct?: number; hPct?: number; z?: number; rotateDeg?: number }>;
-  structuredGroupAlign?: { v: 'top' | 'center' | 'bottom'; h: 'left' | 'center' | 'right' };
+const ROUTE_OPTIONS = ['/menu', '/orders', '/more'];
+
+const DEFAULT_FRAMES: Record<SlideBlock['kind'], Frame> = {
+  heading: { x: 12, y: 12, w: 76, h: 18, r: 0 },
+  subheading: { x: 12, y: 32, w: 70, h: 14, r: 0 },
+  text: { x: 12, y: 48, w: 72, h: 24, r: 0 },
+  button: { x: 12, y: 76, w: 40, h: 12, r: 0 },
+  image: { x: 20, y: 20, w: 48, h: 40, r: 0 },
+  quote: { x: 10, y: 50, w: 60, h: 22, r: 0 },
+  gallery: { x: 6, y: 60, w: 88, h: 26, r: 0 },
+  spacer: { x: 0, y: 0, w: 10, h: 10, r: 0 },
 };
 
-export function coerceConfig(raw: any): SlideConfig {
-  const cfg = raw && typeof raw === 'object' ? raw : {};
-  if (!cfg.mode) cfg.mode = 'structured';
-  if (!cfg.background)
-    cfg.background = { kind: 'color', value: '#111', overlay: false };
-  if (!Array.isArray(cfg.blocks)) cfg.blocks = [];
-  if (!cfg.positions) cfg.positions = {};
-  if (!cfg.structuredGroupAlign)
-    cfg.structuredGroupAlign = { v: 'center', h: 'center' };
-  return cfg as SlideConfig;
+const TEXT_SIZES: { value: NonNullable<SlideBlock['size']>; label: string }[] = [
+  { value: 'sm', label: 'Small' },
+  { value: 'md', label: 'Medium' },
+  { value: 'lg', label: 'Large' },
+  { value: 'xl', label: 'Extra large' },
+];
+
+const cloneCfg = (cfg: SlideCfg): SlideCfg => JSON.parse(JSON.stringify(cfg));
+
+function defaultBackground(): SlideCfg['background'] {
+  return { type: 'color', color: '#111', overlay: { color: '#000', opacity: 0.25 } };
 }
 
-const defaultConfig: SlideConfig = coerceConfig({});
-
-const knownRoutes = ['/menu', '/orders', '/p/contact'];
-
-function SortableBlock({ block, onSelect, selected, onDelete, onMove, index, lastIndex }: any) {
-  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
-    id: block.id,
-  });
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-  } as React.CSSProperties;
-  return (
-    <div
-      ref={setNodeRef}
-      style={style}
-      className={`flex items-center justify-between p-2 border rounded mb-2 ${selected ? 'bg-neutral-100' : ''}`}
-      onClick={() => onSelect(block.id)}
-      {...attributes}
-      {...listeners}
-    >
-      <span className="flex items-center gap-1">
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onMove(block.id, 'up');
-          }}
-          disabled={index === 0}
-          className="p-0.5"
-        >
-          <ChevronUpIcon className="h-4 w-4" />
-        </button>
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onMove(block.id, 'down');
-          }}
-          disabled={index === lastIndex}
-          className="p-0.5"
-        >
-          <ChevronDownIcon className="h-4 w-4" />
-        </button>
-        {block.type}
-      </span>
-      <button
-        type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          onDelete(block.id);
-        }}
-        className="text-sm px-1 border rounded"
-      >
-        x
-      </button>
-    </div>
-  );
+function clampPct(v: number) {
+  if (Number.isNaN(v)) return 0;
+  return Math.min(100, Math.max(0, v));
 }
 
-export default function SlideModal({
-  slide,
-  initialCfg,
-  onClose,
-  onSave,
-}: {
-  slide: SlideRow;
-  initialCfg: SlideConfig;
-  onClose: () => void;
-  onSave: (cfg: SlideConfig) => void;
-}) {
-  const [drawerOpen, setDrawerOpen] = useState(true);
-  const [inspectorOpen, setInspectorOpen] = useState(true);
-  const [editInPreview, setEditInPreview] = useState(true);
-  const [showDebug, setShowDebug] = useState(false);
-  const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [device, setDevice] = useState<'mobile' | 'tablet' | 'desktop'>('mobile');
-  const deviceFrameRef = useRef<HTMLDivElement>(null);
-  const [cfg, setCfg] = useState<SlideConfig>(initialCfg || {
-    blocks: [],
-    positions: {},
-    background: { kind: 'color', value: '#111', overlay: false },
-  });
-  const [logs, setLogs] = useState<string[]>([]);
-  const [type, setType] = useState<string>('menu_highlight');
-  const [title, setTitle] = useState('');
-  const [subtitle, setSubtitle] = useState('');
-  const [ctaLabel, setCtaLabel] = useState('');
-  const [ctaHref, setCtaHref] = useState('');
-  const [visibleFrom, setVisibleFrom] = useState('');
-  const [visibleUntil, setVisibleUntil] = useState('');
-  const [linkChoice, setLinkChoice] = useState('custom');
-  const [customPages, setCustomPages] = useState<string[]>([]);
-  const [template, setTemplate] = useState('');
-  const fileRef = useRef<HTMLInputElement | null>(null);
-  const imageRef = useRef<HTMLInputElement | null>(null);
-  const galleryRef = useRef<HTMLInputElement | null>(null);
-  const [uploading, setUploading] = useState(false);
-  const [uploadPct, setUploadPct] = useState<number | null>(null);
-  const isEdit = !!slide?.id;
-  const restaurantId = slide.restaurant_id;
+function getDefaultFrame(kind: SlideBlock['kind']): Frame {
+  return { ...DEFAULT_FRAMES[kind] };
+}
 
-  function select(id: string | null) {
-    setSelectedId(id);
+function ensureFrame(block: SlideBlock, device: DeviceKind): Frame {
+  return block.frames[device] ? { ...block.frames[device]! } : getDefaultFrame(block.kind);
+}
+
+function convertLegacyFrame(pos: any): Frame {
+  const w = typeof pos?.wPct === 'number' ? clampPct(pos.wPct) : 40;
+  const h = typeof pos?.hPct === 'number' ? clampPct(pos.hPct) : 20;
+  const cx = typeof pos?.xPct === 'number' ? clampPct(pos.xPct) : 50;
+  const cy = typeof pos?.yPct === 'number' ? clampPct(pos.yPct) : 50;
+  const x = clampPct(cx - w / 2);
+  const y = clampPct(cy - h / 2);
+  const r = typeof pos?.rotateDeg === 'number' ? pos.rotateDeg : 0;
+  return { x, y, w, h, r };
+}
+
+function normalizeBackground(raw: any): SlideCfg['background'] {
+  if (!raw) return defaultBackground();
+  if (raw.type === 'color' || raw.type === 'image' || raw.type === 'video') {
+    return {
+      type: raw.type,
+      color: raw.color,
+      url: raw.url,
+      overlay: raw.overlay ? { color: raw.overlay.color, opacity: raw.overlay.opacity ?? 0.25 } : undefined,
+    };
+  }
+  if (raw.kind === 'image' || raw.kind === 'video') {
+    return {
+      type: raw.kind,
+      url: raw.value ?? undefined,
+      overlay: raw.overlay
+        ? { color: raw.overlayColor || '#000', opacity: raw.overlayOpacity ?? 0.25 }
+        : undefined,
+    };
+  }
+  return {
+    type: 'color',
+    color: raw.value || '#111',
+    overlay: raw.overlay
+      ? { color: raw.overlayColor || '#000', opacity: raw.overlayOpacity ?? 0.25 }
+      : undefined,
+  };
+}
+
+function normalizeBlock(raw: any, positions?: Record<string, any>): SlideBlock {
+  const kind: SlideBlock['kind'] = raw.kind ?? raw.type ?? 'text';
+  const frames: SlideBlock['frames'] = {};
+  if (raw.frames && typeof raw.frames === 'object') {
+    (Object.keys(raw.frames) as DeviceKind[]).forEach((device) => {
+      const f = raw.frames[device];
+      if (f) {
+        frames[device] = {
+          x: clampPct(f.x ?? f.xPct ?? DEFAULT_FRAMES[kind].x),
+          y: clampPct(f.y ?? f.yPct ?? DEFAULT_FRAMES[kind].y),
+          w: clampPct(f.w ?? f.wPct ?? DEFAULT_FRAMES[kind].w),
+          h: clampPct(f.h ?? f.hPct ?? DEFAULT_FRAMES[kind].h),
+          r: typeof f.r === 'number' ? f.r : typeof f.rotateDeg === 'number' ? f.rotateDeg : DEFAULT_FRAMES[kind].r,
+        };
+      }
+    });
+  }
+  if (Object.keys(frames).length === 0) {
+    const legacy = positions?.[raw.id];
+    if (legacy) {
+      const converted = convertLegacyFrame(legacy);
+      frames.mobile = converted;
+      frames.tablet = converted;
+      frames.desktop = converted;
+    } else {
+      frames.desktop = getDefaultFrame(kind);
+    }
   }
 
-  useEffect(() => {
-    (window as any).__slideLog = (msg: string) =>
-      setLogs((l) => [...l.slice(-20), String(msg)]);
-    return () => {
-      delete (window as any).__slideLog;
-    };
-  }, []);
+  const block: SlideBlock = {
+    id: raw.id || crypto.randomUUID(),
+    kind,
+    frames,
+    text: raw.text ?? raw.label ?? '',
+    href: raw.href,
+    src: raw.src || raw.url,
+    color: raw.color,
+    align: raw.align,
+    size: raw.size,
+    buttonVariant: raw.buttonVariant,
+    fit: raw.fit,
+    author: raw.author,
+    items: Array.isArray(raw.items)
+      ? raw.items
+      : Array.isArray(raw.images)
+        ? raw.images.map((src: string) => ({ src }))
+        : undefined,
+    height: raw.height,
+  };
+
+  if (kind === 'gallery' && !block.items) block.items = [];
+  if (kind === 'image' && !block.fit) block.fit = 'cover';
+  if (kind === 'heading' && !block.size) block.size = 'xl';
+  if (kind === 'subheading' && !block.size) block.size = 'md';
+  if (kind === 'text' && !block.size) block.size = 'sm';
+  if (kind === 'button' && !block.text) block.text = 'Button';
+  if ((kind === 'heading' || kind === 'subheading' || kind === 'text') && !block.color) {
+    block.color = '#ffffff';
+  }
+
+  return block;
+}
+
+function normalizeConfig(raw: any, slide: SlideRow): SlideCfg {
+  const source = raw && typeof raw === 'object' ? raw : {};
+  const cfg: SlideCfg = {
+    background: normalizeBackground(source.background),
+    blocks: Array.isArray(source.blocks)
+      ? source.blocks.map((b: any) => normalizeBlock(b, source.positions))
+      : [],
+  };
+
+  if (cfg.blocks.length === 0) {
+    const blocks: SlideBlock[] = [];
+    if (slide.title) {
+      blocks.push({
+        id: crypto.randomUUID(),
+        kind: 'heading',
+        text: slide.title,
+        color: '#ffffff',
+        size: 'xl',
+        frames: { desktop: getDefaultFrame('heading') },
+      });
+    }
+    if (slide.subtitle) {
+      blocks.push({
+        id: crypto.randomUUID(),
+        kind: 'subheading',
+        text: slide.subtitle,
+        color: '#ffffff',
+        size: 'md',
+        frames: { desktop: getDefaultFrame('subheading') },
+      });
+    }
+    if (slide.cta_label) {
+      blocks.push({
+        id: crypto.randomUUID(),
+        kind: 'button',
+        text: slide.cta_label,
+        href: slide.cta_href ?? '/menu',
+        frames: { desktop: getDefaultFrame('button') },
+      });
+    }
+    cfg.blocks = blocks.length
+      ? blocks
+      : [
+          {
+            id: crypto.randomUUID(),
+            kind: 'heading',
+            text: 'New Slide',
+            color: '#ffffff',
+            size: 'xl',
+            frames: { desktop: getDefaultFrame('heading') },
+          },
+        ];
+  }
+
+  return cfg;
+}
+
+interface SlideModalProps {
+  slide: SlideRow;
+  initialCfg: SlideCfg | Record<string, any> | null;
+  onSave: (cfg: SlideCfg) => Promise<void> | void;
+  onClose: () => void;
+}
+
+export default function SlideModal({ slide, initialCfg, onSave, onClose }: SlideModalProps) {
+  const restaurantId = slide.restaurant_id;
+  const [cfg, setCfg] = useState<SlideCfg>(() => normalizeConfig(initialCfg ?? {}, slide));
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [activeDevice, setActiveDevice] = useState<DeviceKind>('desktop');
+  const [editInPreview, setEditInPreview] = useState(true);
+  const [drawerOpen, setDrawerOpen] = useState(true);
+  const [inspectorOpen, setInspectorOpen] = useState(true);
+  const [customPages, setCustomPages] = useState<string[]>([]);
+  const [uploading, setUploading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const pastRef = useRef<SlideCfg[]>([]);
+  const futureRef = useRef<SlideCfg[]>([]);
+  const [, forceHistoryTick] = useState(0);
+  const imageInputRef = useRef<HTMLInputElement | null>(null);
+  const blockImageInputRef = useRef<HTMLInputElement | null>(null);
+  const galleryInputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
-    if (!slide) return;
-    setType(slide.type);
-    setTitle(slide.title || '');
-    setSubtitle(slide.subtitle || '');
-    setCtaLabel(slide.cta_label || '');
-    setCtaHref(slide.cta_href || '');
-    setVisibleFrom(slide.visible_from || '');
-    setVisibleUntil(slide.visible_until || '');
-    const cfg0 = coerceConfig(slide.config_json);
-    if (!cfg0.blocks || cfg0.blocks.length === 0) {
-      const blocks: any[] = [];
-      const positions: Record<string, any> = {};
-      let y = 40;
-      if (slide.title) {
-        const id = crypto.randomUUID();
-        blocks.push({ id, type: 'heading', text: slide.title });
-        positions[id] = { xPct: 50, yPct: y, z: 3, rotateDeg: 0 };
-        y += 10;
-      }
-      if (slide.subtitle) {
-        const id = crypto.randomUUID();
-        blocks.push({ id, type: 'subheading', text: slide.subtitle });
-        positions[id] = { xPct: 50, yPct: y, z: 3, rotateDeg: 0 };
-        y += 10;
-      }
-      if (slide.cta_label) {
-        const id = crypto.randomUUID();
-        blocks.push({ id, type: 'button', text: slide.cta_label, href: slide.cta_href || '/menu' });
-        positions[id] = { xPct: 50, yPct: y, z: 3, rotateDeg: 0 };
-      }
-      cfg0.blocks = blocks;
-      cfg0.positions = { ...(cfg0.positions || {}), ...positions };
-    }
-    setCfg(cfg0);
-    select(null);
-  }, [slide, setCfg]);
+    setCfg(normalizeConfig(initialCfg ?? {}, slide));
+    setSelectedId(null);
+    pastRef.current = [];
+    futureRef.current = [];
+    forceHistoryTick((v) => v + 1);
+  }, [initialCfg, slide]);
 
   useEffect(() => {
     if (!restaurantId) return;
@@ -244,842 +248,799 @@ export default function SlideModal({
       .from('custom_pages')
       .select('slug')
       .eq('restaurant_id', restaurantId)
-      .then(({ data }) => setCustomPages(data?.map((d) => `/p/${d.slug}`) || []));
+      .order('slug')
+      .then(({ data }) => {
+        if (data) setCustomPages(data.map((row) => `/p/${row.slug}`));
+      });
   }, [restaurantId]);
 
-  function addBlock(type: any) {
-    const id = crypto.randomUUID();
-    const block: any = { id, type };
-    if (type === 'heading' || type === 'subheading') block.text = type;
-    if (type === 'button') block.text = 'Click Me';
-    if (type === 'button') block.href = '/menu';
-    if (type === 'image') block.url = '';
-    if (type === 'quote') block.text = 'Quote';
-    if (type === 'gallery') block.images = [];
-    if (type === 'spacer') block.size = 'md';
-    setCfg((c) => {
-      const next = { ...c, blocks: [...c.blocks, block] };
-      if (c.mode === 'freeform') {
-        next.positions = {
-          ...next.positions,
-          [id]: { xPct: 50, yPct: 45, rotateDeg: 0 },
-        };
-      }
+  useEffect(() => {
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prevOverflow;
+    };
+  }, []);
+
+  const canUndo = pastRef.current.length > 0;
+  const canRedo = futureRef.current.length > 0;
+
+  const pushHistory = useCallback((snapshot: SlideCfg) => {
+    pastRef.current.push(snapshot);
+    if (pastRef.current.length > 100) pastRef.current.shift();
+    futureRef.current = [];
+    forceHistoryTick((v) => v + 1);
+  }, []);
+
+  const handlePreviewChange = useCallback(
+    (next: SlideCfg, options?: SlidesManagerChangeOptions) => {
+      setCfg((prev) => {
+        if (options?.commit) {
+          pushHistory(cloneCfg(prev));
+        }
+        return next;
+      });
+    },
+    [pushHistory]
+  );
+
+  const updateCfg = useCallback(
+    (mutator: (prev: SlideCfg) => SlideCfg, commit = true) => {
+      setCfg((prev) => {
+        const next = mutator(prev);
+        if (commit) {
+          pushHistory(cloneCfg(prev));
+        }
+        return next;
+      });
+    },
+    [pushHistory]
+  );
+
+  const undo = useCallback(() => {
+    setCfg((current) => {
+      const previous = pastRef.current.pop();
+      if (!previous) return current;
+      futureRef.current.push(cloneCfg(current));
+      forceHistoryTick((v) => v + 1);
+      return previous;
+    });
+  }, []);
+
+  const redo = useCallback(() => {
+    setCfg((current) => {
+      const next = futureRef.current.pop();
+      if (!next) return current;
+      pastRef.current.push(cloneCfg(current));
+      forceHistoryTick((v) => v + 1);
       return next;
     });
-    select(id);
-  }
+  }, []);
 
-  function updateBlock(id: string, patch: any) {
-    setCfg((c) => ({
-      ...c,
-      blocks: c.blocks.map((b) => (b.id === id ? { ...b, ...patch } : b)),
+  const addBlock = (kind: SlideBlock['kind']) => {
+    const id = crypto.randomUUID();
+    const frame = getDefaultFrame(kind);
+    const block: SlideBlock = {
+      id,
+      kind,
+      text:
+        kind === 'heading'
+          ? 'Add a headline'
+          : kind === 'subheading'
+            ? 'Add a subtitle'
+            : kind === 'text'
+              ? 'Write some supporting text'
+              : kind === 'button'
+                ? 'Tap me'
+                : kind === 'quote'
+                  ? 'Add a quote from a happy guest'
+                  : '',
+      href: kind === 'button' ? '/menu' : undefined,
+      frames: { [activeDevice]: frame },
+      color: kind === 'heading' || kind === 'subheading' || kind === 'text' ? '#ffffff' : undefined,
+      size:
+        kind === 'heading' ? 'xl' : kind === 'subheading' ? 'md' : kind === 'text' ? 'sm' : undefined,
+      fit: kind === 'image' ? 'cover' : undefined,
+      items: kind === 'gallery' ? [] : undefined,
+    };
+    updateCfg((prev) => ({ ...prev, blocks: [...prev.blocks, block] }));
+    setSelectedId(id);
+  };
+
+  const removeBlock = (id: string) => {
+    updateCfg((prev) => ({
+      ...prev,
+      blocks: prev.blocks.filter((b) => b.id !== id),
     }));
-  }
+    setSelectedId((prev) => (prev === id ? null : prev));
+  };
 
-  function deleteBlock(id: string) {
-    setCfg((c) => {
-      const pos = { ...c.positions };
-      delete pos[id];
-      return { ...c, blocks: c.blocks.filter((b) => b.id !== id), positions: pos };
+  const moveBlock = (id: string, direction: -1 | 1) => {
+    updateCfg((prev) => {
+      const idx = prev.blocks.findIndex((b) => b.id === id);
+      if (idx === -1) return prev;
+      const swap = idx + direction;
+      if (swap < 0 || swap >= prev.blocks.length) return prev;
+      const blocks = [...prev.blocks];
+      const [item] = blocks.splice(idx, 1);
+      blocks.splice(swap, 0, item);
+      return { ...prev, blocks };
     });
-    if (selectedId === id) select(null);
-  }
+  };
 
-  function moveBlock(id: string, dir: 'up' | 'down') {
-    setCfg((c) => {
-      const idx = c.blocks.findIndex((b) => b.id === id);
-      const swap = dir === 'up' ? idx - 1 : idx + 1;
-      if (idx === -1 || swap < 0 || swap >= c.blocks.length) return c;
-      const blocks = [...c.blocks];
-      [blocks[idx], blocks[swap]] = [blocks[swap], blocks[idx]];
-      return { ...c, blocks };
-    });
-  }
+  const patchBlock = (id: string, patch: Partial<SlideBlock>, commit = true) => {
+    updateCfg(
+      (prev) => ({
+        ...prev,
+        blocks: prev.blocks.map((b) => (b.id === id ? { ...b, ...patch } : b)),
+      }),
+      commit
+    );
+  };
 
-  function handleDragEnd(event: any) {
-    const { active, over } = event;
-    if (!over || active.id === over.id) return;
-    const oldIndex = cfg.blocks.findIndex((b) => b.id === active.id);
-    const newIndex = cfg.blocks.findIndex((b) => b.id === over.id);
-    setCfg((c) => ({ ...c, blocks: arrayMove(c.blocks, oldIndex, newIndex) }));
-  }
+  const updateFrameField = (id: string, field: keyof Frame, value: number) => {
+    updateCfg((prev) => ({
+      ...prev,
+      blocks: prev.blocks.map((b) => {
+        if (b.id !== id) return b;
+        const existing = ensureFrame(b, activeDevice);
+        const nextFrame: Frame = {
+          ...existing,
+          [field]: field === 'r' ? value : clampPct(value),
+        };
+        return {
+          ...b,
+          frames: {
+            ...b.frames,
+            [activeDevice]: nextFrame,
+          },
+        };
+      }),
+    }));
+  };
 
-  async function uploadFile(file: File, cb: (url: string) => void) {
+  const setBackground = (patch: Partial<NonNullable<SlideCfg['background']>>) => {
+    updateCfg((prev) => ({
+      ...prev,
+      background: { ...prev.background, ...patch },
+    }));
+  };
+
+  const handleUpload = async (file: File, onUrl: (url: string) => void) => {
+    if (!restaurantId) return;
     setUploading(true);
-    setUploadPct(0);
-    const ext = file.name.split('.').pop();
-    const path = `slides/${restaurantId}/${crypto.randomUUID()}.${ext}`;
     try {
-      const { data, error } = await supabase.storage
-        .from(STORAGE_BUCKET)
-        .upload(path, file, {
-          upsert: true,
-        });
+      const ext = file.name.split('.').pop();
+      const path = `slides/${restaurantId}/${crypto.randomUUID()}.${ext}`;
+      const { data, error } = await supabase.storage.from(STORAGE_BUCKET).upload(path, file, { upsert: true });
       if (error) throw error;
-      const { data: pub } = supabase.storage
-        .from(STORAGE_BUCKET)
-        .getPublicUrl(data.path);
-      setUploadPct(100);
-      cb(pub.publicUrl);
-    } catch (err: any) {
-      toast.error('Upload failed: ' + err.message);
+      const { data: pub } = supabase.storage.from(STORAGE_BUCKET).getPublicUrl(data.path);
+      if (pub?.publicUrl) onUrl(pub.publicUrl);
     } finally {
       setUploading(false);
-      setUploadPct(null);
     }
-  }
+  };
 
-  async function handleSave() {
-    onSave(cfg);
-    onClose();
-  }
-
-  const selectedBlock = cfg.blocks.find((b) => b.id === selectedId);
-
-  const linkOptions = [...knownRoutes, ...customPages, 'custom'];
-  useEffect(() => {
-    if (selectedBlock && selectedBlock.type === 'button') {
-      if (linkOptions.includes(selectedBlock.href)) setLinkChoice(selectedBlock.href);
-      else setLinkChoice('custom');
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await onSave(cfg);
+      onClose();
+    } finally {
+      setSaving(false);
     }
-  }, [selectedBlock, linkOptions]);
+  };
 
-  const widthMap: any = { mobile: 375, tablet: 768, desktop: 1280 };
+  const selectedBlock = useMemo(
+    () => cfg.blocks.find((b) => b.id === selectedId) || null,
+    [cfg.blocks, selectedId]
+  );
+
+  const frame = selectedBlock ? ensureFrame(selectedBlock, activeDevice) : null;
+
+  const linkOptions = useMemo(() => [...ROUTE_OPTIONS, ...customPages, 'custom'], [customPages]);
+
+  const selectionLabel = selectedBlock ? `${selectedBlock.kind}` : 'None';
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" style={{ position: 'fixed' }}>
-      <div className="bg-white rounded p-4 w-full max-w-5xl" style={{ maxHeight: '90vh', overflow: 'auto', position: 'relative' }}>
-        <div className="flex items-center justify-between mb-4">
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => setDrawerOpen((o) => !o)}
-              className="font-semibold"
-            >
-              Blocks
-            </button>
-            <button
-              type="button"
-              onClick={() => setInspectorOpen((o) => !o)}
-              className="font-semibold"
-            >
-              Inspector
-            </button>
-            <button type="button" disabled className="px-2 py-1 border rounded text-sm opacity-50">
-              Undo
-            </button>
-            <button type="button" disabled className="px-2 py-1 border rounded text-sm opacity-50">
-              Redo
-            </button>
-          </div>
-          <div className="flex items-center gap-3">
-            <label className="text-sm flex items-center gap-1">
-              <input
-                type="checkbox"
-                checked={editInPreview}
-                onChange={(e) => setEditInPreview(e.target.checked)}
-              />
-              Edit in preview
-            </label>
-            <label className="text-sm flex items-center gap-1">
-              <input
-                type="checkbox"
-                checked={showDebug}
-                onChange={(e) => setShowDebug(e.target.checked)}
-              />
-              Show debug
-            </label>
-            <Button onClick={handleSave}>Save</Button>
-            <button onClick={onClose} className="px-2 py-1 border rounded">
-              Close
-            </button>
-          </div>
-        </div>
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: `${drawerOpen ? 280 : 0}px 1fr ${inspectorOpen ? 320 : 0}px`,
-            gap: 16,
-          }}
-        >
-          {drawerOpen && (
-            <div>
-              <div className="mb-2">
-                <select
-                  value={template}
-                  onChange={(e) => {
-                    const t = e.target.value;
-                  setTemplate(t);
-                  switch (t) {
-                    case 'hero':
-                      setCfg({
-                        mode: 'structured',
-                        background: {
-                          kind: 'image',
-                          fit: 'cover',
-                          position: 'center',
-                          overlay: true,
-                          overlayColor: '#000',
-                          overlayOpacity: 0.25,
-                        },
-                        blocks: [
-                          { id: crypto.randomUUID(), type: 'heading', text: 'Welcome' },
-                          {
-                            id: crypto.randomUUID(),
-                            type: 'subheading',
-                            text: 'Fresh, local & fast',
-                          },
-                          {
-                            id: crypto.randomUUID(),
-                            type: 'button',
-                            text: 'Order Now',
-                            href: '/menu',
-                          },
-                        ],
-                        positions: {},
-                      });
-                      break;
-                    case 'quote':
-                      setCfg({
-                        mode: 'structured',
-                        background: { kind: 'color', value: '#fff' },
-                        blocks: [
-                          {
-                            id: crypto.randomUUID(),
-                            type: 'quote',
-                            text: 'Best food in town!',
-                            author: 'Happy Customer',
-                          },
-                        ],
-                        positions: {},
-                      });
-                      break;
-                    case 'gallery':
-                      setCfg({
-                        mode: 'structured',
-                        background: { kind: 'color', value: '#fff' },
-                        blocks: [
-                          {
-                            id: crypto.randomUUID(),
-                            type: 'gallery',
-                            images: [
-                              'https://placehold.co/200',
-                              'https://placehold.co/200',
-                              'https://placehold.co/200',
-                            ],
-                          },
-                        ],
-                        positions: {},
-                      });
-                      break;
-                    case 'split':
-                      setCfg({
-                        mode: 'structured',
-                        background: { kind: 'color', value: '#fff' },
-                        blocks: [
-                          { id: crypto.randomUUID(), type: 'image', url: '' },
-                          { id: crypto.randomUUID(), type: 'heading', text: 'Your headline' },
-                        ],
-                        layout: 'split',
-                        positions: {},
-                      });
-                      break;
-                    case 'cta':
-                      setCfg({
-                        mode: 'structured',
-                        background: { kind: 'color', value: '#111', overlay: false },
-                        blocks: [
-                          { id: crypto.randomUUID(), type: 'heading', text: 'Specials Tonight' },
-                          {
-                            id: crypto.randomUUID(),
-                            type: 'button',
-                            text: 'Browse Menu',
-                            href: '/menu',
-                          },
-                        ],
-                        positions: {},
-                      });
-                      break;
-                    case 'freeform':
-                      setCfg({
-                        mode: 'freeform',
-                        background: { kind: 'color', value: '#111', overlay: false },
-                        blocks: [],
-                        positions: {},
-                      });
-                      break;
-                    default:
-                      break;
-                  }
-                }}
-                className="border p-1 rounded w-full mb-2"
+    <div className="fixed inset-0 z-[80] flex">
+      <div className="absolute inset-0 bg-black/60" onClick={onClose} />
+      <div className="relative z-[81] m-4 flex w-[calc(100%-2rem)] max-w-[calc(100%-2rem)] flex-1 overflow-hidden rounded-2xl bg-white shadow-2xl">
+        <div className="flex min-h-[80vh] w-full flex-col">
+          <header className="flex flex-wrap items-center justify-between gap-3 border-b px-4 py-3">
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setDrawerOpen((v) => !v)}
+                className="rounded border px-3 py-1 text-sm"
               >
-                <option value="">Templates…</option>
-                <option value="hero">Hero with Button</option>
-                <option value="quote">Simple Quote</option>
-                <option value="gallery">Gallery Row</option>
-                <option value="split">Split Column</option>
-                <option value="cta">CTA Banner</option>
-                <option value="freeform">Custom (Freeform)</option>
-              </select>
-            </div>
-            <div className="mb-2 flex flex-wrap gap-2">
-              {[
-                'heading',
-                'subheading',
-                'button',
-                'image',
-                'quote',
-                'gallery',
-                'spacer',
-              ].map((t) => (
-                <button
-                  key={t}
-                  type="button"
-                  onClick={() => addBlock(t)}
-                  className="px-2 py-1 border rounded text-sm"
-                >
-                  Add {t}
-                </button>
-              ))}
-            </div>
-            <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-          <SortableContext items={cfg.blocks.map((b) => b.id)} strategy={verticalListSortingStrategy}>
-                {cfg.blocks.map((b, i) => (
-                  <SortableBlock
-                    key={b.id}
-                    block={b}
-                    onSelect={select}
-                    selected={b.id === selectedId}
-                    onDelete={deleteBlock}
-                    onMove={moveBlock}
-                    index={i}
-                    lastIndex={cfg.blocks.length - 1}
-                  />
-                ))}
-              </SortableContext>
-            </DndContext>
-            </div>
-          )}
-          <div>
-            {/* Preview */}
-            <div className="border p-2 rounded">
-              <div className="mb-2 flex gap-2">
-                {['mobile', 'tablet', 'desktop'].map((m) => (
-                  <button
-                    key={m}
-                    type="button"
-                    onClick={() => setDevice(m as any)}
-                    className={`px-2 py-1 border rounded text-sm ${device === m ? 'bg-neutral-200' : ''}`}
-                  >
-                    {m}
-                  </button>
-                ))}
-              </div>
-              <div
-                ref={deviceFrameRef}
-                style={{
-                  position: 'relative',
-                  width: widthMap[device],
-                  maxWidth: '100%',
-                  margin: '0 auto',
-                  border: '1px solid #e5e7eb',
-                  borderRadius: 12,
-                  overflow: 'hidden',
-                  background: '#fff',
-                  minHeight: '100dvh',
-                }}
-                >
-                <SlidesSection
-                  slide={{
-                    ...slide,
-                    type,
-                    title,
-                    subtitle,
-                    cta_label: ctaLabel,
-                    cta_href: ctaHref,
-                    media_url:
-                      cfg.background?.kind && cfg.background.kind !== 'color'
-                        ? cfg.background.value || null
-                        : null,
-                    config_json: cfg,
-                  }}
-                  cfg={cfg}
-                  setCfg={setCfg}
-                  editingEnabled={editInPreview}
-                  showEditorDebug={showDebug}
-                  deviceFrameRef={deviceFrameRef}
-                  selectedId={selectedId}
-                  onSelect={setSelectedId}
-                />
-              </div>
-            </div>
-          </div>
-          {inspectorOpen && (
-            <div className="space-y-4">
-            {/* Background controls */}
-              <div className="border p-2 rounded">
-                <h3 className="font-medium mb-2">Background</h3>
-                <select
-                  value={cfg.background?.kind}
-                  onChange={(e) =>
-                  setCfg({ ...cfg, background: { ...cfg.background!, kind: e.target.value as any } })
-                }
-                className="border p-1 rounded w-full mb-2"
+                {drawerOpen ? 'Hide Blocks' : 'Show Blocks'}
+              </button>
+              <button
+                type="button"
+                onClick={undo}
+                disabled={!canUndo}
+                className="rounded border px-3 py-1 text-sm disabled:opacity-50"
               >
-                <option value="color">Color</option>
-                <option value="image">Image</option>
-                <option value="video">Video</option>
-              </select>
-              {cfg.background?.kind === 'color' && (
-                <input
-                  type="text"
-                  value={cfg.background?.value || ''}
-                  onChange={(e) =>
-                    setCfg({ ...cfg, background: { ...cfg.background!, value: e.target.value } })
-                  }
-                  className="border p-1 rounded w-full"
-                />
-              )}
-              {cfg.background?.kind !== 'color' && (
-                <div className="space-y-1">
-                  <input
-                    ref={fileRef}
-                    type="file"
-                    className="hidden"
-                    onChange={(e) => {
-                      const f = e.target.files?.[0];
-                      if (f) uploadFile(f, (url) =>
-                        setCfg({ ...cfg, background: { ...cfg.background!, value: url } })
-                      );
-                    }}
-                  />
-                  <button
-                    type="button"
-                    onClick={() => fileRef.current?.click()}
-                    className="px-2 py-1 border rounded text-sm"
-                  >
-                    Upload
-                  </button>
-                  {uploading && <Skeleton className="h-4 w-4 inline-block ml-2" />}
-                  {uploadPct !== null && <span className="text-xs ml-1">{uploadPct}%</span>}
-                  {cfg.background?.value && (
-                    <div className="text-xs break-all">{cfg.background.value}</div>
-                  )}
-                </div>
-              )}
-              <label className="mt-2 flex items-center gap-2">
+                Undo
+              </button>
+              <button
+                type="button"
+                onClick={redo}
+                disabled={!canRedo}
+                className="rounded border px-3 py-1 text-sm disabled:opacity-50"
+              >
+                Redo
+              </button>
+              <button
+                type="button"
+                onClick={() => setInspectorOpen((v) => !v)}
+                className="rounded border px-3 py-1 text-sm"
+              >
+                {inspectorOpen ? 'Hide Inspector' : 'Show Inspector'}
+              </button>
+            </div>
+            <div className="flex items-center gap-4">
+              <label className="flex items-center gap-2 text-sm">
                 <input
                   type="checkbox"
-                  checked={cfg.background?.overlay || false}
-                  onChange={(e) =>
-                    setCfg({
-                      ...cfg,
-                      background: { ...cfg.background!, overlay: e.target.checked },
-                    })
-                  }
+                  checked={editInPreview}
+                  onChange={(e) => setEditInPreview(e.target.checked)}
                 />
-                Overlay
+                Edit in preview
               </label>
-              {cfg.background?.overlay && (
-                <div className="flex gap-2 mt-1">
-                  <input
-                    type="text"
-                    placeholder="#000"
-                    value={cfg.background?.overlayColor || ''}
-                    onChange={(e) =>
-                      setCfg({
-                        ...cfg,
-                        background: { ...cfg.background!, overlayColor: e.target.value },
-                      })
-                    }
-                    className="border p-1 rounded flex-1"
-                  />
-                  <input
-                    type="number"
-                    step="0.05"
-                    min="0"
-                    max="0.6"
-                    value={cfg.background?.overlayOpacity ?? 0.25}
-                    onChange={(e) =>
-                      setCfg({
-                        ...cfg,
-                        background: {
-                          ...cfg.background!,
-                          overlayOpacity: parseFloat(e.target.value),
-                        },
-                      })
-                    }
-                    className="border p-1 rounded w-20"
-                  />
-                </div>
-              )}
-              </div>
-
-            {cfg.mode === 'structured' && (
-              <div className="border p-2 rounded mt-2">
-                <h3 className="font-medium mb-2">Group Position</h3>
-                <div className="flex items-center gap-2 mb-2">
-                  <label className="text-xs">Vertical</label>
-                  <select
-                    value={cfg.structuredGroupAlign?.v || 'center'}
-                    onChange={(e) =>
-                      setCfg({
-                        ...cfg,
-                        structuredGroupAlign: {
-                          ...(cfg.structuredGroupAlign || { h: 'center' }),
-                          v: e.target.value as any,
-                        },
-                      })
-                    }
-                    className="border p-1 rounded flex-1"
-                  >
-                    <option value="top">Top</option>
-                    <option value="center">Center</option>
-                    <option value="bottom">Bottom</option>
-                  </select>
-                </div>
-                <div className="flex items-center gap-2">
-                  <label className="text-xs">Horizontal</label>
-                  <select
-                    value={cfg.structuredGroupAlign?.h || 'center'}
-                    onChange={(e) =>
-                      setCfg({
-                        ...cfg,
-                        structuredGroupAlign: {
-                          ...(cfg.structuredGroupAlign || { v: 'center' }),
-                          h: e.target.value as any,
-                        },
-                      })
-                    }
-                    className="border p-1 rounded flex-1"
-                  >
-                    <option value="left">Left</option>
-                    <option value="center">Center</option>
-                    <option value="right">Right</option>
-                  </select>
-                </div>
-              </div>
-            )}
-
-            {/* Block properties */}
-            {selectedBlock && (
-              <div className="border p-2 rounded">
-                <h3 className="font-medium mb-2">Block</h3>
-                {selectedBlock.type === 'heading' || selectedBlock.type === 'subheading' ? (
-                  <div className="space-y-2">
-                    <input
-                      type="text"
-                      value={selectedBlock.text}
-                      onChange={(e) => updateBlock(selectedBlock.id, { text: e.target.value })}
-                      className="border p-1 rounded w-full"
-                    />
-                    <div className="flex items-center gap-2">
-                      <label className="text-xs">Size</label>
-                      <input
-                        type="number"
-                        value={selectedBlock.fontSize || ''}
-                        onChange={(e) => updateBlock(selectedBlock.id, { fontSize: parseInt(e.target.value) || undefined })}
-                        className="border p-1 rounded w-20"
-                      />
-                      <label className="text-xs">Font</label>
-                      <select
-                        value={selectedBlock.fontFamily || ''}
-                        onChange={(e) => updateBlock(selectedBlock.id, { fontFamily: e.target.value || undefined })}
-                        className="border p-1 rounded"
-                      >
-                        <option value="">Default</option>
-                        <option value="serif">Serif</option>
-                        <option value="monospace">Mono</option>
-                      </select>
-                      <label className="text-xs">Color</label>
-                      <input
-                        type="color"
-                        value={selectedBlock.color || '#000000'}
-                        onChange={(e) => updateBlock(selectedBlock.id, { color: e.target.value })}
-                        className="border rounded w-10 h-6 p-0"
-                      />
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <label className="text-xs">Rotate</label>
-                      <input
-                        type="number"
-                        min="-45"
-                        max="45"
-                        value={selectedBlock.rotateDeg || 0}
-                        onChange={(e) => updateBlock(selectedBlock.id, { rotateDeg: parseInt(e.target.value) || 0 })}
-                        className="border p-1 rounded w-20"
-                      />
-                      <label className="text-xs">Overlay</label>
-                      <input
-                        type="checkbox"
-                        checked={!!selectedBlock.overlay}
-                        onChange={(e) =>
-                          updateBlock(selectedBlock.id, {
-                            overlay: e.target.checked
-                              ? { color: '#000000', opacity: 0.25 }
-                              : undefined,
-                          })
-                        }
-                      />
-                      {selectedBlock.overlay && (
-                        <>
-                          <input
-                            type="color"
-                            value={selectedBlock.overlay.color}
-                            onChange={(e) =>
-                              updateBlock(selectedBlock.id, {
-                                overlay: {
-                                  ...selectedBlock.overlay!,
-                                  color: e.target.value,
-                                },
-                              })
-                            }
-                            className="border rounded w-10 h-6 p-0"
-                          />
-                          <input
-                            type="number"
-                            step="0.05"
-                            min="0"
-                            max="0.6"
-                            value={selectedBlock.overlay.opacity}
-                            onChange={(e) =>
-                              updateBlock(selectedBlock.id, {
-                                overlay: {
-                                  ...selectedBlock.overlay!,
-                                  opacity: parseFloat(e.target.value),
-                                },
-                              })
-                            }
-                            className="border p-1 rounded w-20"
-                          />
-                        </>
-                      )}
-                    </div>
-                  </div>
-                ) : null}
-                {selectedBlock.type === 'button' && (
-                  <>
-                    <input
-                      type="text"
-                      value={selectedBlock.text}
-                      onChange={(e) => updateBlock(selectedBlock.id, { text: e.target.value })}
-                      className="border p-1 rounded w-full mb-2"
-                    />
-                    <select
-                      value={linkChoice}
-                      onChange={(e) => {
-                        const v = e.target.value;
-                        setLinkChoice(v);
-                        if (v === 'custom') updateBlock(selectedBlock.id, { href: '' });
-                        else updateBlock(selectedBlock.id, { href: v });
-                      }}
-                      className="border p-1 rounded w-full mb-2"
-                    >
-                      {linkOptions.map((o) => (
-                        <option key={o} value={o}>
-                          {o === 'custom' ? 'Custom URL…' : o}
-                        </option>
-                      ))}
-                    </select>
-                    {linkChoice === 'custom' && (
-                      <input
-                        type="text"
-                        value={selectedBlock.href || ''}
-                        onChange={(e) => updateBlock(selectedBlock.id, { href: e.target.value })}
-                        className="border p-1 rounded w-full mb-2"
-                      />
-                    )}
-                  </>
-                )}
-                {selectedBlock.type === 'image' && (
-                  <div className="space-y-2">
-                    <input
-                      ref={imageRef}
-                      type="file"
-                      className="hidden"
-                      onChange={(e) => {
-                        const f = e.target.files?.[0];
-                        if (f)
-                          uploadFile(f, (url) => updateBlock(selectedBlock.id, { url }));
-                      }}
-                    />
-                    <button
-                      type="button"
-                      onClick={() => imageRef.current?.click()}
-                      className="px-2 py-1 border rounded text-sm"
-                    >
-                      Upload
-                    </button>
-                    {uploading && <Skeleton className="h-4 w-4 inline-block ml-2" />}
-                    {uploadPct !== null && <span className="text-xs ml-1">{uploadPct}%</span>}
-                    {selectedBlock.url && (
-                      <div className="text-xs break-all">{selectedBlock.url}</div>
-                    )}
-                    <div className="flex items-center gap-2">
-                      <label className="text-xs">Rotate</label>
-                      <input
-                        type="number"
-                        min="-45"
-                        max="45"
-                        value={selectedBlock.rotateDeg || 0}
-                        onChange={(e) =>
-                          updateBlock(selectedBlock.id, { rotateDeg: parseInt(e.target.value) || 0 })
-                        }
-                        className="border p-1 rounded w-20"
-                      />
-                      <label className="text-xs">Overlay</label>
-                      <input
-                        type="checkbox"
-                        checked={!!selectedBlock.overlay}
-                        onChange={(e) =>
-                          updateBlock(selectedBlock.id, {
-                            overlay: e.target.checked
-                              ? { color: '#000000', opacity: 0.25 }
-                              : undefined,
-                          })
-                        }
-                      />
-                      {selectedBlock.overlay && (
-                        <>
-                          <input
-                            type="color"
-                            value={selectedBlock.overlay.color}
-                            onChange={(e) =>
-                              updateBlock(selectedBlock.id, {
-                                overlay: {
-                                  ...selectedBlock.overlay!,
-                                  color: e.target.value,
-                                },
-                              })
-                            }
-                            className="border rounded w-10 h-6 p-0"
-                          />
-                          <input
-                            type="number"
-                            step="0.05"
-                            min="0"
-                            max="0.6"
-                            value={selectedBlock.overlay.opacity}
-                            onChange={(e) =>
-                              updateBlock(selectedBlock.id, {
-                                overlay: {
-                                  ...selectedBlock.overlay!,
-                                  opacity: parseFloat(e.target.value),
-                                },
-                              })
-                            }
-                            className="border p-1 rounded w-20"
-                          />
-                        </>
-                      )}
-                    </div>
-                  </div>
-                )}
-                {selectedBlock.type === 'gallery' && (
-                  <div className="space-y-2">
-                    <input
-                      ref={galleryRef}
-                      type="file"
-                      multiple
-                      className="hidden"
-                      onChange={(e) => {
-                        const files = Array.from(e.target.files || []);
-                        files.forEach((f) =>
-                          uploadFile(f, (url) =>
-                            updateBlock(selectedBlock.id, {
-                              images: [...selectedBlock.images, url],
-                            })
-                          )
-                        );
-                      }}
-                    />
-                    <button
-                      type="button"
-                      onClick={() => galleryRef.current?.click()}
-                      className="px-2 py-1 border rounded text-sm"
-                    >
-                      Upload Images
-                    </button>
-                    {uploading && <Skeleton className="h-4 w-4 inline-block ml-2" />}
-                    {uploadPct !== null && <span className="text-xs ml-1">{uploadPct}%</span>}
-                    {selectedBlock.images.map((img: string, i: number) => (
-                      <div key={i} className="flex items-center gap-2 text-xs">
-                        <span className="flex-1 break-all">{img}</span>
+              <Button onClick={handleSave} disabled={saving}>
+                {saving ? 'Saving…' : 'Save'}
+              </Button>
+              <button onClick={onClose} className="rounded border px-3 py-1 text-sm">
+                Close
+              </button>
+            </div>
+          </header>
+          <div className="flex flex-1 overflow-hidden">
+            {drawerOpen && (
+              <aside className="w-64 shrink-0 border-r bg-white">
+                <div className="h-full space-y-4 overflow-y-auto p-4">
+                  <div>
+                    <h3 className="text-sm font-semibold uppercase tracking-wide text-neutral-500">Blocks</h3>
+                    <div className="mt-2 grid grid-cols-2 gap-2">
+                      {(
+                        [
+                          'heading',
+                          'subheading',
+                          'text',
+                          'button',
+                          'image',
+                          'quote',
+                          'gallery',
+                          'spacer',
+                        ] as SlideBlock['kind'][]
+                      ).map((kind) => (
                         <button
+                          key={kind}
                           type="button"
-                          onClick={() =>
-                            updateBlock(selectedBlock.id, {
-                              images: selectedBlock.images.filter((_: any, idx: number) => idx !== i),
+                          onClick={() => addBlock(kind)}
+                          className="rounded border px-2 py-1 text-left text-xs capitalize hover:border-emerald-500"
+                        >
+                          + {kind}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                  <div>
+                    <h3 className="mb-2 text-sm font-semibold text-neutral-600">Layers</h3>
+                    <div className="space-y-2">
+                      {cfg.blocks.map((block, index) => (
+                        <div
+                          key={block.id}
+                          className={`rounded border px-2 py-2 text-sm transition hover:border-emerald-400 ${
+                            block.id === selectedId ? 'border-emerald-500 bg-emerald-50' : 'border-neutral-200'
+                          }`}
+                        >
+                          <button
+                            type="button"
+                            onClick={() => setSelectedId(block.id)}
+                            className="flex w-full items-center justify-between text-left"
+                          >
+                            <span className="capitalize">{block.kind}</span>
+                            <span className="text-xs text-neutral-500">{index + 1}</span>
+                          </button>
+                          <div className="mt-2 flex gap-2 text-xs">
+                            <button
+                              type="button"
+                              onClick={() => moveBlock(block.id, -1)}
+                              className="rounded border px-2 py-1 disabled:opacity-40"
+                              disabled={index === 0}
+                            >
+                              Up
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => moveBlock(block.id, 1)}
+                              className="rounded border px-2 py-1 disabled:opacity-40"
+                              disabled={index === cfg.blocks.length - 1}
+                            >
+                              Down
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => removeBlock(block.id)}
+                              className="rounded border px-2 py-1 text-red-600"
+                            >
+                              Delete
+                            </button>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div>
+                    <h3 className="mb-2 text-sm font-semibold text-neutral-600">Device</h3>
+                    <div className="flex gap-2">
+                      {(['mobile', 'tablet', 'desktop'] as DeviceKind[]).map((device) => (
+                        <button
+                          key={device}
+                          type="button"
+                          onClick={() => setActiveDevice(device)}
+                          className={`rounded border px-2 py-1 text-xs capitalize ${
+                            activeDevice === device ? 'border-emerald-500 bg-emerald-50' : 'border-neutral-200'
+                          }`}
+                        >
+                          {device}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </aside>
+            )}
+            <main className="flex-1 overflow-hidden bg-neutral-50">
+              <SlidesManager
+                initialCfg={cfg}
+                onChange={handlePreviewChange}
+                editable={true}
+                selectedId={selectedId}
+                onSelect={setSelectedId}
+                activeDevice={activeDevice}
+                editInPreview={editInPreview}
+              />
+            </main>
+            {inspectorOpen && (
+              <aside className="w-80 shrink-0 border-l bg-white">
+                <div className="h-full overflow-y-auto p-4 space-y-6">
+                  <section>
+                    <h3 className="text-sm font-semibold text-neutral-600">Background</h3>
+                    <div className="mt-3 space-y-3 text-sm">
+                      <label className="block">
+                        <span className="text-xs font-medium text-neutral-500">Type</span>
+                        <select
+                          value={cfg.background?.type || 'color'}
+                          onChange={(e) =>
+                            setBackground({
+                              type: e.target.value as SlideCfg['background']['type'],
+                              url: undefined,
                             })
                           }
-                          className="border px-1 rounded"
+                          className="mt-1 w-full rounded border px-2 py-1"
                         >
-                          x
-                        </button>
+                          <option value="color">Color</option>
+                          <option value="image">Image</option>
+                          <option value="video">Video</option>
+                        </select>
+                      </label>
+                      {cfg.background?.type === 'color' && (
+                        <label className="block">
+                          <span className="text-xs font-medium text-neutral-500">Color</span>
+                          <input
+                            type="color"
+                            value={cfg.background?.color || '#111111'}
+                            onChange={(e) => setBackground({ color: e.target.value })}
+                            className="mt-1 h-10 w-full rounded border"
+                          />
+                        </label>
+                      )}
+                      {cfg.background?.type !== 'color' && (
+                        <div className="space-y-2">
+                          <label className="block text-xs font-medium text-neutral-500">Media URL</label>
+                          <input
+                            type="text"
+                            value={cfg.background?.url || ''}
+                            onChange={(e) => setBackground({ url: e.target.value })}
+                            className="w-full rounded border px-2 py-1 text-sm"
+                            placeholder="https://"
+                          />
+                          <input
+                            ref={imageInputRef}
+                            type="file"
+                            accept={cfg.background?.type === 'video' ? 'video/*' : 'image/*'}
+                            className="hidden"
+                            onChange={(e) => {
+                              const file = e.target.files?.[0];
+                              if (file) {
+                                handleUpload(file, (url) => setBackground({ url }));
+                                e.target.value = '';
+                              }
+                            }}
+                          />
+                          <button
+                            type="button"
+                            onClick={() => imageInputRef.current?.click()}
+                            className="rounded border px-3 py-1 text-xs"
+                          >
+                            Upload
+                          </button>
+                          {uploading && <div className="text-xs text-neutral-500">Uploading…</div>}
+                        </div>
+                      )}
+                      <label className="flex items-center gap-2 text-xs">
+                        <input
+                          type="checkbox"
+                          checked={!!cfg.background?.overlay}
+                          onChange={(e) =>
+                            setBackground(
+                              e.target.checked
+                                ? { overlay: { color: '#000000', opacity: 0.25 } }
+                                : { overlay: undefined }
+                            )
+                          }
+                        />
+                        Overlay
+                      </label>
+                      {cfg.background?.overlay && (
+                        <div className="flex gap-2">
+                          <input
+                            type="color"
+                            value={cfg.background.overlay.color || '#000000'}
+                            onChange={(e) =>
+                              setBackground({
+                                overlay: {
+                                  color: e.target.value,
+                                  opacity: cfg.background?.overlay?.opacity ?? 0.25,
+                                },
+                              })
+                            }
+                            className="h-10 w-1/2 rounded border"
+                          />
+                          <input
+                            type="number"
+                            min={0}
+                            max={0.9}
+                            step={0.05}
+                            value={cfg.background.overlay.opacity ?? 0.25}
+                            onChange={(e) =>
+                              setBackground({
+                                overlay: {
+                                  color: cfg.background?.overlay?.color ?? '#000000',
+                                  opacity: Number(e.target.value),
+                                },
+                              })
+                            }
+                            className="w-1/2 rounded border px-2 py-1 text-sm"
+                          />
+                        </div>
+                      )}
+                    </div>
+                  </section>
+                  <section>
+                    <div className="flex items-center justify-between">
+                      <h3 className="text-sm font-semibold text-neutral-600">Inspector</h3>
+                      <span className="text-xs text-neutral-500">Selected: {selectionLabel}</span>
+                    </div>
+                    {!selectedBlock ? (
+                      <p className="mt-3 text-xs text-neutral-500">
+                        Choose a block from the preview or layers list to edit its properties.
+                      </p>
+                    ) : (
+                      <div className="mt-3 space-y-4 text-sm">
+                        {(selectedBlock.kind === 'heading' ||
+                          selectedBlock.kind === 'subheading' ||
+                          selectedBlock.kind === 'text') && (
+                          <>
+                            <label className="block">
+                              <span className="text-xs font-medium text-neutral-500">Text</span>
+                              <textarea
+                                rows={3}
+                                value={selectedBlock.text ?? ''}
+                                onChange={(e) => patchBlock(selectedBlock.id, { text: e.target.value })}
+                                className="mt-1 w-full rounded border px-2 py-1"
+                              />
+                            </label>
+                            <label className="block">
+                              <span className="text-xs font-medium text-neutral-500">Color</span>
+                              <input
+                                type="color"
+                                value={selectedBlock.color || '#ffffff'}
+                                onChange={(e) => patchBlock(selectedBlock.id, { color: e.target.value })}
+                                className="mt-1 h-10 w-full rounded border"
+                              />
+                            </label>
+                            <label className="block">
+                              <span className="text-xs font-medium text-neutral-500">Size</span>
+                              <select
+                                value={selectedBlock.size || 'md'}
+                                onChange={(e) => patchBlock(selectedBlock.id, { size: e.target.value as any })}
+                                className="mt-1 w-full rounded border px-2 py-1"
+                              >
+                                {TEXT_SIZES.map((opt) => (
+                                  <option key={opt.value} value={opt.value}>
+                                    {opt.label}
+                                  </option>
+                                ))}
+                              </select>
+                            </label>
+                            <div>
+                              <span className="text-xs font-medium text-neutral-500">Alignment</span>
+                              <div className="mt-1 flex gap-2">
+                                {(['left', 'center', 'right'] as const).map((align) => (
+                                  <button
+                                    key={align}
+                                    type="button"
+                                    onClick={() => patchBlock(selectedBlock.id, { align })}
+                                    className={`rounded border px-2 py-1 text-xs capitalize ${
+                                      selectedBlock.align === align ? 'border-emerald-500 bg-emerald-50' : ''
+                                    }`}
+                                  >
+                                    {align}
+                                  </button>
+                                ))}
+                              </div>
+                            </div>
+                          </>
+                        )}
+                        {selectedBlock.kind === 'button' && (
+                          <>
+                            <label className="block">
+                              <span className="text-xs font-medium text-neutral-500">Label</span>
+                              <input
+                                type="text"
+                                value={selectedBlock.text || ''}
+                                onChange={(e) => patchBlock(selectedBlock.id, { text: e.target.value })}
+                                className="mt-1 w-full rounded border px-2 py-1"
+                              />
+                            </label>
+                            <label className="block">
+                              <span className="text-xs font-medium text-neutral-500">Link</span>
+                              <select
+                                value={linkOptions.includes(selectedBlock.href ?? '') ? selectedBlock.href : 'custom'}
+                                onChange={(e) => {
+                                  const value = e.target.value;
+                                  if (value === 'custom') return;
+                                  patchBlock(selectedBlock.id, { href: value });
+                                }}
+                                className="mt-1 w-full rounded border px-2 py-1"
+                              >
+                                {linkOptions.map((opt) => (
+                                  <option key={opt} value={opt}>
+                                    {opt === 'custom' ? 'Custom URL' : opt}
+                                  </option>
+                                ))}
+                              </select>
+                            </label>
+                            {(!selectedBlock.href || !linkOptions.includes(selectedBlock.href)) && (
+                              <label className="block">
+                                <span className="text-xs font-medium text-neutral-500">Custom URL</span>
+                                <input
+                                  type="text"
+                                  value={selectedBlock.href || ''}
+                                  onChange={(e) => patchBlock(selectedBlock.id, { href: e.target.value })}
+                                  className="mt-1 w-full rounded border px-2 py-1"
+                                  placeholder="https://"
+                                />
+                              </label>
+                            )}
+                          </>
+                        )}
+                        {selectedBlock.kind === 'image' && (
+                          <>
+                            <div className="space-y-2">
+                              <span className="text-xs font-medium text-neutral-500">Image</span>
+                              {selectedBlock.src && (
+                                <img src={selectedBlock.src} alt="" className="h-28 w-full rounded object-cover" />
+                              )}
+                              <input
+                                ref={blockImageInputRef}
+                                type="file"
+                                accept="image/*"
+                                className="hidden"
+                                onChange={(e) => {
+                                  const file = e.target.files?.[0];
+                                  if (file) {
+                                    handleUpload(file, (url) => patchBlock(selectedBlock.id, { src: url }));
+                                    e.target.value = '';
+                                  }
+                                }}
+                              />
+                              <button
+                                type="button"
+                                onClick={() => blockImageInputRef.current?.click()}
+                                className="rounded border px-3 py-1 text-xs"
+                              >
+                                {selectedBlock.src ? 'Replace image' : 'Upload image'}
+                              </button>
+                              <label className="block">
+                                <span className="text-xs font-medium text-neutral-500">Fit</span>
+                                <select
+                                  value={selectedBlock.fit || 'cover'}
+                                  onChange={(e) =>
+                                    patchBlock(selectedBlock.id, { fit: e.target.value as 'cover' | 'contain' })
+                                  }
+                                  className="mt-1 w-full rounded border px-2 py-1"
+                                >
+                                  <option value="cover">Cover</option>
+                                  <option value="contain">Contain</option>
+                                </select>
+                              </label>
+                            </div>
+                          </>
+                        )}
+                        {selectedBlock.kind === 'gallery' && (
+                          <div className="space-y-3">
+                            <div className="flex items-center justify-between text-xs text-neutral-500">
+                              <span>{selectedBlock.items?.length || 0} images</span>
+                              <button
+                                type="button"
+                                onClick={() => galleryInputRef.current?.click()}
+                                className="rounded border px-2 py-1"
+                              >
+                                Upload
+                              </button>
+                            </div>
+                            <input
+                              ref={galleryInputRef}
+                              type="file"
+                              accept="image/*"
+                              multiple
+                              className="hidden"
+                              onChange={async (e) => {
+                                const files = Array.from(e.target.files || []);
+                                if (!files.length) return;
+                                const current = cfg.blocks.find((b) => b.id === selectedBlock.id);
+                                const nextItems = [...(current?.items || [])];
+                                for (const file of files) {
+                                  // eslint-disable-next-line no-await-in-loop
+                                  await handleUpload(file, (url) => {
+                                    nextItems.push({ src: url });
+                                  });
+                                }
+                                patchBlock(selectedBlock.id, { items: nextItems });
+                                e.target.value = '';
+                              }}
+                            />
+                            <div className="space-y-2">
+                              {(selectedBlock.items || []).map((item, index) => (
+                                <div key={item.src} className="flex items-center gap-2 text-xs">
+                                  <img src={item.src} alt="" className="h-12 w-12 rounded object-cover" />
+                                  <div className="flex gap-1">
+                                    <button
+                                      type="button"
+                                      className="rounded border px-2 py-1"
+                                      disabled={index === 0}
+                                      onClick={() => {
+                                        const next = [...(selectedBlock.items || [])];
+                                        const [moved] = next.splice(index, 1);
+                                        next.splice(index - 1, 0, moved);
+                                        patchBlock(selectedBlock.id, { items: next });
+                                      }}
+                                    >
+                                      Up
+                                    </button>
+                                    <button
+                                      type="button"
+                                      className="rounded border px-2 py-1"
+                                      disabled={index === (selectedBlock.items || []).length - 1}
+                                      onClick={() => {
+                                        const next = [...(selectedBlock.items || [])];
+                                        const [moved] = next.splice(index, 1);
+                                        next.splice(index + 1, 0, moved);
+                                        patchBlock(selectedBlock.id, { items: next });
+                                      }}
+                                    >
+                                      Down
+                                    </button>
+                                    <button
+                                      type="button"
+                                      className="rounded border px-2 py-1 text-red-600"
+                                      onClick={() => {
+                                        const next = (selectedBlock.items || []).filter((_, i) => i !== index);
+                                        patchBlock(selectedBlock.id, { items: next });
+                                      }}
+                                    >
+                                      Remove
+                                    </button>
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                        {selectedBlock.kind === 'quote' && (
+                          <>
+                            <label className="block">
+                              <span className="text-xs font-medium text-neutral-500">Quote</span>
+                              <textarea
+                                rows={3}
+                                value={selectedBlock.text || ''}
+                                onChange={(e) => patchBlock(selectedBlock.id, { text: e.target.value })}
+                                className="mt-1 w-full rounded border px-2 py-1"
+                              />
+                            </label>
+                            <label className="block">
+                              <span className="text-xs font-medium text-neutral-500">Author</span>
+                              <input
+                                type="text"
+                                value={selectedBlock.author || ''}
+                                onChange={(e) => patchBlock(selectedBlock.id, { author: e.target.value })}
+                                className="mt-1 w-full rounded border px-2 py-1"
+                              />
+                            </label>
+                          </>
+                        )}
+                        <div className="rounded border px-3 py-3">
+                          <h4 className="text-xs font-semibold uppercase tracking-wide text-neutral-500">Frame ({activeDevice})</h4>
+                          <div className="mt-2 grid grid-cols-2 gap-2 text-xs">
+                            {frame && (
+                              <>
+                                <label className="flex flex-col gap-1">
+                                  <span>X%</span>
+                                  <input
+                                    type="number"
+                                    value={frame.x}
+                                    onChange={(e) => updateFrameField(selectedBlock.id, 'x', parseFloat(e.target.value))}
+                                    className="rounded border px-2 py-1"
+                                  />
+                                </label>
+                                <label className="flex flex-col gap-1">
+                                  <span>Y%</span>
+                                  <input
+                                    type="number"
+                                    value={frame.y}
+                                    onChange={(e) => updateFrameField(selectedBlock.id, 'y', parseFloat(e.target.value))}
+                                    className="rounded border px-2 py-1"
+                                  />
+                                </label>
+                                <label className="flex flex-col gap-1">
+                                  <span>Width%</span>
+                                  <input
+                                    type="number"
+                                    value={frame.w}
+                                    onChange={(e) => updateFrameField(selectedBlock.id, 'w', parseFloat(e.target.value))}
+                                    className="rounded border px-2 py-1"
+                                  />
+                                </label>
+                                <label className="flex flex-col gap-1">
+                                  <span>Height%</span>
+                                  <input
+                                    type="number"
+                                    value={frame.h}
+                                    onChange={(e) => updateFrameField(selectedBlock.id, 'h', parseFloat(e.target.value))}
+                                    className="rounded border px-2 py-1"
+                                  />
+                                </label>
+                                <label className="flex flex-col gap-1">
+                                  <span>Rotation°</span>
+                                  <input
+                                    type="number"
+                                    value={frame.r}
+                                    onChange={(e) => updateFrameField(selectedBlock.id, 'r', parseFloat(e.target.value))}
+                                    className="rounded border px-2 py-1"
+                                  />
+                                </label>
+                              </>
+                            )}
+                          </div>
+                        </div>
                       </div>
-                    ))}
-                  </div>
-                )}
-                {selectedBlock.type === 'quote' && (
-                  <>
-                    <input
-                      type="text"
-                      value={selectedBlock.text}
-                      onChange={(e) => updateBlock(selectedBlock.id, { text: e.target.value })}
-                      className="border p-1 rounded w-full mb-2"
-                    />
-                    <input
-                      type="text"
-                      value={selectedBlock.author || ''}
-                      placeholder="Author"
-                      onChange={(e) => updateBlock(selectedBlock.id, { author: e.target.value })}
-                      className="border p-1 rounded w-full mb-2"
-                    />
-                  </>
-                )}
-                {selectedBlock.type === 'spacer' && (
-                  <select
-                    value={selectedBlock.size}
-                    onChange={(e) => updateBlock(selectedBlock.id, { size: e.target.value })}
-                    className="border p-1 rounded w-full"
-                  >
-                    <option value="sm">Small</option>
-                    <option value="md">Medium</option>
-                    <option value="lg">Large</option>
-                  </select>
-                )}
-              </div>
+                    )}
+                  </section>
+                </div>
+              </aside>
             )}
-            </div>
-          )}
-        </div>
-        <div className="mt-4 flex justify-end gap-2">
-          <Button onClick={handleSave}>{isEdit ? 'Save' : 'Create'}</Button>
+          </div>
         </div>
       </div>
-      {showDebug && (
-        <div
-          style={{
-            position: 'absolute',
-            left: 8,
-            bottom: 8,
-            background: '#000',
-            color: '#0f0',
-            fontSize: 10,
-            padding: '4px 6px',
-            borderRadius: 4,
-            maxWidth: 300,
-            maxHeight: '40%',
-            overflowY: 'auto',
-          }}
-        >
-          {logs.map((l, i) => (
-            <div key={i}>{l}</div>
-          ))}
-        </div>
-      )}
     </div>
   );
 }
+
+export type { SlideCfg } from './SlidesManager';
+

--- a/components/SlidesManager.tsx
+++ b/components/SlidesManager.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 import {
   DndContext,
   PointerSensor,
@@ -15,12 +16,491 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { ArrowsUpDownIcon, ChevronUpIcon, ChevronDownIcon } from '@heroicons/react/24/outline';
-import { supabase } from '@/utils/supabaseClient';
+import { ArrowsUpDownIcon, ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/outline';
 import { toast } from '@/components/ui/toast';
-import { SlideRow } from '@/components/customer/home/SlidesContainer';
+import { supabase } from '@/utils/supabaseClient';
+import type { SlideRow } from '@/components/customer/home/SlidesContainer';
+
+export type DeviceKind = 'mobile' | 'tablet' | 'desktop';
+
+export type Frame = {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  r: number;
+};
+
+export type SlideBlock = {
+  id: string;
+  kind: 'heading' | 'subheading' | 'text' | 'button' | 'image' | 'quote' | 'gallery' | 'spacer';
+  text?: string;
+  href?: string;
+  src?: string;
+  items?: { src: string; alt?: string }[];
+  frames: Partial<Record<DeviceKind, Frame>>;
+  color?: string;
+  align?: 'left' | 'center' | 'right';
+  size?: 'sm' | 'md' | 'lg' | 'xl';
+  buttonVariant?: 'primary' | 'secondary';
+  fit?: 'cover' | 'contain';
+  author?: string;
+  height?: number;
+};
+
+export type SlideCfg = {
+  background?: {
+    type: 'color' | 'image' | 'video';
+    color?: string;
+    url?: string;
+    overlay?: { color: string; opacity: number };
+  };
+  blocks: SlideBlock[];
+};
+
+export type SlidesManagerChangeOptions = {
+  commit?: boolean;
+};
+
+type SlidesManagerProps = {
+  initialCfg: SlideCfg;
+  onChange: (cfg: SlideCfg, options?: SlidesManagerChangeOptions) => void;
+  editable: boolean;
+  selectedId?: string | null;
+  onSelect?: (id: string | null) => void;
+  activeDevice?: DeviceKind;
+  editInPreview?: boolean;
+};
+
+const DEVICE_SIZES: Record<DeviceKind, number> = {
+  mobile: 375,
+  tablet: 768,
+  desktop: 1280,
+};
+
+const clamp = (v: number, min: number, max: number) => Math.min(max, Math.max(min, v));
+
+function ensureFrame(block: SlideBlock, device: DeviceKind): Frame {
+  const fallback: Frame = { x: 10, y: 10, w: 40, h: 20, r: 0 };
+  if (block.frames?.[device]) return block.frames[device]!;
+  const existing = Object.values(block.frames || {})[0];
+  return existing ? existing : fallback;
+}
 
 export default function SlidesManager({
+  initialCfg,
+  onChange,
+  editable,
+  selectedId,
+  onSelect,
+  activeDevice = 'desktop',
+  editInPreview = true,
+}: SlidesManagerProps) {
+  const frameRef = useRef<HTMLDivElement>(null);
+  const cfg = useMemo(() => initialCfg, [initialCfg]);
+  const width = DEVICE_SIZES[activeDevice] ?? DEVICE_SIZES.desktop;
+
+  const handleFrameChange = (blockId: string, frame: Frame, options?: SlidesManagerChangeOptions) => {
+    const next: SlideCfg = {
+      ...cfg,
+      blocks: cfg.blocks.map((b) =>
+        b.id === blockId
+          ? {
+              ...b,
+              frames: {
+                ...b.frames,
+                [activeDevice]: { ...frame },
+              },
+            }
+          : b
+      ),
+    };
+    onChange(next, options);
+  };
+
+  const handleInlineText = (blockId: string, text: string) => {
+    const next: SlideCfg = {
+      ...cfg,
+      blocks: cfg.blocks.map((b) => (b.id === blockId ? { ...b, text } : b)),
+    };
+    onChange(next, { commit: true });
+  };
+
+  const renderBlockContent = (block: SlideBlock): ReactNode => {
+    switch (block.kind) {
+      case 'heading':
+      case 'subheading':
+      case 'text': {
+        const Tag = block.kind === 'heading' ? 'h2' : block.kind === 'subheading' ? 'h3' : 'p';
+        const sizes: Record<NonNullable<SlideBlock['size']>, string> = {
+          sm: '1.125rem',
+          md: '1.5rem',
+          lg: '2.5rem',
+          xl: '3.5rem',
+        };
+        const style: CSSProperties = {
+          color: block.color || '#ffffff',
+          textAlign: block.align ?? 'left',
+          fontSize: block.size ? sizes[block.size] ?? undefined : undefined,
+          fontWeight: block.kind === 'heading' ? 700 : block.kind === 'subheading' ? 600 : 400,
+        };
+        const editableProps =
+          editable && editInPreview
+            ? {
+                contentEditable: true,
+                suppressContentEditableWarning: true,
+                onBlur: (e: React.FocusEvent<HTMLElement>) =>
+                  handleInlineText(block.id, e.currentTarget.textContent || ''),
+              }
+            : {};
+        return (
+          <Tag
+            {...editableProps}
+            style={style}
+            className="leading-tight"
+          >
+            {block.text ?? ''}
+          </Tag>
+        );
+      }
+      case 'button': {
+        return (
+          <a
+            href={block.href || '#'}
+            onClick={(e) => e.preventDefault()}
+            className={`btn-primary inline-flex items-center justify-center px-5 py-3 ${
+              block.buttonVariant === 'secondary' ? 'bg-white text-black' : ''
+            }`}
+            style={{ textAlign: 'center' }}
+          >
+            {block.text || 'Button'}
+          </a>
+        );
+      }
+      case 'image': {
+        if (!block.src) return <div className="bg-neutral-200 w-full h-full rounded" />;
+        return (
+          <img
+            src={block.src}
+            alt=""
+            className="w-full h-full object-cover"
+            style={{ objectFit: block.fit || 'cover', borderRadius: 12 }}
+          />
+        );
+      }
+      case 'quote': {
+        return (
+          <div className="text-white">
+            <p className="italic">“{block.text ?? ''}”</p>
+            {block.author && <p className="mt-2 text-sm">— {block.author}</p>}
+          </div>
+        );
+      }
+      case 'gallery': {
+        return (
+          <div className="flex h-full w-full gap-2 overflow-hidden rounded">
+            {(block.items || []).map((item) => (
+              <img
+                key={item.src}
+                src={item.src}
+                alt={item.alt || ''}
+                className="h-full flex-1 object-cover"
+              />
+            ))}
+          </div>
+        );
+      }
+      case 'spacer':
+        return <div className="w-full h-full" />;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="flex-1 overflow-auto bg-neutral-50">
+      <div className="flex justify-center p-6">
+        <div
+          ref={frameRef}
+          className="relative bg-white shadow-xl rounded-2xl overflow-hidden"
+          style={{
+            width,
+            maxWidth: '100%',
+            height: '100dvh',
+            minHeight: '100dvh',
+          }}
+          onClick={() => onSelect?.(null)}
+        >
+          <SlideBackground cfg={cfg} />
+          <div className="absolute inset-0" style={{ pointerEvents: editable && editInPreview ? 'auto' : 'none' }}>
+            {cfg.blocks.map((block) => {
+              const frame = ensureFrame(block, activeDevice);
+              return (
+                <InteractiveBox
+                  key={block.id}
+                  id={block.id}
+                  frame={frame}
+                  containerRef={frameRef}
+                  selected={selectedId === block.id}
+                  editable={editable && editInPreview}
+                  onSelect={() => onSelect?.(block.id)}
+                  onChange={(nextFrame, opts) => handleFrameChange(block.id, nextFrame, opts)}
+                >
+                  {renderBlockContent(block)}
+                </InteractiveBox>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type InteractiveBoxProps = {
+  id: string;
+  frame: Frame;
+  containerRef: React.RefObject<HTMLDivElement>;
+  selected: boolean;
+  editable: boolean;
+  onSelect: () => void;
+  onChange: (frame: Frame, options?: SlidesManagerChangeOptions) => void;
+  children: ReactNode;
+};
+
+type PointerState = {
+  type: 'move' | 'resize' | 'rotate';
+  startX: number;
+  startY: number;
+  startFrame: Frame;
+  corner?: string;
+};
+
+function InteractiveBox({
+  frame,
+  containerRef,
+  selected,
+  editable,
+  onSelect,
+  onChange,
+  children,
+}: InteractiveBoxProps) {
+  const localRef = useRef<HTMLDivElement>(null);
+  const pointerState = useRef<PointerState | null>(null);
+
+  const getContainerRect = () => containerRef.current?.getBoundingClientRect();
+
+  const handlePointerDown = (type: PointerState['type'], corner?: string) => (e: React.PointerEvent) => {
+    if (!editable) return;
+    e.stopPropagation();
+    const rect = getContainerRect();
+    if (!rect) return;
+    pointerState.current = {
+      type,
+      startX: e.clientX,
+      startY: e.clientY,
+      startFrame: { ...frame },
+      corner,
+    };
+    localRef.current?.setPointerCapture?.(e.pointerId);
+    onSelect();
+  };
+
+  const handlePointerMove = (e: React.PointerEvent) => {
+    if (!editable) return;
+    const ps = pointerState.current;
+    if (!ps) return;
+    const rect = getContainerRect();
+    if (!rect) return;
+    const dx = ((e.clientX - ps.startX) / rect.width) * 100;
+    const dy = ((e.clientY - ps.startY) / rect.height) * 100;
+    if (ps.type === 'move') {
+      const next: Frame = {
+        ...ps.startFrame,
+        x: clamp(ps.startFrame.x + dx, 0, 100 - ps.startFrame.w),
+        y: clamp(ps.startFrame.y + dy, 0, 100 - ps.startFrame.h),
+      };
+      onChange(next, { commit: false });
+    } else if (ps.type === 'resize') {
+      const next: Frame = { ...ps.startFrame };
+      const min = 5;
+      if (ps.corner?.includes('e')) {
+        next.w = clamp(ps.startFrame.w + dx, min, 100 - ps.startFrame.x);
+      }
+      if (ps.corner?.includes('s')) {
+        next.h = clamp(ps.startFrame.h + dy, min, 100 - ps.startFrame.y);
+      }
+      if (ps.corner?.includes('w')) {
+        const newX = clamp(ps.startFrame.x + dx, 0, ps.startFrame.x + ps.startFrame.w - min);
+        const deltaX = ps.startFrame.x - newX;
+        next.x = newX;
+        next.w = clamp(ps.startFrame.w + deltaX, min, 100 - newX);
+      }
+      if (ps.corner?.includes('n')) {
+        const newY = clamp(ps.startFrame.y + dy, 0, ps.startFrame.y + ps.startFrame.h - min);
+        const deltaY = ps.startFrame.y - newY;
+        next.y = newY;
+        next.h = clamp(ps.startFrame.h + deltaY, min, 100 - newY);
+      }
+      onChange(next, { commit: false });
+    } else if (ps.type === 'rotate') {
+      const el = localRef.current;
+      if (!el) return;
+      const box = el.getBoundingClientRect();
+      const cx = box.left + box.width / 2;
+      const cy = box.top + box.height / 2;
+      const angle = (Math.atan2(e.clientY - cy, e.clientX - cx) * 180) / Math.PI;
+      const deg = ((Math.round(angle) % 360) + 360) % 360;
+      onChange({ ...ps.startFrame, r: deg }, { commit: false });
+    }
+  };
+
+  const handlePointerUp = (e: React.PointerEvent) => {
+    if (!editable) return;
+    const ps = pointerState.current;
+    if (!ps) return;
+    pointerState.current = null;
+    localRef.current?.releasePointerCapture?.(e.pointerId);
+    onChange(frame, { commit: true });
+  };
+
+  const style: CSSProperties = {
+    position: 'absolute',
+    left: `${frame.x}%`,
+    top: `${frame.y}%`,
+    width: `${frame.w}%`,
+    height: `${frame.h}%`,
+    transform: `rotate(${frame.r ?? 0}deg)`,
+    transformOrigin: 'top left',
+    border: selected && editable ? '1px dashed rgba(56,189,248,0.8)' : undefined,
+    borderRadius: 8,
+    touchAction: 'none',
+    cursor: editable ? 'move' : 'default',
+  };
+
+  return (
+    <div
+      ref={localRef}
+      style={style}
+      onPointerDown={handlePointerDown('move')}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onClick={(e) => {
+        if (!editable) return;
+        e.stopPropagation();
+        onSelect();
+      }}
+    >
+      {children}
+      {editable && selected && (
+        <>
+          <div
+            onPointerDown={handlePointerDown('rotate')}
+            className="absolute left-1/2 top-[-32px] h-5 w-5 -translate-x-1/2 rounded-full border border-sky-500 bg-white"
+          />
+          {[
+            ['n', '50%', 0],
+            ['s', '50%', 100],
+            ['w', 0, '50%'],
+            ['e', 100, '50%'],
+            ['nw', 0, 0],
+            ['ne', 100, 0],
+            ['sw', 0, 100],
+            ['se', 100, 100],
+          ].map(([corner, left, top]) => (
+            <div
+              key={corner as string}
+              onPointerDown={handlePointerDown('resize', corner as string)}
+              className="absolute h-3 w-3 rounded-full border border-sky-500 bg-white"
+              style={{
+                left: typeof left === 'number' ? `${left}%` : left,
+                top: typeof top === 'number' ? `${top}%` : top,
+                transform: 'translate(-50%, -50%)',
+              }}
+            />
+          ))}
+        </>
+      )}
+    </div>
+  );
+}
+
+function SlideBackground({ cfg }: { cfg: SlideCfg }) {
+  const bg = cfg.background;
+  if (!bg) return null;
+  if (bg.type === 'color') {
+    return (
+      <>
+        <div
+          className="absolute inset-0"
+          style={{ background: bg.color || '#111', pointerEvents: 'none' }}
+        />
+        {bg.overlay && (
+          <div
+            className="absolute inset-0"
+            style={{
+              background: bg.overlay.color,
+              opacity: bg.overlay.opacity,
+              pointerEvents: 'none',
+            }}
+          />
+        )}
+      </>
+    );
+  }
+  if (bg.type === 'image') {
+    return (
+      <>
+        <div
+          className="absolute inset-0"
+          style={{
+            backgroundImage: bg.url ? `url(${bg.url})` : undefined,
+            backgroundSize: 'cover',
+            backgroundPosition: 'center',
+            pointerEvents: 'none',
+          }}
+        />
+        {bg.overlay && (
+          <div
+            className="absolute inset-0"
+            style={{
+              background: bg.overlay.color,
+              opacity: bg.overlay.opacity,
+              pointerEvents: 'none',
+            }}
+          />
+        )}
+      </>
+    );
+  }
+  if (bg.type === 'video' && bg.url) {
+    return (
+      <>
+        <video
+          src={bg.url}
+          autoPlay
+          loop
+          muted
+          playsInline
+          className="absolute inset-0 h-full w-full object-cover"
+        />
+        {bg.overlay && (
+          <div
+            className="absolute inset-0"
+            style={{
+              background: bg.overlay.color,
+              opacity: bg.overlay.opacity,
+              pointerEvents: 'none',
+            }}
+          />
+        )}
+      </>
+    );
+  }
+  return null;
+}
+
+export function SlidesDashboardList({
   restaurantId,
   onEdit,
   refreshKey,
@@ -80,9 +560,7 @@ export default function SlidesManager({
   }
 
   async function toggleActive(row: SlideRow) {
-    const updated = slides.map((s) =>
-      s.id === row.id ? { ...s, is_active: !row.is_active } : s
-    );
+    const updated = slides.map((s) => (s.id === row.id ? { ...s, is_active: !row.is_active } : s));
     setSlides(updated);
     const { error } = await supabase
       .from('restaurant_slides')
@@ -133,10 +611,7 @@ export default function SlidesManager({
     if (index === -1 || swapIndex < 0 || swapIndex >= nonHero.length) return;
     const target = nonHero[swapIndex];
     const reordered = [...nonHero];
-    [reordered[index], reordered[swapIndex]] = [
-      reordered[swapIndex],
-      reordered[index],
-    ];
+    [reordered[index], reordered[swapIndex]] = [reordered[swapIndex], reordered[index]];
     setSlides((prev) => {
       const heroes = prev.filter((s) => s.type === 'hero');
       return [...heroes, ...reordered].sort((a, b) => a.sort_order - b.sort_order);
@@ -218,8 +693,12 @@ export default function SlidesManager({
       <div className="flex items-center justify-between mb-3">
         <h3 className="text-lg font-semibold">Slides (beta)</h3>
         <div className="flex gap-2">
-          <button onClick={addStarter} className="px-3 py-2 rounded border">Add Starter Slides</button>
-          <button onClick={openCreate} className="px-3 py-2 rounded bg-emerald-600 text-white">New Slide</button>
+          <button onClick={addStarter} className="px-3 py-2 rounded border">
+            Add Starter Slides
+          </button>
+          <button onClick={openCreate} className="px-3 py-2 rounded bg-emerald-600 text-white">
+            New Slide
+          </button>
         </div>
       </div>
       {loading ? (
@@ -252,15 +731,7 @@ export default function SlidesManager({
   );
 }
 
-function SortableRow({
-  row,
-  onEdit,
-  onDelete,
-  onToggle,
-  onMove,
-  index,
-  lastIndex,
-}: {
+type SortableRowProps = {
   row: SlideRow;
   onEdit: (r: SlideRow) => void;
   onDelete: (r: SlideRow) => void;
@@ -268,7 +739,9 @@ function SortableRow({
   onMove: (r: SlideRow, dir: 'up' | 'down') => void;
   index: number;
   lastIndex: number;
-}) {
+};
+
+function SortableRow({ row, onEdit, onDelete, onToggle, onMove, index, lastIndex }: SortableRowProps) {
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
     id: row.id!,
     disabled: row.type === 'hero',
@@ -288,16 +761,10 @@ function SortableRow({
         <ArrowsUpDownIcon className="h-5 w-5" />
       </span>
       <div className="flex flex-col">
-        <button
-          disabled={locked || index <= 0}
-          onClick={() => onMove(row, 'up')}
-        >
+        <button disabled={locked || index <= 0} onClick={() => onMove(row, 'up')}>
           <ChevronUpIcon className="h-4 w-4" />
         </button>
-        <button
-          disabled={locked || index === lastIndex}
-          onClick={() => onMove(row, 'down')}
-        >
+        <button disabled={locked || index === lastIndex} onClick={() => onMove(row, 'down')}>
           <ChevronDownIcon className="h-4 w-4" />
         </button>
       </div>
@@ -307,19 +774,11 @@ function SortableRow({
         <span className="px-2 py-1 text-xs border rounded">Locked</span>
       ) : (
         <label className="inline-flex items-center gap-1 text-sm">
-          <input
-            type="checkbox"
-            checked={row.is_active ?? true}
-            onChange={() => onToggle(row)}
-          />
+          <input type="checkbox" checked={row.is_active ?? true} onChange={() => onToggle(row)} />
           Active
         </label>
       )}
-      <button
-        onClick={() => onEdit(row)}
-        className="ml-2 px-3 py-1 rounded border"
-        disabled={locked}
-      >
+      <button onClick={() => onEdit(row)} className="ml-2 px-3 py-1 rounded border" disabled={locked}>
         Edit
       </button>
       <button

--- a/pages/dashboard/website/settings.tsx
+++ b/pages/dashboard/website/settings.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router';
 import DashboardLayout from '../../../components/DashboardLayout';
 import Toast from '../../../components/Toast';
 import CustomPagesSection from '../../../components/CustomPagesSection';
-import SlidesManager from '../../../components/SlidesManager';
+import { SlidesDashboardList } from '../../../components/SlidesManager';
 import SlideModal from '../../../components/SlideModal';
 import type { SlideRow } from '../../../components/customer/home/SlidesContainer';
 import { supabase } from '../../../utils/supabaseClient';
@@ -445,7 +445,7 @@ export default function WebsitePage() {
       </div>
       {restaurantId && (
         <>
-          <SlidesManager restaurantId={restaurantId} onEdit={handleEditSlide} refreshKey={refreshSlides} />
+          <SlidesDashboardList restaurantId={restaurantId} onEdit={handleEditSlide} refreshKey={refreshSlides} />
           {editingSlide && (
             <SlideModal
               slide={editingSlide}


### PR DESCRIPTION
## Summary
- rebuild the slide editor modal with the three-pane builder shell, block history, and Supabase-backed saves
- add a canvas-focused SlidesManager component while retaining the dashboard slide list via SlidesDashboardList
- update customer slide rendering and data coercion to consume the new config schema

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c82fef27908325adb67c6d1dfa12da