### PR TITLE
fix(slide-modal): reorganize layout

### DIFF
--- a/components/SlideModal.tsx
+++ b/components/SlideModal.tsx
@@ -1,19 +1,25 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import SlidesManager, {
   type DeviceKind,
   type Frame,
   type SlideBlock,
   type SlideCfg,
   type SlidesManagerChangeOptions,
-} from './SlidesManager';
-import Button from '@/components/ui/Button';
-import { supabase } from '@/utils/supabaseClient';
-import { STORAGE_BUCKET } from '@/lib/storage';
-import { SlideRow } from '@/components/customer/home/SlidesContainer';
+} from "./SlidesManager";
+import Button from "@/components/ui/Button";
+import { supabase } from "@/utils/supabaseClient";
+import { STORAGE_BUCKET } from "@/lib/storage";
+import { SlideRow } from "@/components/customer/home/SlidesContainer";
 
-const ROUTE_OPTIONS = ['/menu', '/orders', '/more'];
+const ROUTE_OPTIONS = ["/menu", "/orders", "/more"];
 
-const DEFAULT_FRAMES: Record<SlideBlock['kind'], Frame> = {
+const DEFAULT_FRAMES: Record<SlideBlock["kind"], Frame> = {
   heading: { x: 12, y: 12, w: 76, h: 18, r: 0 },
   subheading: { x: 12, y: 32, w: 70, h: 14, r: 0 },
   text: { x: 12, y: 48, w: 72, h: 24, r: 0 },
@@ -24,17 +30,22 @@ const DEFAULT_FRAMES: Record<SlideBlock['kind'], Frame> = {
   spacer: { x: 0, y: 0, w: 10, h: 10, r: 0 },
 };
 
-const TEXT_SIZES: { value: NonNullable<SlideBlock['size']>; label: string }[] = [
-  { value: 'sm', label: 'Small' },
-  { value: 'md', label: 'Medium' },
-  { value: 'lg', label: 'Large' },
-  { value: 'xl', label: 'Extra large' },
-];
+const TEXT_SIZES: { value: NonNullable<SlideBlock["size"]>; label: string }[] =
+  [
+    { value: "sm", label: "Small" },
+    { value: "md", label: "Medium" },
+    { value: "lg", label: "Large" },
+    { value: "xl", label: "Extra large" },
+  ];
 
 const cloneCfg = (cfg: SlideCfg): SlideCfg => JSON.parse(JSON.stringify(cfg));
 
-function defaultBackground(): SlideCfg['background'] {
-  return { type: 'color', color: '#111', overlay: { color: '#000', opacity: 0.25 } };
+function defaultBackground(): SlideCfg["background"] {
+  return {
+    type: "color",
+    color: "#111",
+    overlay: { color: "#000", opacity: 0.25 },
+  };
 }
 
 function clampPct(v: number) {
@@ -42,57 +53,67 @@ function clampPct(v: number) {
   return Math.min(100, Math.max(0, v));
 }
 
-function getDefaultFrame(kind: SlideBlock['kind']): Frame {
+function getDefaultFrame(kind: SlideBlock["kind"]): Frame {
   return { ...DEFAULT_FRAMES[kind] };
 }
 
 function ensureFrame(block: SlideBlock, device: DeviceKind): Frame {
-  return block.frames[device] ? { ...block.frames[device]! } : getDefaultFrame(block.kind);
+  return block.frames[device]
+    ? { ...block.frames[device]! }
+    : getDefaultFrame(block.kind);
 }
 
 function convertLegacyFrame(pos: any): Frame {
-  const w = typeof pos?.wPct === 'number' ? clampPct(pos.wPct) : 40;
-  const h = typeof pos?.hPct === 'number' ? clampPct(pos.hPct) : 20;
-  const cx = typeof pos?.xPct === 'number' ? clampPct(pos.xPct) : 50;
-  const cy = typeof pos?.yPct === 'number' ? clampPct(pos.yPct) : 50;
+  const w = typeof pos?.wPct === "number" ? clampPct(pos.wPct) : 40;
+  const h = typeof pos?.hPct === "number" ? clampPct(pos.hPct) : 20;
+  const cx = typeof pos?.xPct === "number" ? clampPct(pos.xPct) : 50;
+  const cy = typeof pos?.yPct === "number" ? clampPct(pos.yPct) : 50;
   const x = clampPct(cx - w / 2);
   const y = clampPct(cy - h / 2);
-  const r = typeof pos?.rotateDeg === 'number' ? pos.rotateDeg : 0;
+  const r = typeof pos?.rotateDeg === "number" ? pos.rotateDeg : 0;
   return { x, y, w, h, r };
 }
 
-function normalizeBackground(raw: any): SlideCfg['background'] {
+function normalizeBackground(raw: any): SlideCfg["background"] {
   if (!raw) return defaultBackground();
-  if (raw.type === 'color' || raw.type === 'image' || raw.type === 'video') {
+  if (raw.type === "color" || raw.type === "image" || raw.type === "video") {
     return {
       type: raw.type,
       color: raw.color,
       url: raw.url,
-      overlay: raw.overlay ? { color: raw.overlay.color, opacity: raw.overlay.opacity ?? 0.25 } : undefined,
+      overlay: raw.overlay
+        ? { color: raw.overlay.color, opacity: raw.overlay.opacity ?? 0.25 }
+        : undefined,
     };
   }
-  if (raw.kind === 'image' || raw.kind === 'video') {
+  if (raw.kind === "image" || raw.kind === "video") {
     return {
       type: raw.kind,
       url: raw.value ?? undefined,
       overlay: raw.overlay
-        ? { color: raw.overlayColor || '#000', opacity: raw.overlayOpacity ?? 0.25 }
+        ? {
+            color: raw.overlayColor || "#000",
+            opacity: raw.overlayOpacity ?? 0.25,
+          }
         : undefined,
     };
   }
   return {
-    type: 'color',
-    color: raw.value || '#111',
+    type: "color",
+    color: raw.value || "#111",
     overlay: raw.overlay
-      ? { color: raw.overlayColor || '#000', opacity: raw.overlayOpacity ?? 0.25 }
+      ? {
+          color: raw.overlayColor || "#000",
+          opacity: raw.overlayOpacity ?? 0.25,
+        }
       : undefined,
   };
 }
 
 function normalizeBlock(raw: any, positions?: Record<string, any>): SlideBlock {
-  const kind: SlideBlock['kind'] = raw.kind ?? raw.type ?? 'text';
-  const frames: SlideBlock['frames'] = {};
-  if (raw.frames && typeof raw.frames === 'object') {
+  const kind: SlideBlock["kind"] = raw.kind ?? raw.type ?? "text";
+  const frames: SlideBlock["frames"] = {};
+  if (raw.frames && typeof raw.frames === "object") {
     (Object.keys(raw.frames) as DeviceKind[]).forEach((device) => {
       const f = raw.frames[device];
       if (f) {
@@ -101,7 +122,12 @@ function normalizeBlock(raw: any, positions?: Record<string, any>): SlideBlock {
           y: clampPct(f.y ?? f.yPct ?? DEFAULT_FRAMES[kind].y),
           w: clampPct(f.w ?? f.wPct ?? DEFAULT_FRAMES[kind].w),
           h: clampPct(f.h ?? f.hPct ?? DEFAULT_FRAMES[kind].h),
-          r: typeof f.r === 'number' ? f.r : typeof f.rotateDeg === 'number' ? f.rotateDeg : DEFAULT_FRAMES[kind].r,
+          r:
+            typeof f.r === "number"
+              ? f.r
+              : typeof f.rotateDeg === "number"
+                ? f.rotateDeg
+                : DEFAULT_FRAMES[kind].r,
         };
       }
     });
@@ -122,7 +148,7 @@ function normalizeBlock(raw: any, positions?: Record<string, any>): SlideBlock {
     id: raw.id || crypto.randomUUID(),
     kind,
     frames,
-    text: raw.text ?? raw.label ?? '',
+    text: raw.text ?? raw.label ?? "",
     href: raw.href,
     src: raw.src || raw.url,
     color: raw.color,
@@ -139,21 +165,24 @@ function normalizeBlock(raw: any, positions?: Record<string, any>): SlideBlock {
     height: raw.height,
   };
 
-  if (kind === 'gallery' && !block.items) block.items = [];
-  if (kind === 'image' && !block.fit) block.fit = 'cover';
-  if (kind === 'heading' && !block.size) block.size = 'xl';
-  if (kind === 'subheading' && !block.size) block.size = 'md';
-  if (kind === 'text' && !block.size) block.size = 'sm';
-  if (kind === 'button' && !block.text) block.text = 'Button';
-  if ((kind === 'heading' || kind === 'subheading' || kind === 'text') && !block.color) {
-    block.color = '#ffffff';
+  if (kind === "gallery" && !block.items) block.items = [];
+  if (kind === "image" && !block.fit) block.fit = "cover";
+  if (kind === "heading" && !block.size) block.size = "xl";
+  if (kind === "subheading" && !block.size) block.size = "md";
+  if (kind === "text" && !block.size) block.size = "sm";
+  if (kind === "button" && !block.text) block.text = "Button";
+  if (
+    (kind === "heading" || kind === "subheading" || kind === "text") &&
+    !block.color
+  ) {
+    block.color = "#ffffff";
   }
 
   return block;
 }
 
 function normalizeConfig(raw: any, slide: SlideRow): SlideCfg {
-  const source = raw && typeof raw === 'object' ? raw : {};
+  const source = raw && typeof raw === "object" ? raw : {};
   const cfg: SlideCfg = {
     background: normalizeBackground(source.background),
     blocks: Array.isArray(source.blocks)
@@ -166,30 +195,30 @@ function normalizeConfig(raw: any, slide: SlideRow): SlideCfg {
     if (slide.title) {
       blocks.push({
         id: crypto.randomUUID(),
-        kind: 'heading',
+        kind: "heading",
         text: slide.title,
-        color: '#ffffff',
-        size: 'xl',
-        frames: { desktop: getDefaultFrame('heading') },
+        color: "#ffffff",
+        size: "xl",
+        frames: { desktop: getDefaultFrame("heading") },
       });
     }
     if (slide.subtitle) {
       blocks.push({
         id: crypto.randomUUID(),
-        kind: 'subheading',
+        kind: "subheading",
         text: slide.subtitle,
-        color: '#ffffff',
-        size: 'md',
-        frames: { desktop: getDefaultFrame('subheading') },
+        color: "#ffffff",
+        size: "md",
+        frames: { desktop: getDefaultFrame("subheading") },
       });
     }
     if (slide.cta_label) {
       blocks.push({
         id: crypto.randomUUID(),
-        kind: 'button',
+        kind: "button",
         text: slide.cta_label,
-        href: slide.cta_href ?? '/menu',
-        frames: { desktop: getDefaultFrame('button') },
+        href: slide.cta_href ?? "/menu",
+        frames: { desktop: getDefaultFrame("button") },
       });
     }
     cfg.blocks = blocks.length
@@ -197,11 +226,11 @@ function normalizeConfig(raw: any, slide: SlideRow): SlideCfg {
       : [
           {
             id: crypto.randomUUID(),
-            kind: 'heading',
-            text: 'New Slide',
-            color: '#ffffff',
-            size: 'xl',
-            frames: { desktop: getDefaultFrame('heading') },
+            kind: "heading",
+            text: "New Slide",
+            color: "#ffffff",
+            size: "xl",
+            frames: { desktop: getDefaultFrame("heading") },
           },
         ];
   }
@@ -216,14 +245,21 @@ interface SlideModalProps {
   onClose: () => void;
 }
 
-export default function SlideModal({ slide, initialCfg, onSave, onClose }: SlideModalProps) {
+export default function SlideModal({
+  slide,
+  initialCfg,
+  onSave,
+  onClose,
+}: SlideModalProps) {
   const restaurantId = slide.restaurant_id;
-  const [cfg, setCfg] = useState<SlideCfg>(() => normalizeConfig(initialCfg ?? {}, slide));
+  const [cfg, setCfg] = useState<SlideCfg>(() =>
+    normalizeConfig(initialCfg ?? {}, slide),
+  );
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [activeDevice, setActiveDevice] = useState<DeviceKind>('desktop');
+  const [activeDevice, setActiveDevice] = useState<DeviceKind>("desktop");
   const [editInPreview, setEditInPreview] = useState(true);
-  const [drawerOpen, setDrawerOpen] = useState(true);
-  const [inspectorOpen, setInspectorOpen] = useState(true);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [inspectorOpen, setInspectorOpen] = useState(false);
   const [customPages, setCustomPages] = useState<string[]>([]);
   const [uploading, setUploading] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -245,10 +281,10 @@ export default function SlideModal({ slide, initialCfg, onSave, onClose }: Slide
   useEffect(() => {
     if (!restaurantId) return;
     supabase
-      .from('custom_pages')
-      .select('slug')
-      .eq('restaurant_id', restaurantId)
-      .order('slug')
+      .from("custom_pages")
+      .select("slug")
+      .eq("restaurant_id", restaurantId)
+      .order("slug")
       .then(({ data }) => {
         if (data) setCustomPages(data.map((row) => `/p/${row.slug}`));
       });
@@ -256,7 +292,7 @@ export default function SlideModal({ slide, initialCfg, onSave, onClose }: Slide
 
   useEffect(() => {
     const prevOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
+    document.body.style.overflow = "hidden";
     return () => {
       document.body.style.overflow = prevOverflow;
     };
@@ -281,7 +317,7 @@ export default function SlideModal({ slide, initialCfg, onSave, onClose }: Slide
         return next;
       });
     },
-    [pushHistory]
+    [pushHistory],
   );
 
   const updateCfg = useCallback(
@@ -294,7 +330,7 @@ export default function SlideModal({ slide, initialCfg, onSave, onClose }: Slide
         return next;
       });
     },
-    [pushHistory]
+    [pushHistory],
   );
 
   const undo = useCallback(() => {
@@ -317,31 +353,40 @@ export default function SlideModal({ slide, initialCfg, onSave, onClose }: Slide
     });
   }, []);
 
-  const addBlock = (kind: SlideBlock['kind']) => {
+  const addBlock = (kind: SlideBlock["kind"]) => {
     const id = crypto.randomUUID();
     const frame = getDefaultFrame(kind);
     const block: SlideBlock = {
       id,
       kind,
       text:
-        kind === 'heading'
-          ? 'Add a headline'
-          : kind === 'subheading'
-            ? 'Add a subtitle'
-            : kind === 'text'
-              ? 'Write some supporting text'
-              : kind === 'button'
-                ? 'Tap me'
-                : kind === 'quote'
-                  ? 'Add a quote from a happy guest'
-                  : '',
-      href: kind === 'button' ? '/menu' : undefined,
+        kind === "heading"
+          ? "Add a headline"
+          : kind === "subheading"
+            ? "Add a subtitle"
+            : kind === "text"
+              ? "Write some supporting text"
+              : kind === "button"
+                ? "Tap me"
+                : kind === "quote"
+                  ? "Add a quote from a happy guest"
+                  : "",
+      href: kind === "button" ? "/menu" : undefined,
       frames: { [activeDevice]: frame },
-      color: kind === 'heading' || kind === 'subheading' || kind === 'text' ? '#ffffff' : undefined,
+      color:
+        kind === "heading" || kind === "subheading" || kind === "text"
+          ? "#ffffff"
+          : undefined,
       size:
-        kind === 'heading' ? 'xl' : kind === 'subheading' ? 'md' : kind === 'text' ? 'sm' : undefined,
-      fit: kind === 'image' ? 'cover' : undefined,
-      items: kind === 'gallery' ? [] : undefined,
+        kind === "heading"
+          ? "xl"
+          : kind === "subheading"
+            ? "md"
+            : kind === "text"
+              ? "sm"
+              : undefined,
+      fit: kind === "image" ? "cover" : undefined,
+      items: kind === "gallery" ? [] : undefined,
     };
     updateCfg((prev) => ({ ...prev, blocks: [...prev.blocks, block] }));
     setSelectedId(id);
@@ -368,13 +413,17 @@ export default function SlideModal({ slide, initialCfg, onSave, onClose }: Slide
     });
   };
 
-  const patchBlock = (id: string, patch: Partial<SlideBlock>, commit = true) => {
+  const patchBlock = (
+    id: string,
+    patch: Partial<SlideBlock>,
+    commit = true,
+  ) => {
     updateCfg(
       (prev) => ({
         ...prev,
         blocks: prev.blocks.map((b) => (b.id === id ? { ...b, ...patch } : b)),
       }),
-      commit
+      commit,
     );
   };
 
@@ -386,7 +435,7 @@ export default function SlideModal({ slide, initialCfg, onSave, onClose }: Slide
         const existing = ensureFrame(b, activeDevice);
         const nextFrame: Frame = {
           ...existing,
-          [field]: field === 'r' ? value : clampPct(value),
+          [field]: field === "r" ? value : clampPct(value),
         };
         return {
           ...b,
@@ -399,7 +448,9 @@ export default function SlideModal({ slide, initialCfg, onSave, onClose }: Slide
     }));
   };
 
-  const setBackground = (patch: Partial<NonNullable<SlideCfg['background']>>) => {
+  const setBackground = (
+    patch: Partial<NonNullable<SlideCfg["background"]>>,
+  ) => {
     updateCfg((prev) => ({
       ...prev,
       background: { ...prev.background, ...patch },
@@ -410,11 +461,15 @@ export default function SlideModal({ slide, initialCfg, onSave, onClose }: Slide
     if (!restaurantId) return;
     setUploading(true);
     try {
-      const ext = file.name.split('.').pop();
+      const ext = file.name.split(".").pop();
       const path = `slides/${restaurantId}/${crypto.randomUUID()}.${ext}`;
-      const { data, error } = await supabase.storage.from(STORAGE_BUCKET).upload(path, file, { upsert: true });
+      const { data, error } = await supabase.storage
+        .from(STORAGE_BUCKET)
+        .upload(path, file, { upsert: true });
       if (error) throw error;
-      const { data: pub } = supabase.storage.from(STORAGE_BUCKET).getPublicUrl(data.path);
+      const { data: pub } = supabase.storage
+        .from(STORAGE_BUCKET)
+        .getPublicUrl(data.path);
       if (pub?.publicUrl) onUrl(pub.publicUrl);
     } finally {
       setUploading(false);
@@ -433,14 +488,17 @@ export default function SlideModal({ slide, initialCfg, onSave, onClose }: Slide
 
   const selectedBlock = useMemo(
     () => cfg.blocks.find((b) => b.id === selectedId) || null,
-    [cfg.blocks, selectedId]
+    [cfg.blocks, selectedId],
   );
 
   const frame = selectedBlock ? ensureFrame(selectedBlock, activeDevice) : null;
 
-  const linkOptions = useMemo(() => [...ROUTE_OPTIONS, ...customPages, 'custom'], [customPages]);
+  const linkOptions = useMemo(
+    () => [...ROUTE_OPTIONS, ...customPages, "custom"],
+    [customPages],
+  );
 
-  const selectionLabel = selectedBlock ? `${selectedBlock.kind}` : 'None';
+  const selectionLabel = selectedBlock ? `${selectedBlock.kind}` : "None";
 
   return (
     <div className="fixed inset-0 z-[80] flex">
@@ -452,9 +510,10 @@ export default function SlideModal({ slide, initialCfg, onSave, onClose }: Slide
               <button
                 type="button"
                 onClick={() => setDrawerOpen((v) => !v)}
-                className="rounded border px-3 py-1 text-sm"
+                className={`rounded border border-neutral-200 px-3 py-1 text-sm ${drawerOpen ? "border-emerald-500 bg-emerald-50" : ""}`}
+                aria-pressed={drawerOpen}
               >
-                {drawerOpen ? 'Hide Blocks' : 'Show Blocks'}
+                Blocks
               </button>
               <button
                 type="button"
@@ -475,9 +534,10 @@ export default function SlideModal({ slide, initialCfg, onSave, onClose }: Slide
               <button
                 type="button"
                 onClick={() => setInspectorOpen((v) => !v)}
-                className="rounded border px-3 py-1 text-sm"
+                className={`rounded border border-neutral-200 px-3 py-1 text-sm ${inspectorOpen ? "border-emerald-500 bg-emerald-50" : ""}`}
+                aria-pressed={inspectorOpen}
               >
-                {inspectorOpen ? 'Hide Inspector' : 'Show Inspector'}
+                Inspector
               </button>
             </div>
             <div className="flex items-center gap-4">
@@ -490,9 +550,12 @@ export default function SlideModal({ slide, initialCfg, onSave, onClose }: Slide
                 Edit in preview
               </label>
               <Button onClick={handleSave} disabled={saving}>
-                {saving ? 'Saving…' : 'Save'}
+                {saving ? "Saving…" : "Save"}
               </Button>
-              <button onClick={onClose} className="rounded border px-3 py-1 text-sm">
+              <button
+                onClick={onClose}
+                className="rounded border px-3 py-1 text-sm"
+              >
                 Close
               </button>
             </div>
@@ -502,19 +565,21 @@ export default function SlideModal({ slide, initialCfg, onSave, onClose }: Slide
               <aside className="w-64 shrink-0 border-r bg-white">
                 <div className="h-full space-y-4 overflow-y-auto p-4">
                   <div>
-                    <h3 className="text-sm font-semibold uppercase tracking-wide text-neutral-500">Blocks</h3>
+                    <h3 className="text-sm font-semibold uppercase tracking-wide text-neutral-500">
+                      Blocks
+                    </h3>
                     <div className="mt-2 grid grid-cols-2 gap-2">
                       {(
                         [
-                          'heading',
-                          'subheading',
-                          'text',
-                          'button',
-                          'image',
-                          'quote',
-                          'gallery',
-                          'spacer',
-                        ] as SlideBlock['kind'][]
+                          "heading",
+                          "subheading",
+                          "text",
+                          "button",
+                          "image",
+                          "quote",
+                          "gallery",
+                          "spacer",
+                        ] as SlideBlock["kind"][]
                       ).map((kind) => (
                         <button
                           key={kind}
@@ -528,13 +593,17 @@ export default function SlideModal({ slide, initialCfg, onSave, onClose }: Slide
                     </div>
                   </div>
                   <div>
-                    <h3 className="mb-2 text-sm font-semibold text-neutral-600">Layers</h3>
+                    <h3 className="mb-2 text-sm font-semibold text-neutral-600">
+                      Layers
+                    </h3>
                     <div className="space-y-2">
                       {cfg.blocks.map((block, index) => (
                         <div
                           key={block.id}
                           className={`rounded border px-2 py-2 text-sm transition hover:border-emerald-400 ${
-                            block.id === selectedId ? 'border-emerald-500 bg-emerald-50' : 'border-neutral-200'
+                            block.id === selectedId
+                              ? "border-emerald-500 bg-emerald-50"
+                              : "border-neutral-200"
                           }`}
                         >
                           <button
@@ -543,7 +612,9 @@ export default function SlideModal({ slide, initialCfg, onSave, onClose }: Slide
                             className="flex w-full items-center justify-between text-left"
                           >
                             <span className="capitalize">{block.kind}</span>
-                            <span className="text-xs text-neutral-500">{index + 1}</span>
+                            <span className="text-xs text-neutral-500">
+                              {index + 1}
+                            </span>
                           </button>
                           <div className="mt-2 flex gap-2 text-xs">
                             <button
@@ -575,466 +646,668 @@ export default function SlideModal({ slide, initialCfg, onSave, onClose }: Slide
                     </div>
                   </div>
                   <div>
-                    <h3 className="mb-2 text-sm font-semibold text-neutral-600">Device</h3>
+                    <h3 className="mb-2 text-sm font-semibold text-neutral-600">
+                      Device
+                    </h3>
                     <div className="flex gap-2">
-                      {(['mobile', 'tablet', 'desktop'] as DeviceKind[]).map((device) => (
-                        <button
-                          key={device}
-                          type="button"
-                          onClick={() => setActiveDevice(device)}
-                          className={`rounded border px-2 py-1 text-xs capitalize ${
-                            activeDevice === device ? 'border-emerald-500 bg-emerald-50' : 'border-neutral-200'
-                          }`}
-                        >
-                          {device}
-                        </button>
-                      ))}
+                      {(["mobile", "tablet", "desktop"] as DeviceKind[]).map(
+                        (device) => (
+                          <button
+                            key={device}
+                            type="button"
+                            onClick={() => setActiveDevice(device)}
+                            className={`rounded border px-2 py-1 text-xs capitalize ${
+                              activeDevice === device
+                                ? "border-emerald-500 bg-emerald-50"
+                                : "border-neutral-200"
+                            }`}
+                          >
+                            {device}
+                          </button>
+                        ),
+                      )}
                     </div>
                   </div>
                 </div>
               </aside>
             )}
-            <main className="flex-1 overflow-hidden bg-neutral-50">
-              <SlidesManager
-                initialCfg={cfg}
-                onChange={handlePreviewChange}
-                editable={true}
-                selectedId={selectedId}
-                onSelect={setSelectedId}
-                activeDevice={activeDevice}
-                editInPreview={editInPreview}
-              />
-            </main>
-            {inspectorOpen && (
-              <aside className="w-80 shrink-0 border-l bg-white">
-                <div className="h-full overflow-y-auto p-4 space-y-6">
-                  <section>
-                    <h3 className="text-sm font-semibold text-neutral-600">Background</h3>
-                    <div className="mt-3 space-y-3 text-sm">
-                      <label className="block">
-                        <span className="text-xs font-medium text-neutral-500">Type</span>
-                        <select
-                          value={cfg.background?.type || 'color'}
-                          onChange={(e) =>
-                            setBackground({
-                              type: e.target.value as SlideCfg['background']['type'],
-                              url: undefined,
-                            })
-                          }
-                          className="mt-1 w-full rounded border px-2 py-1"
-                        >
-                          <option value="color">Color</option>
-                          <option value="image">Image</option>
-                          <option value="video">Video</option>
-                        </select>
-                      </label>
-                      {cfg.background?.type === 'color' && (
+            <div className="flex flex-1 flex-col overflow-hidden">
+              <main className="flex-1 overflow-hidden bg-neutral-50">
+                <div className="flex h-full w-full items-center justify-center overflow-auto">
+                  <SlidesManager
+                    initialCfg={cfg}
+                    onChange={handlePreviewChange}
+                    editable={true}
+                    selectedId={selectedId}
+                    onSelect={setSelectedId}
+                    activeDevice={activeDevice}
+                    editInPreview={editInPreview}
+                  />
+                </div>
+              </main>
+              {inspectorOpen && (
+                <div className="border-t bg-white">
+                  <div className="max-h-[60vh] overflow-y-auto p-4 space-y-6">
+                    <section>
+                      <h3 className="text-sm font-semibold text-neutral-600">
+                        Background
+                      </h3>
+                      <div className="mt-3 space-y-3 text-sm">
                         <label className="block">
-                          <span className="text-xs font-medium text-neutral-500">Color</span>
-                          <input
-                            type="color"
-                            value={cfg.background?.color || '#111111'}
-                            onChange={(e) => setBackground({ color: e.target.value })}
-                            className="mt-1 h-10 w-full rounded border"
-                          />
-                        </label>
-                      )}
-                      {cfg.background?.type !== 'color' && (
-                        <div className="space-y-2">
-                          <label className="block text-xs font-medium text-neutral-500">Media URL</label>
-                          <input
-                            type="text"
-                            value={cfg.background?.url || ''}
-                            onChange={(e) => setBackground({ url: e.target.value })}
-                            className="w-full rounded border px-2 py-1 text-sm"
-                            placeholder="https://"
-                          />
-                          <input
-                            ref={imageInputRef}
-                            type="file"
-                            accept={cfg.background?.type === 'video' ? 'video/*' : 'image/*'}
-                            className="hidden"
-                            onChange={(e) => {
-                              const file = e.target.files?.[0];
-                              if (file) {
-                                handleUpload(file, (url) => setBackground({ url }));
-                                e.target.value = '';
-                              }
-                            }}
-                          />
-                          <button
-                            type="button"
-                            onClick={() => imageInputRef.current?.click()}
-                            className="rounded border px-3 py-1 text-xs"
+                          <span className="text-xs font-medium text-neutral-500">
+                            Type
+                          </span>
+                          <select
+                            value={cfg.background?.type || "color"}
+                            onChange={(e) =>
+                              setBackground({
+                                type: e.target
+                                  .value as SlideCfg["background"]["type"],
+                                url: undefined,
+                              })
+                            }
+                            className="mt-1 w-full rounded border px-2 py-1"
                           >
-                            Upload
-                          </button>
-                          {uploading && <div className="text-xs text-neutral-500">Uploading…</div>}
-                        </div>
-                      )}
-                      <label className="flex items-center gap-2 text-xs">
-                        <input
-                          type="checkbox"
-                          checked={!!cfg.background?.overlay}
-                          onChange={(e) =>
-                            setBackground(
-                              e.target.checked
-                                ? { overlay: { color: '#000000', opacity: 0.25 } }
-                                : { overlay: undefined }
-                            )
-                          }
-                        />
-                        Overlay
-                      </label>
-                      {cfg.background?.overlay && (
-                        <div className="flex gap-2">
-                          <input
-                            type="color"
-                            value={cfg.background.overlay.color || '#000000'}
-                            onChange={(e) =>
-                              setBackground({
-                                overlay: {
-                                  color: e.target.value,
-                                  opacity: cfg.background?.overlay?.opacity ?? 0.25,
-                                },
-                              })
-                            }
-                            className="h-10 w-1/2 rounded border"
-                          />
-                          <input
-                            type="number"
-                            min={0}
-                            max={0.9}
-                            step={0.05}
-                            value={cfg.background.overlay.opacity ?? 0.25}
-                            onChange={(e) =>
-                              setBackground({
-                                overlay: {
-                                  color: cfg.background?.overlay?.color ?? '#000000',
-                                  opacity: Number(e.target.value),
-                                },
-                              })
-                            }
-                            className="w-1/2 rounded border px-2 py-1 text-sm"
-                          />
-                        </div>
-                      )}
-                    </div>
-                  </section>
-                  <section>
-                    <div className="flex items-center justify-between">
-                      <h3 className="text-sm font-semibold text-neutral-600">Inspector</h3>
-                      <span className="text-xs text-neutral-500">Selected: {selectionLabel}</span>
-                    </div>
-                    {!selectedBlock ? (
-                      <p className="mt-3 text-xs text-neutral-500">
-                        Choose a block from the preview or layers list to edit its properties.
-                      </p>
-                    ) : (
-                      <div className="mt-3 space-y-4 text-sm">
-                        {(selectedBlock.kind === 'heading' ||
-                          selectedBlock.kind === 'subheading' ||
-                          selectedBlock.kind === 'text') && (
-                          <>
-                            <label className="block">
-                              <span className="text-xs font-medium text-neutral-500">Text</span>
-                              <textarea
-                                rows={3}
-                                value={selectedBlock.text ?? ''}
-                                onChange={(e) => patchBlock(selectedBlock.id, { text: e.target.value })}
-                                className="mt-1 w-full rounded border px-2 py-1"
-                              />
-                            </label>
-                            <label className="block">
-                              <span className="text-xs font-medium text-neutral-500">Color</span>
-                              <input
-                                type="color"
-                                value={selectedBlock.color || '#ffffff'}
-                                onChange={(e) => patchBlock(selectedBlock.id, { color: e.target.value })}
-                                className="mt-1 h-10 w-full rounded border"
-                              />
-                            </label>
-                            <label className="block">
-                              <span className="text-xs font-medium text-neutral-500">Size</span>
-                              <select
-                                value={selectedBlock.size || 'md'}
-                                onChange={(e) => patchBlock(selectedBlock.id, { size: e.target.value as any })}
-                                className="mt-1 w-full rounded border px-2 py-1"
-                              >
-                                {TEXT_SIZES.map((opt) => (
-                                  <option key={opt.value} value={opt.value}>
-                                    {opt.label}
-                                  </option>
-                                ))}
-                              </select>
-                            </label>
-                            <div>
-                              <span className="text-xs font-medium text-neutral-500">Alignment</span>
-                              <div className="mt-1 flex gap-2">
-                                {(['left', 'center', 'right'] as const).map((align) => (
-                                  <button
-                                    key={align}
-                                    type="button"
-                                    onClick={() => patchBlock(selectedBlock.id, { align })}
-                                    className={`rounded border px-2 py-1 text-xs capitalize ${
-                                      selectedBlock.align === align ? 'border-emerald-500 bg-emerald-50' : ''
-                                    }`}
-                                  >
-                                    {align}
-                                  </button>
-                                ))}
-                              </div>
-                            </div>
-                          </>
+                            <option value="color">Color</option>
+                            <option value="image">Image</option>
+                            <option value="video">Video</option>
+                          </select>
+                        </label>
+                        {cfg.background?.type === "color" && (
+                          <label className="block">
+                            <span className="text-xs font-medium text-neutral-500">
+                              Color
+                            </span>
+                            <input
+                              type="color"
+                              value={cfg.background?.color || "#111111"}
+                              onChange={(e) =>
+                                setBackground({ color: e.target.value })
+                              }
+                              className="mt-1 h-10 w-full rounded border"
+                            />
+                          </label>
                         )}
-                        {selectedBlock.kind === 'button' && (
-                          <>
-                            <label className="block">
-                              <span className="text-xs font-medium text-neutral-500">Label</span>
-                              <input
-                                type="text"
-                                value={selectedBlock.text || ''}
-                                onChange={(e) => patchBlock(selectedBlock.id, { text: e.target.value })}
-                                className="mt-1 w-full rounded border px-2 py-1"
-                              />
+                        {cfg.background?.type !== "color" && (
+                          <div className="space-y-2">
+                            <label className="block text-xs font-medium text-neutral-500">
+                              Media URL
                             </label>
-                            <label className="block">
-                              <span className="text-xs font-medium text-neutral-500">Link</span>
-                              <select
-                                value={linkOptions.includes(selectedBlock.href ?? '') ? selectedBlock.href : 'custom'}
-                                onChange={(e) => {
-                                  const value = e.target.value;
-                                  if (value === 'custom') return;
-                                  patchBlock(selectedBlock.id, { href: value });
-                                }}
-                                className="mt-1 w-full rounded border px-2 py-1"
-                              >
-                                {linkOptions.map((opt) => (
-                                  <option key={opt} value={opt}>
-                                    {opt === 'custom' ? 'Custom URL' : opt}
-                                  </option>
-                                ))}
-                              </select>
-                            </label>
-                            {(!selectedBlock.href || !linkOptions.includes(selectedBlock.href)) && (
+                            <input
+                              type="text"
+                              value={cfg.background?.url || ""}
+                              onChange={(e) =>
+                                setBackground({ url: e.target.value })
+                              }
+                              className="w-full rounded border px-2 py-1 text-sm"
+                              placeholder="https://"
+                            />
+                            <input
+                              ref={imageInputRef}
+                              type="file"
+                              accept={
+                                cfg.background?.type === "video"
+                                  ? "video/*"
+                                  : "image/*"
+                              }
+                              className="hidden"
+                              onChange={(e) => {
+                                const file = e.target.files?.[0];
+                                if (file) {
+                                  handleUpload(file, (url) =>
+                                    setBackground({ url }),
+                                  );
+                                  e.target.value = "";
+                                }
+                              }}
+                            />
+                            <button
+                              type="button"
+                              onClick={() => imageInputRef.current?.click()}
+                              className="rounded border px-3 py-1 text-xs"
+                            >
+                              Upload
+                            </button>
+                            {uploading && (
+                              <div className="text-xs text-neutral-500">
+                                Uploading…
+                              </div>
+                            )}
+                          </div>
+                        )}
+                        <label className="flex items-center gap-2 text-xs">
+                          <input
+                            type="checkbox"
+                            checked={!!cfg.background?.overlay}
+                            onChange={(e) =>
+                              setBackground(
+                                e.target.checked
+                                  ? {
+                                      overlay: {
+                                        color: "#000000",
+                                        opacity: 0.25,
+                                      },
+                                    }
+                                  : { overlay: undefined },
+                              )
+                            }
+                          />
+                          Overlay
+                        </label>
+                        {cfg.background?.overlay && (
+                          <div className="flex gap-2">
+                            <input
+                              type="color"
+                              value={cfg.background.overlay.color || "#000000"}
+                              onChange={(e) =>
+                                setBackground({
+                                  overlay: {
+                                    color: e.target.value,
+                                    opacity:
+                                      cfg.background?.overlay?.opacity ?? 0.25,
+                                  },
+                                })
+                              }
+                              className="h-10 w-1/2 rounded border"
+                            />
+                            <input
+                              type="number"
+                              min={0}
+                              max={0.9}
+                              step={0.05}
+                              value={cfg.background.overlay.opacity ?? 0.25}
+                              onChange={(e) =>
+                                setBackground({
+                                  overlay: {
+                                    color:
+                                      cfg.background?.overlay?.color ??
+                                      "#000000",
+                                    opacity: Number(e.target.value),
+                                  },
+                                })
+                              }
+                              className="w-1/2 rounded border px-2 py-1 text-sm"
+                            />
+                          </div>
+                        )}
+                      </div>
+                    </section>
+                    <section>
+                      <div className="flex items-center justify-between">
+                        <h3 className="text-sm font-semibold text-neutral-600">
+                          Inspector
+                        </h3>
+                        <span className="text-xs text-neutral-500">
+                          Selected: {selectionLabel}
+                        </span>
+                      </div>
+                      {!selectedBlock ? (
+                        <p className="mt-3 text-xs text-neutral-500">
+                          Choose a block from the preview or layers list to edit
+                          its properties.
+                        </p>
+                      ) : (
+                        <div className="mt-3 space-y-4 text-sm">
+                          {(selectedBlock.kind === "heading" ||
+                            selectedBlock.kind === "subheading" ||
+                            selectedBlock.kind === "text") && (
+                            <>
                               <label className="block">
-                                <span className="text-xs font-medium text-neutral-500">Custom URL</span>
-                                <input
-                                  type="text"
-                                  value={selectedBlock.href || ''}
-                                  onChange={(e) => patchBlock(selectedBlock.id, { href: e.target.value })}
+                                <span className="text-xs font-medium text-neutral-500">
+                                  Text
+                                </span>
+                                <textarea
+                                  rows={3}
+                                  value={selectedBlock.text ?? ""}
+                                  onChange={(e) =>
+                                    patchBlock(selectedBlock.id, {
+                                      text: e.target.value,
+                                    })
+                                  }
                                   className="mt-1 w-full rounded border px-2 py-1"
-                                  placeholder="https://"
                                 />
                               </label>
-                            )}
-                          </>
-                        )}
-                        {selectedBlock.kind === 'image' && (
-                          <>
-                            <div className="space-y-2">
-                              <span className="text-xs font-medium text-neutral-500">Image</span>
-                              {selectedBlock.src && (
-                                <img src={selectedBlock.src} alt="" className="h-28 w-full rounded object-cover" />
-                              )}
-                              <input
-                                ref={blockImageInputRef}
-                                type="file"
-                                accept="image/*"
-                                className="hidden"
-                                onChange={(e) => {
-                                  const file = e.target.files?.[0];
-                                  if (file) {
-                                    handleUpload(file, (url) => patchBlock(selectedBlock.id, { src: url }));
-                                    e.target.value = '';
-                                  }
-                                }}
-                              />
-                              <button
-                                type="button"
-                                onClick={() => blockImageInputRef.current?.click()}
-                                className="rounded border px-3 py-1 text-xs"
-                              >
-                                {selectedBlock.src ? 'Replace image' : 'Upload image'}
-                              </button>
                               <label className="block">
-                                <span className="text-xs font-medium text-neutral-500">Fit</span>
-                                <select
-                                  value={selectedBlock.fit || 'cover'}
+                                <span className="text-xs font-medium text-neutral-500">
+                                  Color
+                                </span>
+                                <input
+                                  type="color"
+                                  value={selectedBlock.color || "#ffffff"}
                                   onChange={(e) =>
-                                    patchBlock(selectedBlock.id, { fit: e.target.value as 'cover' | 'contain' })
+                                    patchBlock(selectedBlock.id, {
+                                      color: e.target.value,
+                                    })
+                                  }
+                                  className="mt-1 h-10 w-full rounded border"
+                                />
+                              </label>
+                              <label className="block">
+                                <span className="text-xs font-medium text-neutral-500">
+                                  Size
+                                </span>
+                                <select
+                                  value={selectedBlock.size || "md"}
+                                  onChange={(e) =>
+                                    patchBlock(selectedBlock.id, {
+                                      size: e.target.value as any,
+                                    })
                                   }
                                   className="mt-1 w-full rounded border px-2 py-1"
                                 >
-                                  <option value="cover">Cover</option>
-                                  <option value="contain">Contain</option>
+                                  {TEXT_SIZES.map((opt) => (
+                                    <option key={opt.value} value={opt.value}>
+                                      {opt.label}
+                                    </option>
+                                  ))}
                                 </select>
                               </label>
-                            </div>
-                          </>
-                        )}
-                        {selectedBlock.kind === 'gallery' && (
-                          <div className="space-y-3">
-                            <div className="flex items-center justify-between text-xs text-neutral-500">
-                              <span>{selectedBlock.items?.length || 0} images</span>
-                              <button
-                                type="button"
-                                onClick={() => galleryInputRef.current?.click()}
-                                className="rounded border px-2 py-1"
-                              >
-                                Upload
-                              </button>
-                            </div>
-                            <input
-                              ref={galleryInputRef}
-                              type="file"
-                              accept="image/*"
-                              multiple
-                              className="hidden"
-                              onChange={async (e) => {
-                                const files = Array.from(e.target.files || []);
-                                if (!files.length) return;
-                                const current = cfg.blocks.find((b) => b.id === selectedBlock.id);
-                                const nextItems = [...(current?.items || [])];
-                                for (const file of files) {
-                                  // eslint-disable-next-line no-await-in-loop
-                                  await handleUpload(file, (url) => {
-                                    nextItems.push({ src: url });
-                                  });
-                                }
-                                patchBlock(selectedBlock.id, { items: nextItems });
-                                e.target.value = '';
-                              }}
-                            />
-                            <div className="space-y-2">
-                              {(selectedBlock.items || []).map((item, index) => (
-                                <div key={item.src} className="flex items-center gap-2 text-xs">
-                                  <img src={item.src} alt="" className="h-12 w-12 rounded object-cover" />
-                                  <div className="flex gap-1">
-                                    <button
-                                      type="button"
-                                      className="rounded border px-2 py-1"
-                                      disabled={index === 0}
-                                      onClick={() => {
-                                        const next = [...(selectedBlock.items || [])];
-                                        const [moved] = next.splice(index, 1);
-                                        next.splice(index - 1, 0, moved);
-                                        patchBlock(selectedBlock.id, { items: next });
-                                      }}
-                                    >
-                                      Up
-                                    </button>
-                                    <button
-                                      type="button"
-                                      className="rounded border px-2 py-1"
-                                      disabled={index === (selectedBlock.items || []).length - 1}
-                                      onClick={() => {
-                                        const next = [...(selectedBlock.items || [])];
-                                        const [moved] = next.splice(index, 1);
-                                        next.splice(index + 1, 0, moved);
-                                        patchBlock(selectedBlock.id, { items: next });
-                                      }}
-                                    >
-                                      Down
-                                    </button>
-                                    <button
-                                      type="button"
-                                      className="rounded border px-2 py-1 text-red-600"
-                                      onClick={() => {
-                                        const next = (selectedBlock.items || []).filter((_, i) => i !== index);
-                                        patchBlock(selectedBlock.id, { items: next });
-                                      }}
-                                    >
-                                      Remove
-                                    </button>
-                                  </div>
+                              <div>
+                                <span className="text-xs font-medium text-neutral-500">
+                                  Alignment
+                                </span>
+                                <div className="mt-1 flex gap-2">
+                                  {(["left", "center", "right"] as const).map(
+                                    (align) => (
+                                      <button
+                                        key={align}
+                                        type="button"
+                                        onClick={() =>
+                                          patchBlock(selectedBlock.id, {
+                                            align,
+                                          })
+                                        }
+                                        className={`rounded border px-2 py-1 text-xs capitalize ${
+                                          selectedBlock.align === align
+                                            ? "border-emerald-500 bg-emerald-50"
+                                            : ""
+                                        }`}
+                                      >
+                                        {align}
+                                      </button>
+                                    ),
+                                  )}
                                 </div>
-                              ))}
-                            </div>
-                          </div>
-                        )}
-                        {selectedBlock.kind === 'quote' && (
-                          <>
-                            <label className="block">
-                              <span className="text-xs font-medium text-neutral-500">Quote</span>
-                              <textarea
-                                rows={3}
-                                value={selectedBlock.text || ''}
-                                onChange={(e) => patchBlock(selectedBlock.id, { text: e.target.value })}
-                                className="mt-1 w-full rounded border px-2 py-1"
-                              />
-                            </label>
-                            <label className="block">
-                              <span className="text-xs font-medium text-neutral-500">Author</span>
+                              </div>
+                            </>
+                          )}
+                          {selectedBlock.kind === "button" && (
+                            <>
+                              <label className="block">
+                                <span className="text-xs font-medium text-neutral-500">
+                                  Label
+                                </span>
+                                <input
+                                  type="text"
+                                  value={selectedBlock.text || ""}
+                                  onChange={(e) =>
+                                    patchBlock(selectedBlock.id, {
+                                      text: e.target.value,
+                                    })
+                                  }
+                                  className="mt-1 w-full rounded border px-2 py-1"
+                                />
+                              </label>
+                              <label className="block">
+                                <span className="text-xs font-medium text-neutral-500">
+                                  Link
+                                </span>
+                                <select
+                                  value={
+                                    linkOptions.includes(
+                                      selectedBlock.href ?? "",
+                                    )
+                                      ? selectedBlock.href
+                                      : "custom"
+                                  }
+                                  onChange={(e) => {
+                                    const value = e.target.value;
+                                    if (value === "custom") return;
+                                    patchBlock(selectedBlock.id, {
+                                      href: value,
+                                    });
+                                  }}
+                                  className="mt-1 w-full rounded border px-2 py-1"
+                                >
+                                  {linkOptions.map((opt) => (
+                                    <option key={opt} value={opt}>
+                                      {opt === "custom" ? "Custom URL" : opt}
+                                    </option>
+                                  ))}
+                                </select>
+                              </label>
+                              {(!selectedBlock.href ||
+                                !linkOptions.includes(selectedBlock.href)) && (
+                                <label className="block">
+                                  <span className="text-xs font-medium text-neutral-500">
+                                    Custom URL
+                                  </span>
+                                  <input
+                                    type="text"
+                                    value={selectedBlock.href || ""}
+                                    onChange={(e) =>
+                                      patchBlock(selectedBlock.id, {
+                                        href: e.target.value,
+                                      })
+                                    }
+                                    className="mt-1 w-full rounded border px-2 py-1"
+                                    placeholder="https://"
+                                  />
+                                </label>
+                              )}
+                            </>
+                          )}
+                          {selectedBlock.kind === "image" && (
+                            <>
+                              <div className="space-y-2">
+                                <span className="text-xs font-medium text-neutral-500">
+                                  Image
+                                </span>
+                                {selectedBlock.src && (
+                                  <img
+                                    src={selectedBlock.src}
+                                    alt=""
+                                    className="h-28 w-full rounded object-cover"
+                                  />
+                                )}
+                                <input
+                                  ref={blockImageInputRef}
+                                  type="file"
+                                  accept="image/*"
+                                  className="hidden"
+                                  onChange={(e) => {
+                                    const file = e.target.files?.[0];
+                                    if (file) {
+                                      handleUpload(file, (url) =>
+                                        patchBlock(selectedBlock.id, {
+                                          src: url,
+                                        }),
+                                      );
+                                      e.target.value = "";
+                                    }
+                                  }}
+                                />
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    blockImageInputRef.current?.click()
+                                  }
+                                  className="rounded border px-3 py-1 text-xs"
+                                >
+                                  {selectedBlock.src
+                                    ? "Replace image"
+                                    : "Upload image"}
+                                </button>
+                                <label className="block">
+                                  <span className="text-xs font-medium text-neutral-500">
+                                    Fit
+                                  </span>
+                                  <select
+                                    value={selectedBlock.fit || "cover"}
+                                    onChange={(e) =>
+                                      patchBlock(selectedBlock.id, {
+                                        fit: e.target.value as
+                                          | "cover"
+                                          | "contain",
+                                      })
+                                    }
+                                    className="mt-1 w-full rounded border px-2 py-1"
+                                  >
+                                    <option value="cover">Cover</option>
+                                    <option value="contain">Contain</option>
+                                  </select>
+                                </label>
+                              </div>
+                            </>
+                          )}
+                          {selectedBlock.kind === "gallery" && (
+                            <div className="space-y-3">
+                              <div className="flex items-center justify-between text-xs text-neutral-500">
+                                <span>
+                                  {selectedBlock.items?.length || 0} images
+                                </span>
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    galleryInputRef.current?.click()
+                                  }
+                                  className="rounded border px-2 py-1"
+                                >
+                                  Upload
+                                </button>
+                              </div>
                               <input
-                                type="text"
-                                value={selectedBlock.author || ''}
-                                onChange={(e) => patchBlock(selectedBlock.id, { author: e.target.value })}
-                                className="mt-1 w-full rounded border px-2 py-1"
+                                ref={galleryInputRef}
+                                type="file"
+                                accept="image/*"
+                                multiple
+                                className="hidden"
+                                onChange={async (e) => {
+                                  const files = Array.from(
+                                    e.target.files || [],
+                                  );
+                                  if (!files.length) return;
+                                  const current = cfg.blocks.find(
+                                    (b) => b.id === selectedBlock.id,
+                                  );
+                                  const nextItems = [...(current?.items || [])];
+                                  for (const file of files) {
+                                    // eslint-disable-next-line no-await-in-loop
+                                    await handleUpload(file, (url) => {
+                                      nextItems.push({ src: url });
+                                    });
+                                  }
+                                  patchBlock(selectedBlock.id, {
+                                    items: nextItems,
+                                  });
+                                  e.target.value = "";
+                                }}
                               />
-                            </label>
-                          </>
-                        )}
-                        <div className="rounded border px-3 py-3">
-                          <h4 className="text-xs font-semibold uppercase tracking-wide text-neutral-500">Frame ({activeDevice})</h4>
-                          <div className="mt-2 grid grid-cols-2 gap-2 text-xs">
-                            {frame && (
-                              <>
-                                <label className="flex flex-col gap-1">
-                                  <span>X%</span>
-                                  <input
-                                    type="number"
-                                    value={frame.x}
-                                    onChange={(e) => updateFrameField(selectedBlock.id, 'x', parseFloat(e.target.value))}
-                                    className="rounded border px-2 py-1"
-                                  />
-                                </label>
-                                <label className="flex flex-col gap-1">
-                                  <span>Y%</span>
-                                  <input
-                                    type="number"
-                                    value={frame.y}
-                                    onChange={(e) => updateFrameField(selectedBlock.id, 'y', parseFloat(e.target.value))}
-                                    className="rounded border px-2 py-1"
-                                  />
-                                </label>
-                                <label className="flex flex-col gap-1">
-                                  <span>Width%</span>
-                                  <input
-                                    type="number"
-                                    value={frame.w}
-                                    onChange={(e) => updateFrameField(selectedBlock.id, 'w', parseFloat(e.target.value))}
-                                    className="rounded border px-2 py-1"
-                                  />
-                                </label>
-                                <label className="flex flex-col gap-1">
-                                  <span>Height%</span>
-                                  <input
-                                    type="number"
-                                    value={frame.h}
-                                    onChange={(e) => updateFrameField(selectedBlock.id, 'h', parseFloat(e.target.value))}
-                                    className="rounded border px-2 py-1"
-                                  />
-                                </label>
-                                <label className="flex flex-col gap-1">
-                                  <span>Rotation°</span>
-                                  <input
-                                    type="number"
-                                    value={frame.r}
-                                    onChange={(e) => updateFrameField(selectedBlock.id, 'r', parseFloat(e.target.value))}
-                                    className="rounded border px-2 py-1"
-                                  />
-                                </label>
-                              </>
-                            )}
+                              <div className="space-y-2">
+                                {(selectedBlock.items || []).map(
+                                  (item, index) => (
+                                    <div
+                                      key={item.src}
+                                      className="flex items-center gap-2 text-xs"
+                                    >
+                                      <img
+                                        src={item.src}
+                                        alt=""
+                                        className="h-12 w-12 rounded object-cover"
+                                      />
+                                      <div className="flex gap-1">
+                                        <button
+                                          type="button"
+                                          className="rounded border px-2 py-1"
+                                          disabled={index === 0}
+                                          onClick={() => {
+                                            const next = [
+                                              ...(selectedBlock.items || []),
+                                            ];
+                                            const [moved] = next.splice(
+                                              index,
+                                              1,
+                                            );
+                                            next.splice(index - 1, 0, moved);
+                                            patchBlock(selectedBlock.id, {
+                                              items: next,
+                                            });
+                                          }}
+                                        >
+                                          Up
+                                        </button>
+                                        <button
+                                          type="button"
+                                          className="rounded border px-2 py-1"
+                                          disabled={
+                                            index ===
+                                            (selectedBlock.items || []).length -
+                                              1
+                                          }
+                                          onClick={() => {
+                                            const next = [
+                                              ...(selectedBlock.items || []),
+                                            ];
+                                            const [moved] = next.splice(
+                                              index,
+                                              1,
+                                            );
+                                            next.splice(index + 1, 0, moved);
+                                            patchBlock(selectedBlock.id, {
+                                              items: next,
+                                            });
+                                          }}
+                                        >
+                                          Down
+                                        </button>
+                                        <button
+                                          type="button"
+                                          className="rounded border px-2 py-1 text-red-600"
+                                          onClick={() => {
+                                            const next = (
+                                              selectedBlock.items || []
+                                            ).filter((_, i) => i !== index);
+                                            patchBlock(selectedBlock.id, {
+                                              items: next,
+                                            });
+                                          }}
+                                        >
+                                          Remove
+                                        </button>
+                                      </div>
+                                    </div>
+                                  ),
+                                )}
+                              </div>
+                            </div>
+                          )}
+                          {selectedBlock.kind === "quote" && (
+                            <>
+                              <label className="block">
+                                <span className="text-xs font-medium text-neutral-500">
+                                  Quote
+                                </span>
+                                <textarea
+                                  rows={3}
+                                  value={selectedBlock.text || ""}
+                                  onChange={(e) =>
+                                    patchBlock(selectedBlock.id, {
+                                      text: e.target.value,
+                                    })
+                                  }
+                                  className="mt-1 w-full rounded border px-2 py-1"
+                                />
+                              </label>
+                              <label className="block">
+                                <span className="text-xs font-medium text-neutral-500">
+                                  Author
+                                </span>
+                                <input
+                                  type="text"
+                                  value={selectedBlock.author || ""}
+                                  onChange={(e) =>
+                                    patchBlock(selectedBlock.id, {
+                                      author: e.target.value,
+                                    })
+                                  }
+                                  className="mt-1 w-full rounded border px-2 py-1"
+                                />
+                              </label>
+                            </>
+                          )}
+                          <div className="rounded border px-3 py-3">
+                            <h4 className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+                              Frame ({activeDevice})
+                            </h4>
+                            <div className="mt-2 grid grid-cols-2 gap-2 text-xs">
+                              {frame && (
+                                <>
+                                  <label className="flex flex-col gap-1">
+                                    <span>X%</span>
+                                    <input
+                                      type="number"
+                                      value={frame.x}
+                                      onChange={(e) =>
+                                        updateFrameField(
+                                          selectedBlock.id,
+                                          "x",
+                                          parseFloat(e.target.value),
+                                        )
+                                      }
+                                      className="rounded border px-2 py-1"
+                                    />
+                                  </label>
+                                  <label className="flex flex-col gap-1">
+                                    <span>Y%</span>
+                                    <input
+                                      type="number"
+                                      value={frame.y}
+                                      onChange={(e) =>
+                                        updateFrameField(
+                                          selectedBlock.id,
+                                          "y",
+                                          parseFloat(e.target.value),
+                                        )
+                                      }
+                                      className="rounded border px-2 py-1"
+                                    />
+                                  </label>
+                                  <label className="flex flex-col gap-1">
+                                    <span>Width%</span>
+                                    <input
+                                      type="number"
+                                      value={frame.w}
+                                      onChange={(e) =>
+                                        updateFrameField(
+                                          selectedBlock.id,
+                                          "w",
+                                          parseFloat(e.target.value),
+                                        )
+                                      }
+                                      className="rounded border px-2 py-1"
+                                    />
+                                  </label>
+                                  <label className="flex flex-col gap-1">
+                                    <span>Height%</span>
+                                    <input
+                                      type="number"
+                                      value={frame.h}
+                                      onChange={(e) =>
+                                        updateFrameField(
+                                          selectedBlock.id,
+                                          "h",
+                                          parseFloat(e.target.value),
+                                        )
+                                      }
+                                      className="rounded border px-2 py-1"
+                                    />
+                                  </label>
+                                  <label className="flex flex-col gap-1">
+                                    <span>Rotation°</span>
+                                    <input
+                                      type="number"
+                                      value={frame.r}
+                                      onChange={(e) =>
+                                        updateFrameField(
+                                          selectedBlock.id,
+                                          "r",
+                                          parseFloat(e.target.value),
+                                        )
+                                      }
+                                      className="rounded border px-2 py-1"
+                                    />
+                                  </label>
+                                </>
+                              )}
+                            </div>
                           </div>
                         </div>
-                      </div>
-                    )}
-                  </section>
+                      )}
+                    </section>
+                  </div>
                 </div>
-              </aside>
-            )}
+              )}
+            </div>
           </div>
         </div>
       </div>
@@ -1042,5 +1315,4 @@ export default function SlideModal({ slide, initialCfg, onSave, onClose }: Slide
   );
 }
 
-export type { SlideCfg } from './SlidesManager';
-
+export type { SlideCfg } from "./SlidesManager";


### PR DESCRIPTION
## Summary
- hide the block drawer and inspector by default and highlight toggle buttons in the Slide modal header
- wrap the preview in a centered container and relocate the blocks drawer to the left with the inspector in a bottom drawer
- preserve all inspector controls while updating the layout classes to match the new structure

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c84ef88e508325a43144d0f85a1157