### PR TITLE
feat(slides): add review quotes and visibility controls

### DIFF
--- a/components/SlideModal.tsx
+++ b/components/SlideModal.tsx
@@ -27,6 +27,8 @@ import SlidesManager, {
   type QuoteBlockConfig,
   type BlockHoverTransition,
   type BlockTransitionConfig,
+  DEFAULT_BLOCK_VISIBILITY,
+  type BlockVisibilityConfig,
   type DeviceKind,
   type Frame,
   type SlideBackground,
@@ -37,6 +39,7 @@ import SlidesManager, {
   resolveImageConfig,
   resolveGalleryConfig,
   resolveQuoteConfig,
+  resolveBlockVisibility,
   resolveBlockAnimationConfig,
   resolveBlockTransitionConfig,
   DEFAULT_BLOCK_ANIMATION_CONFIG,
@@ -159,6 +162,30 @@ const QUOTE_STYLE_OPTIONS: { value: QuoteBlockConfig["style"]; label: string }[]
   { value: "emphasis", label: "Emphasis" },
   { value: "card", label: "Card" },
 ];
+
+type ReviewOption = {
+  id: string;
+  author: string;
+  text: string;
+};
+
+const DEFAULT_REVIEW_OPTIONS: ReviewOption[] = [
+  { id: "mock-1", author: "Jasmine", text: "🔥 The best burger I've had in years!" },
+  { id: "mock-2", author: "Luke", text: "Quick delivery and amazing fries." },
+  { id: "mock-3", author: "Aminah", text: "So good I came back the next day." },
+  { id: "mock-4", author: "Ben", text: "Perfect hangover cure!" },
+];
+
+const DEVICE_VISIBILITY_CONTROLS: { key: keyof BlockVisibilityConfig; label: string }[] = [
+  { key: "mobile", label: "Show on Mobile" },
+  { key: "tablet", label: "Show on Tablet" },
+  { key: "desktop", label: "Show on Desktop" },
+];
+
+const formatReviewOptionLabel = (option: ReviewOption) => {
+  const snippet = option.text.length > 60 ? `${option.text.slice(0, 57)}…` : option.text;
+  return `${option.author} — ${snippet}`;
+};
 
 const SIZE_TO_FONT_SIZE_PX: Record<NonNullable<SlideBlock["size"]>, number> = {
   sm: 18,
@@ -749,6 +776,8 @@ function mergeInteractionConfig(
 ): Record<string, any> {
   const base = { ...(candidate ?? {}) };
   const syntheticBlock: SlideBlock = { ...block, config: base };
+  const visibility = resolveBlockVisibility(syntheticBlock);
+  base.visibleOn = { ...visibility } satisfies BlockVisibilityConfig;
   const animation = resolveBlockAnimationConfig(syntheticBlock);
   const transition = resolveBlockTransitionConfig(syntheticBlock);
   base.animation = {
@@ -1132,6 +1161,7 @@ export default function SlideModal({
   const videoPosterInputRef = useRef<HTMLInputElement | null>(null);
   const isManipulatingRef = useRef(false);
   const selectedIdRef = useRef<string | null>(null);
+  const reviewOptions = DEFAULT_REVIEW_OPTIONS;
 
   useEffect(() => {
     setCfg(normalizeConfig(initialCfg ?? {}, slide));
@@ -1574,6 +1604,35 @@ export default function SlideModal({
     );
   };
 
+  const updateVisibilityConfig = (
+    id: string,
+    mutator: (prev: BlockVisibilityConfig) => BlockVisibilityConfig,
+    commit = true,
+  ) => {
+    updateCfg(
+      (prev) => ({
+        ...prev,
+        blocks: prev.blocks.map((b) => {
+          if (b.id !== id) return b;
+          const current = resolveBlockVisibility(b);
+          const next = mutator({ ...current });
+          const normalized: BlockVisibilityConfig = {
+            mobile: next.mobile,
+            tablet: next.tablet,
+            desktop: next.desktop,
+          };
+          const previous = extractConfig(b.config);
+          const candidate = { ...previous, visibleOn: normalized };
+          return {
+            ...b,
+            config: mergeInteractionConfig({ ...b, config: candidate }, candidate),
+          };
+        }),
+      }),
+      commit,
+    );
+  };
+
   const updateFrameField = (id: string, field: keyof Frame, value: number) => {
     updateCfg((prev) => ({
       ...prev,
@@ -1819,6 +1878,13 @@ export default function SlideModal({
         : null,
     [selectedBlock],
   );
+
+  const selectedVisibilityConfig = useMemo(() => {
+    if (!selectedBlock) {
+      return { ...DEFAULT_BLOCK_VISIBILITY };
+    }
+    return resolveBlockVisibility(selectedBlock);
+  }, [selectedBlock]);
 
   const selectedAnimationConfig = useMemo(
     () =>
@@ -4262,6 +4328,59 @@ export default function SlideModal({
                             )}
                           {selectedBlock.kind === "quote" && selectedQuoteConfig && (
                             <div className="space-y-4">
+                              <div className="space-y-2">
+                                <label className="flex items-center justify-between text-xs text-neutral-500">
+                                  <span>Use customer review</span>
+                                  <input
+                                    type="checkbox"
+                                    checked={selectedQuoteConfig.useReview}
+                                    onChange={(e) =>
+                                      updateQuoteConfig(selectedBlock.id, (config) => ({
+                                        ...config,
+                                        useReview: e.target.checked,
+                                        reviewId: e.target.checked ? config.reviewId : null,
+                                      }))
+                                    }
+                                  />
+                                </label>
+                                {selectedQuoteConfig.useReview && (
+                                  reviewOptions.length > 0 ? (
+                                    <label className="block">
+                                      <span className="text-xs font-medium text-neutral-500">
+                                        Select review
+                                      </span>
+                                      <select
+                                        value={selectedQuoteConfig.reviewId ?? ""}
+                                        onChange={(e) => {
+                                          const nextId = e.target.value;
+                                          const review = reviewOptions.find(
+                                            (option) => option.id === nextId,
+                                          );
+                                          updateQuoteConfig(selectedBlock.id, (config) => ({
+                                            ...config,
+                                            useReview: true,
+                                            reviewId: nextId.length > 0 ? nextId : null,
+                                            text: review ? review.text : config.text,
+                                            author: review ? review.author : config.author,
+                                          }));
+                                        }}
+                                        className={INSPECTOR_INPUT_CLASS}
+                                      >
+                                        <option value="">Choose a review…</option>
+                                        {reviewOptions.map((option) => (
+                                          <option key={option.id} value={option.id}>
+                                            {formatReviewOptionLabel(option)}
+                                          </option>
+                                        ))}
+                                      </select>
+                                    </label>
+                                  ) : (
+                                    <p className="text-xs text-neutral-500">
+                                      No reviews available.
+                                    </p>
+                                  )
+                                )}
+                              </div>
                               <label className="block">
                                 <span className="text-xs font-medium text-neutral-500">
                                   Quote text
@@ -4534,6 +4653,29 @@ export default function SlideModal({
                               </div>
                             </div>
                           )}
+                          <div className="rounded border px-3 py-3 space-y-3">
+                            <h4 className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+                              Visibility
+                            </h4>
+                            {DEVICE_VISIBILITY_CONTROLS.map(({ key, label }) => (
+                              <label
+                                key={key}
+                                className="flex items-center justify-between text-xs text-neutral-500"
+                              >
+                                <span>{label}</span>
+                                <input
+                                  type="checkbox"
+                                  checked={selectedVisibilityConfig[key]}
+                                  onChange={(e) =>
+                                    updateVisibilityConfig(selectedBlock.id, (config) => ({
+                                      ...config,
+                                      [key]: e.target.checked,
+                                    }))
+                                  }
+                                />
+                              </label>
+                            ))}
+                          </div>
                           <div className="rounded border px-3 py-3 space-y-3">
                             <h4 className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
                               Appearance

--- a/components/SlidesManager.tsx
+++ b/components/SlidesManager.tsx
@@ -1385,12 +1385,24 @@ export default function SlidesManager({
           authorStyle.lineHeight = lineHeightValue;
         }
         const trimmedAuthor = quote.author.trim();
+        const showReviewRating = quote.useReview && Boolean(quote.reviewId);
+        const ratingClasses = ['text-base', 'opacity-90'];
+        ratingClasses.push(trimmedAuthor.length > 0 ? 'mt-1' : 'mt-3');
+        const ratingStyle: CSSProperties = {};
+        if (resolvedFontFamily) {
+          ratingStyle.fontFamily = resolvedFontFamily;
+        }
         return (
           <div style={wrapperStyle}>
             <div className={innerClasses.join(' ')} style={innerStyle}>
               <p className={textClasses.join(' ')} style={textStyle}>“{quote.text}”</p>
               {trimmedAuthor.length > 0 ? (
                 <p className={authorClasses.join(' ')} style={authorStyle}>— {trimmedAuthor}</p>
+              ) : null}
+              {showReviewRating ? (
+                <p className={ratingClasses.join(' ')} style={ratingStyle} aria-label="Five star review">
+                  {'⭐️⭐️⭐️⭐️⭐️'}
+                </p>
               ) : null}
             </div>
           </div>

--- a/components/SlidesSection.tsx
+++ b/components/SlidesSection.tsx
@@ -9,6 +9,7 @@ import {
   type BlockBackground,
   type BlockBackgroundGradientDirection,
   type BlockShadowPreset,
+  resolveBlockVisibility,
 } from './SlidesManager';
 import type { SlideRow } from '@/components/customer/home/SlidesContainer';
 
@@ -285,6 +286,10 @@ export default function SlidesSection({ slide, cfg }: { slide: SlideRow; cfg: Sl
         <Background cfg={cfg} />
         <div className="relative h-full w-full" style={{ pointerEvents: 'none' }}>
           {blocks.map((block) => {
+            const visibility = resolveBlockVisibility(block);
+            if (!visibility[device]) {
+              return null;
+            }
             const frame = pickFrame(block, device);
             const style: CSSProperties = {
               position: 'absolute',

--- a/components/SlidesSection.tsx
+++ b/components/SlidesSection.tsx
@@ -9,6 +9,7 @@ import {
   type BlockBackground,
   type BlockBackgroundGradientDirection,
   type BlockShadowPreset,
+  resolveQuoteConfig,
   resolveBlockVisibility,
 } from './SlidesManager';
 import type { SlideRow } from '@/components/customer/home/SlidesContainer';
@@ -104,12 +105,24 @@ function renderBlock(block: SlideBlock) {
         />
       );
     case 'quote':
-      return (
-        <blockquote className="text-white">
-          <p className="text-lg italic">“{block.text}”</p>
-          {block.author && <cite className="mt-2 block text-sm">— {block.author}</cite>}
-        </blockquote>
-      );
+      {
+        const quote = resolveQuoteConfig(block);
+        const trimmedAuthor = quote.author.trim();
+        const showReviewRating = quote.useReview && Boolean(quote.reviewId);
+        return (
+          <blockquote className="text-white" style={{ textAlign: quote.align }}>
+            <p className="text-lg italic">“{quote.text}”</p>
+            {trimmedAuthor.length > 0 ? (
+              <cite className="mt-2 block text-sm">— {trimmedAuthor}</cite>
+            ) : null}
+            {showReviewRating ? (
+              <p className={`text-base opacity-90 ${trimmedAuthor.length > 0 ? 'mt-1' : 'mt-3'}`} aria-label="Five star review">
+                {'⭐️⭐️⭐️⭐️⭐️'}
+              </p>
+            ) : null}
+          </blockquote>
+        );
+      }
     case 'gallery':
       return (
         <div className="flex h-full w-full gap-2 overflow-hidden rounded-xl">


### PR DESCRIPTION
## Summary
- enable quote blocks to pull from selectable mock customer reviews while persisting useReview and reviewId metadata
- add per-device visibility configuration with inspector checkboxes and default handling in block config
- honor visibility settings in both the slide editor preview and customer-facing slides

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd12946e188325b302f4181d1802fb