### PR TITLE
fix: normalize inspector sliders

### DIFF
--- a/components/SlideModal.tsx
+++ b/components/SlideModal.tsx
@@ -2609,48 +2609,60 @@ export default function SlideModal({
                             ]}
                           />
                           <div className="grid grid-cols-2 gap-2 text-xs">
-                            <label className="block font-medium text-neutral-500">
-                              Focal X
-                              <InputNumber
-                                
-                                min={0}
-                                max={1}
-                                step={0.01}
-                                value={imageBackground?.focal?.x ?? 0.5}
-                                onChange={(e) =>
-                                  updateBackground((prev) => {
-                                    if (prev?.type !== "image") return prev;
-                                    const nextFocal = {
-                                      ...(prev.focal || { x: 0.5, y: 0.5 }),
-                                      x: clamp01(Number(e.target.value)),
-                                    };
-                                    return { ...prev, focal: nextFocal };
-                                  })
-                                }
-                                className={INSPECTOR_INPUT_CLASS}
-                              />
-                            </label>
-                            <label className="block font-medium text-neutral-500">
-                              Focal Y
-                              <InputNumber
-                                
-                                min={0}
-                                max={1}
-                                step={0.01}
-                                value={imageBackground?.focal?.y ?? 0.5}
-                                onChange={(e) =>
-                                  updateBackground((prev) => {
-                                    if (prev?.type !== "image") return prev;
-                                    const nextFocal = {
-                                      ...(prev.focal || { x: 0.5, y: 0.5 }),
-                                      y: clamp01(Number(e.target.value)),
-                                    };
-                                    return { ...prev, focal: nextFocal };
-                                  })
-                                }
-                                className={INSPECTOR_INPUT_CLASS}
-                              />
-                            </label>
+                            <InputSlider
+                              label="Focal X"
+                              labelClassName="text-neutral-500"
+                              min={0}
+                              max={1}
+                              step={0.01}
+                              value={imageBackground?.focal?.x}
+                              fallbackValue={0.5}
+                              onValueChange={(next) =>
+                                updateBackground((prev) => {
+                                  if (prev?.type !== "image") return prev;
+                                  const resolved =
+                                    typeof next === "number" && Number.isFinite(next)
+                                      ? clamp01(next)
+                                      : 0.5;
+                                  const nextFocal = {
+                                    ...(prev.focal || { x: 0.5, y: 0.5 }),
+                                    x: resolved,
+                                  };
+                                  return { ...prev, focal: nextFocal };
+                                })
+                              }
+                              containerClassName="mt-1 flex items-center gap-2"
+                              sliderClassName="flex-1"
+                              numberInputClassName="w-24 shrink-0 border border-neutral-300 px-2 py-1 text-right text-xs text-neutral-900"
+                              numberInputProps={{ inputMode: "decimal" }}
+                            />
+                            <InputSlider
+                              label="Focal Y"
+                              labelClassName="text-neutral-500"
+                              min={0}
+                              max={1}
+                              step={0.01}
+                              value={imageBackground?.focal?.y}
+                              fallbackValue={0.5}
+                              onValueChange={(next) =>
+                                updateBackground((prev) => {
+                                  if (prev?.type !== "image") return prev;
+                                  const resolved =
+                                    typeof next === "number" && Number.isFinite(next)
+                                      ? clamp01(next)
+                                      : 0.5;
+                                  const nextFocal = {
+                                    ...(prev.focal || { x: 0.5, y: 0.5 }),
+                                    y: resolved,
+                                  };
+                                  return { ...prev, focal: nextFocal };
+                                })
+                              }
+                              containerClassName="mt-1 flex items-center gap-2"
+                              sliderClassName="flex-1"
+                              numberInputClassName="w-24 shrink-0 border border-neutral-300 px-2 py-1 text-right text-xs text-neutral-900"
+                              numberInputProps={{ inputMode: "decimal" }}
+                            />
                           </div>
                           <label className="flex items-center gap-2 text-xs font-medium text-neutral-500">
                             <InputCheckbox
@@ -2896,48 +2908,60 @@ export default function SlideModal({
                             ]}
                           />
                           <div className="grid grid-cols-2 gap-2 text-xs">
-                            <label className="block font-medium text-neutral-500">
-                              Focal X
-                              <InputNumber
-                                
-                                min={0}
-                                max={1}
-                                step={0.01}
-                                value={videoBackground?.focal?.x ?? 0.5}
-                                onChange={(e) =>
-                                  updateBackground((prev) => {
-                                    if (prev?.type !== "video") return prev;
-                                    const nextFocal = {
-                                      ...(prev.focal || { x: 0.5, y: 0.5 }),
-                                      x: clamp01(Number(e.target.value)),
-                                    };
-                                    return { ...prev, focal: nextFocal };
-                                  })
-                                }
-                                className={INSPECTOR_INPUT_CLASS}
-                              />
-                            </label>
-                            <label className="block font-medium text-neutral-500">
-                              Focal Y
-                              <InputNumber
-                                
-                                min={0}
-                                max={1}
-                                step={0.01}
-                                value={videoBackground?.focal?.y ?? 0.5}
-                                onChange={(e) =>
-                                  updateBackground((prev) => {
-                                    if (prev?.type !== "video") return prev;
-                                    const nextFocal = {
-                                      ...(prev.focal || { x: 0.5, y: 0.5 }),
-                                      y: clamp01(Number(e.target.value)),
-                                    };
-                                    return { ...prev, focal: nextFocal };
-                                  })
-                                }
-                                className={INSPECTOR_INPUT_CLASS}
-                              />
-                            </label>
+                            <InputSlider
+                              label="Focal X"
+                              labelClassName="text-neutral-500"
+                              min={0}
+                              max={1}
+                              step={0.01}
+                              value={videoBackground?.focal?.x}
+                              fallbackValue={0.5}
+                              onValueChange={(next) =>
+                                updateBackground((prev) => {
+                                  if (prev?.type !== "video") return prev;
+                                  const resolved =
+                                    typeof next === "number" && Number.isFinite(next)
+                                      ? clamp01(next)
+                                      : 0.5;
+                                  const nextFocal = {
+                                    ...(prev.focal || { x: 0.5, y: 0.5 }),
+                                    x: resolved,
+                                  };
+                                  return { ...prev, focal: nextFocal };
+                                })
+                              }
+                              containerClassName="mt-1 flex items-center gap-2"
+                              sliderClassName="flex-1"
+                              numberInputClassName="w-24 shrink-0 border border-neutral-300 px-2 py-1 text-right text-xs text-neutral-900"
+                              numberInputProps={{ inputMode: "decimal" }}
+                            />
+                            <InputSlider
+                              label="Focal Y"
+                              labelClassName="text-neutral-500"
+                              min={0}
+                              max={1}
+                              step={0.01}
+                              value={videoBackground?.focal?.y}
+                              fallbackValue={0.5}
+                              onValueChange={(next) =>
+                                updateBackground((prev) => {
+                                  if (prev?.type !== "video") return prev;
+                                  const resolved =
+                                    typeof next === "number" && Number.isFinite(next)
+                                      ? clamp01(next)
+                                      : 0.5;
+                                  const nextFocal = {
+                                    ...(prev.focal || { x: 0.5, y: 0.5 }),
+                                    y: resolved,
+                                  };
+                                  return { ...prev, focal: nextFocal };
+                                })
+                              }
+                              containerClassName="mt-1 flex items-center gap-2"
+                              sliderClassName="flex-1"
+                              numberInputClassName="w-24 shrink-0 border border-neutral-300 px-2 py-1 text-right text-xs text-neutral-900"
+                              numberInputProps={{ inputMode: "decimal" }}
+                            />
                           </div>
                           <div className="flex flex-wrap gap-3 text-xs font-medium text-neutral-500">
                             <label className="flex items-center gap-2">
@@ -4039,7 +4063,9 @@ export default function SlideModal({
                               <InspectorSliderControl
                                 label="Corner radius (px)"
                                 value={selectedButtonConfig.radius}
-                                fallbackValue={selectedButtonConfig.radius}
+                                fallbackValue={
+                                  selectedButtonConfig.radius ?? DEFAULT_BUTTON_CONFIG.radius
+                                }
                                 min={0}
                                 max={100}
                                 step={1}
@@ -4240,7 +4266,9 @@ export default function SlideModal({
                                 <InspectorSliderControl
                                   label="Corner radius (px)"
                                   value={selectedImageConfig.radius}
-                                  fallbackValue={selectedImageConfig.radius}
+                                  fallbackValue={
+                                    selectedImageConfig.radius ?? DEFAULT_IMAGE_CONFIG.radius
+                                  }
                                   min={0}
                                   max={100}
                                   step={1}
@@ -4541,7 +4569,9 @@ export default function SlideModal({
                                   <InspectorSliderControl
                                     label="Corner radius (px)"
                                     value={selectedGalleryConfig.radius}
-                                    fallbackValue={selectedGalleryConfig.radius}
+                                    fallbackValue={
+                                      selectedGalleryConfig.radius ?? DEFAULT_GALLERY_CONFIG.radius
+                                    }
                                     min={0}
                                     max={100}
                                     step={1}
@@ -4802,14 +4832,16 @@ export default function SlideModal({
                                   <InspectorSliderControl
                                     label="Background opacity"
                                     value={selectedQuoteConfig.bgOpacity}
-                                    fallbackValue={selectedQuoteConfig.bgOpacity}
+                                    fallbackValue={
+                                      selectedQuoteConfig.bgOpacity ?? DEFAULT_QUOTE_CONFIG.bgOpacity
+                                    }
                                     min={0}
                                     max={1}
                                     step={0.01}
                                     onChange={(next) => {
                                       const resolved =
                                         next === undefined || Number.isNaN(next)
-                                          ? selectedQuoteConfig.bgOpacity
+                                          ? selectedQuoteConfig.bgOpacity ?? DEFAULT_QUOTE_CONFIG.bgOpacity
                                           : clamp01(next);
                                       updateQuoteConfig(selectedBlock.id, (config) => ({
                                         ...config,
@@ -4820,14 +4852,16 @@ export default function SlideModal({
                                   <InspectorSliderControl
                                     label="Corner radius (px)"
                                     value={selectedQuoteConfig.radius}
-                                    fallbackValue={selectedQuoteConfig.radius}
+                                    fallbackValue={
+                                      selectedQuoteConfig.radius ?? DEFAULT_QUOTE_CONFIG.radius
+                                    }
                                     min={0}
                                     max={100}
                                     step={1}
                                     onChange={(next) => {
                                       const resolved =
                                         next === undefined || Number.isNaN(next)
-                                          ? selectedQuoteConfig.radius
+                                          ? selectedQuoteConfig.radius ?? DEFAULT_QUOTE_CONFIG.radius
                                           : Math.round(next);
                                       updateQuoteConfig(selectedBlock.id, (config) => ({
                                         ...config,
@@ -4838,14 +4872,16 @@ export default function SlideModal({
                                   <InspectorSliderControl
                                     label="Padding (px)"
                                     value={selectedQuoteConfig.padding}
-                                    fallbackValue={selectedQuoteConfig.padding}
+                                    fallbackValue={
+                                      selectedQuoteConfig.padding ?? DEFAULT_QUOTE_CONFIG.padding
+                                    }
                                     min={0}
                                     max={100}
                                     step={1}
                                     onChange={(next) => {
                                       const resolved =
                                         next === undefined || Number.isNaN(next)
-                                          ? selectedQuoteConfig.padding
+                                          ? selectedQuoteConfig.padding ?? DEFAULT_QUOTE_CONFIG.padding
                                           : Math.round(next);
                                       updateQuoteConfig(selectedBlock.id, (config) => ({
                                         ...config,

--- a/components/SlideModal.tsx
+++ b/components/SlideModal.tsx
@@ -443,20 +443,21 @@ const InspectorColorInput: React.FC<InspectorColorInputProps> = ({
         disabled={disabled}
       />
       {allowAlpha && (
-        <div className="flex items-center gap-2">
-          <InputSlider
-            min={0}
-            max={100}
-            step={1}
-            value={Math.round(parsed.alpha * 100)}
-            onChange={(event) => handleAlphaChange(Number(event.target.value))}
-            disabled={disabled}
-            className="flex-1"
-          />
-          <span className="w-10 text-right text-xs text-neutral-500">
-            {Math.round(parsed.alpha * 100)}%
-          </span>
-        </div>
+        <InputSlider
+          min={0}
+          max={100}
+          step={1}
+          value={Math.round(parsed.alpha * 100)}
+          fallbackValue={100}
+          onValueChange={(next) =>
+            handleAlphaChange(typeof next === "number" ? next : 0)
+          }
+          disabled={disabled}
+          containerClassName="mt-0 flex flex-1 items-center gap-2"
+          sliderClassName="flex-1"
+          numberInputClassName="w-16 shrink-0 text-right text-xs"
+          numberInputProps={{ inputMode: "numeric" }}
+        />
       )}
     </div>
   );
@@ -490,104 +491,32 @@ const InspectorSliderControl: React.FC<InspectorSliderControlProps> = ({
   disabled = false,
   numberInputClassName,
 }) => {
-  const formatDisplay = useCallback(
-    (current: number | undefined): string => {
-      if (formatValue) {
-        return formatValue(current, fallbackValue);
-      }
-      const base =
-        current !== undefined
-          ? current
-          : fallbackValue !== undefined
-            ? fallbackValue
-            : undefined;
-      if (base === undefined || Number.isNaN(base)) {
-        return "";
-      }
-      return `${base}`;
-    },
-    [fallbackValue, formatValue],
-  );
-
-  const [inputValue, setInputValue] = useState<string>(() =>
-    formatDisplay(value),
-  );
-
-  useEffect(() => {
-    setInputValue(formatDisplay(value));
-  }, [formatDisplay, value]);
-
-  const sliderValue = useMemo(() => {
-    const base =
-      value !== undefined
-        ? value
-        : fallbackValue !== undefined
-          ? fallbackValue
-          : min;
-    if (Number.isNaN(base)) {
-      return min;
-    }
-    return clampRange(base, min, max);
-  }, [fallbackValue, max, min, value]);
-
-  const handleSliderChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const raw = Number(event.target.value);
-      const clamped = clampRange(raw, min, max);
-      setInputValue(formatDisplay(clamped));
-      onChange(clamped);
-    },
-    [formatDisplay, max, min, onChange],
-  );
-
-  const handleNumberChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const raw = event.target.value;
-      setInputValue(raw);
-      if (raw.trim().length === 0) {
+  const handleValueChange = useCallback(
+    (next: number | undefined) => {
+      if (Number.isNaN(next as number)) {
         onChange(undefined);
         return;
       }
-      const parsed = Number(raw);
-      if (Number.isNaN(parsed)) {
-        return;
-      }
-      const clamped = clampRange(parsed, min, max);
-      onChange(clamped);
-      if (clamped !== parsed) {
-        setInputValue(formatDisplay(clamped));
-      }
+      onChange(next);
     },
-    [formatDisplay, max, min, onChange],
+    [onChange],
   );
 
   return (
-    <label className="block text-xs font-medium text-neutral-500">
-      <span>{label}</span>
-      <div className="mt-2 flex items-center gap-3">
-        <InputSlider
-
-          min={min}
-          max={max}
-          step={step}
-          value={sliderValue}
-          onChange={handleSliderChange}
-          disabled={disabled}
-          className="flex-1"
-        />
-        <InputNumber
-          min={min}
-          max={max}
-          step={step}
-          value={inputValue}
-          onChange={handleNumberChange}
-          disabled={disabled}
-          className={`${INSPECTOR_INPUT_CLASS} w-20 shrink-0 text-right ${
-            numberInputClassName ?? ""
-          }`}
-        />
-      </div>
-    </label>
+    <InputSlider
+      label={<span>{label}</span>}
+      labelClassName="text-neutral-500"
+      min={min}
+      max={max}
+      step={step}
+      value={value}
+      fallbackValue={fallbackValue ?? min}
+      formatValue={formatValue}
+      onValueChange={handleValueChange}
+      disabled={disabled}
+      sliderClassName="flex-1"
+      numberInputClassName={`${INSPECTOR_INPUT_CLASS} ${numberInputClassName ?? ""}`}
+    />
   );
 };
 
@@ -4260,19 +4189,24 @@ export default function SlideModal({
                                         <span>{selectedImageConfig.focalX.toFixed(2)}</span>
                                       </div>
                                       <InputSlider
-                                        
                                         min={0}
                                         max={1}
                                         step={0.01}
                                         value={selectedImageConfig.focalX}
-                                        onChange={(e) => {
-                                          const value = Number(e.target.value);
+                                        fallbackValue={DEFAULT_IMAGE_CONFIG.focalX}
+                                        onValueChange={(next) => {
+                                          const value =
+                                            typeof next === "number"
+                                              ? next
+                                              : DEFAULT_IMAGE_CONFIG.focalX;
                                           updateImageConfig(selectedBlock.id, (config) => ({
                                             ...config,
                                             focalX: value,
                                           }));
                                         }}
-                                        className="mt-1 w-full"
+                                        containerClassName="mt-1"
+                                        className="w-full"
+                                        numberInputClassName="w-24 shrink-0 text-right text-xs"
                                       />
                                     </label>
                                     <label className="block text-xs text-neutral-500">
@@ -4281,19 +4215,24 @@ export default function SlideModal({
                                         <span>{selectedImageConfig.focalY.toFixed(2)}</span>
                                       </div>
                                       <InputSlider
-                                        
                                         min={0}
                                         max={1}
                                         step={0.01}
                                         value={selectedImageConfig.focalY}
-                                        onChange={(e) => {
-                                          const value = Number(e.target.value);
+                                        fallbackValue={DEFAULT_IMAGE_CONFIG.focalY}
+                                        onValueChange={(next) => {
+                                          const value =
+                                            typeof next === "number"
+                                              ? next
+                                              : DEFAULT_IMAGE_CONFIG.focalY;
                                           updateImageConfig(selectedBlock.id, (config) => ({
                                             ...config,
                                             focalY: value,
                                           }));
                                         }}
-                                        className="mt-1 w-full"
+                                        containerClassName="mt-1"
+                                        className="w-full"
+                                        numberInputClassName="w-24 shrink-0 text-right text-xs"
                                       />
                                     </label>
                                   </div>

--- a/components/ui/InputSlider.tsx
+++ b/components/ui/InputSlider.tsx
@@ -1,27 +1,176 @@
-import React from "react";
-import {
-  mergeClassNames,
-  wrapWithLabel,
-} from "./inputShared";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { InputNumber } from "./InputNumber";
+import { INPUT_BASE_CLASS, mergeClassNames, wrapWithLabel } from "./inputShared";
 
 export interface InputSliderProps
-  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "type"> {
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "type" | "value" | "defaultValue" | "onChange"> {
   label?: React.ReactNode;
   labelClassName?: string;
+  containerClassName?: string;
+  sliderClassName?: string;
+  numberInputClassName?: string;
+  /**
+   * The value to display in both the slider and number input. When undefined,
+   * the slider falls back to `fallbackValue` (or the provided `min`/`0`).
+   */
+  value?: number;
+  /**
+   * Fallback value to use when `value` is undefined.
+   */
+  fallbackValue?: number;
+  /**
+   * Optional formatter for the number input display value.
+   */
+  formatValue?: (
+    value: number | undefined,
+    fallbackValue?: number,
+  ) => string;
+  /**
+   * Invoked whenever the slider or number input produce a new value.
+   */
+  onValueChange?: (value: number | undefined) => void;
+  /**
+   * Additional props for the number input element.
+   */
+  numberInputProps?: Omit<React.InputHTMLAttributes<HTMLInputElement>, "type" | "value" | "defaultValue" | "onChange">;
 }
 
 const SLIDER_BASE_CLASS =
   "w-full h-2 cursor-pointer appearance-none rounded-full bg-neutral-200 accent-emerald-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-60 [&::-webkit-slider-runnable-track]:h-2 [&::-webkit-slider-runnable-track]:rounded-full [&::-webkit-slider-runnable-track]:bg-neutral-200 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-emerald-500 [&::-webkit-slider-thumb]:shadow [&::-webkit-slider-thumb]:border-0 [&::-moz-range-track]:h-2 [&::-moz-range-track]:rounded-full [&::-moz-range-track]:bg-neutral-200 [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-emerald-500 [&::-moz-range-thumb]:border-0 [&::-moz-range-progress]:bg-emerald-500";
 
+const NUMBER_BASE_CLASS = mergeClassNames(INPUT_BASE_CLASS, "w-20 shrink-0 text-right");
+
+const clamp = (value: number, min: number, max: number): number => {
+  if (Number.isNaN(value)) return min;
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+};
+
 export const InputSlider = React.forwardRef<HTMLInputElement, InputSliderProps>(
-  ({ label, labelClassName, className, ...props }, ref) => {
+  (
+    {
+      label,
+      labelClassName,
+      containerClassName,
+      sliderClassName,
+      numberInputClassName,
+      value,
+      fallbackValue,
+      formatValue,
+      onValueChange,
+      numberInputProps,
+      min: rawMin = 0,
+      max: rawMax = 100,
+      step = 1,
+      disabled = false,
+      className,
+      ...sliderProps
+    },
+    ref,
+  ) => {
+    const min = Number.isFinite(rawMin) ? Number(rawMin) : 0;
+    const max = Number.isFinite(rawMax) ? Number(rawMax) : min + 100;
+
+    const resolveFallback = useCallback((): number => {
+      if (typeof fallbackValue === "number" && Number.isFinite(fallbackValue)) {
+        return clamp(fallbackValue, min, max);
+      }
+      if (typeof value === "number" && Number.isFinite(value)) {
+        return clamp(value, min, max);
+      }
+      if (Number.isFinite(min)) return min;
+      return 0;
+    }, [fallbackValue, max, min, value]);
+
+    const formatDisplay = useCallback(
+      (current: number | undefined): string => {
+        if (formatValue) {
+          return formatValue(current, fallbackValue);
+        }
+        const base =
+          typeof current === "number" && Number.isFinite(current)
+            ? current
+            : typeof fallbackValue === "number" && Number.isFinite(fallbackValue)
+              ? fallbackValue
+              : undefined;
+        if (base === undefined) {
+          return "";
+        }
+        return `${base}`;
+      },
+      [fallbackValue, formatValue],
+    );
+
+    const sliderValue = useMemo(() => {
+      if (typeof value === "number" && Number.isFinite(value)) {
+        return clamp(value, min, max);
+      }
+      return resolveFallback();
+    }, [max, min, resolveFallback, value]);
+
+    const [inputValue, setInputValue] = useState<string>(() => formatDisplay(value));
+
+    useEffect(() => {
+      setInputValue(formatDisplay(value));
+    }, [formatDisplay, value]);
+
+    const handleSliderChange = useCallback(
+      (event: React.ChangeEvent<HTMLInputElement>) => {
+        const numericValue = Number(event.target.value);
+        const clamped = clamp(numericValue, min, max);
+        setInputValue(formatDisplay(clamped));
+        onValueChange?.(clamped);
+      },
+      [formatDisplay, max, min, onValueChange],
+    );
+
+    const handleNumberChange = useCallback(
+      (event: React.ChangeEvent<HTMLInputElement>) => {
+        const raw = event.target.value;
+        setInputValue(raw);
+        if (raw.trim().length === 0) {
+          onValueChange?.(undefined);
+          return;
+        }
+        const parsed = Number(raw);
+        if (!Number.isFinite(parsed)) {
+          return;
+        }
+        const clamped = clamp(parsed, min, max);
+        onValueChange?.(clamped);
+        if (clamped !== parsed) {
+          setInputValue(formatDisplay(clamped));
+        }
+      },
+      [formatDisplay, max, min, onValueChange],
+    );
+
     const input = (
-      <input
-        {...props}
-        ref={ref}
-        type="range"
-        className={mergeClassNames(SLIDER_BASE_CLASS, className)}
-      />
+      <div className={mergeClassNames("mt-2 flex items-center gap-3", containerClassName)}>
+        <input
+          {...sliderProps}
+          ref={ref}
+          type="range"
+          min={min}
+          max={max}
+          step={step}
+          value={sliderValue}
+          onChange={handleSliderChange}
+          disabled={disabled}
+          className={mergeClassNames(SLIDER_BASE_CLASS, className, sliderClassName)}
+        />
+        <InputNumber
+          {...numberInputProps}
+          min={min}
+          max={max}
+          step={step}
+          value={inputValue}
+          onChange={handleNumberChange}
+          disabled={disabled}
+          className={mergeClassNames(NUMBER_BASE_CLASS, numberInputClassName)}
+        />
+      </div>
     );
 
     return wrapWithLabel(label, input, labelClassName);

--- a/components/ui/InputSlider.tsx
+++ b/components/ui/InputSlider.tsx
@@ -36,11 +36,11 @@ export interface InputSliderProps
 }
 
 const SLIDER_BASE_CLASS =
-  "h-2 w-full flex-1 cursor-pointer appearance-none rounded-full bg-neutral-200 accent-emerald-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-60 [&::-webkit-slider-runnable-track]:h-2 [&::-webkit-slider-runnable-track]:rounded-full [&::-webkit-slider-runnable-track]:bg-neutral-200 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-emerald-500 [&::-webkit-slider-thumb]:shadow [&::-webkit-slider-thumb]:border-0 [&::-moz-range-track]:h-2 [&::-moz-range-track]:rounded-full [&::-moz-range-track]:bg-neutral-200 [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-emerald-500 [&::-moz-range-thumb]:border-0 [&::-moz-range-progress]:bg-emerald-500";
+  "h-2 min-h-[24px] w-full min-w-[120px] flex-1 cursor-pointer appearance-none rounded-full bg-neutral-200 accent-emerald-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-60 [&::-webkit-slider-runnable-track]:h-2 [&::-webkit-slider-runnable-track]:rounded-full [&::-webkit-slider-runnable-track]:bg-neutral-200 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-emerald-500 [&::-webkit-slider-thumb]:shadow [&::-webkit-slider-thumb]:border-0 [&::-moz-range-track]:h-2 [&::-moz-range-track]:rounded-full [&::-moz-range-track]:bg-neutral-200 [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-emerald-500 [&::-moz-range-thumb]:border-0 [&::-moz-range-progress]:bg-emerald-500";
 
 const NUMBER_BASE_CLASS = mergeClassNames(
   INPUT_BASE_CLASS,
-  "w-[60px] shrink-0 text-right",
+  "w-[60px] max-w-[60px] shrink-0 text-right",
 );
 
 const clamp = (value: number, min: number, max: number): number => {
@@ -96,13 +96,10 @@ export const InputSlider = React.forwardRef<HTMLInputElement, InputSliderProps>(
             ? current
             : typeof fallbackValue === "number" && Number.isFinite(fallbackValue)
               ? fallbackValue
-              : undefined;
-        if (base === undefined) {
-          return "";
-        }
+              : resolveFallback();
         return `${base}`;
       },
-      [fallbackValue, formatValue],
+      [fallbackValue, formatValue, resolveFallback],
     );
 
     const sliderValue = useMemo(() => {

--- a/components/ui/InputSlider.tsx
+++ b/components/ui/InputSlider.tsx
@@ -36,9 +36,12 @@ export interface InputSliderProps
 }
 
 const SLIDER_BASE_CLASS =
-  "w-full h-2 cursor-pointer appearance-none rounded-full bg-neutral-200 accent-emerald-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-60 [&::-webkit-slider-runnable-track]:h-2 [&::-webkit-slider-runnable-track]:rounded-full [&::-webkit-slider-runnable-track]:bg-neutral-200 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-emerald-500 [&::-webkit-slider-thumb]:shadow [&::-webkit-slider-thumb]:border-0 [&::-moz-range-track]:h-2 [&::-moz-range-track]:rounded-full [&::-moz-range-track]:bg-neutral-200 [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-emerald-500 [&::-moz-range-thumb]:border-0 [&::-moz-range-progress]:bg-emerald-500";
+  "h-2 w-full flex-1 cursor-pointer appearance-none rounded-full bg-neutral-200 accent-emerald-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-60 [&::-webkit-slider-runnable-track]:h-2 [&::-webkit-slider-runnable-track]:rounded-full [&::-webkit-slider-runnable-track]:bg-neutral-200 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-emerald-500 [&::-webkit-slider-thumb]:shadow [&::-webkit-slider-thumb]:border-0 [&::-moz-range-track]:h-2 [&::-moz-range-track]:rounded-full [&::-moz-range-track]:bg-neutral-200 [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-emerald-500 [&::-moz-range-thumb]:border-0 [&::-moz-range-progress]:bg-emerald-500";
 
-const NUMBER_BASE_CLASS = mergeClassNames(INPUT_BASE_CLASS, "w-20 shrink-0 text-right");
+const NUMBER_BASE_CLASS = mergeClassNames(
+  INPUT_BASE_CLASS,
+  "w-[60px] shrink-0 text-right",
+);
 
 const clamp = (value: number, min: number, max: number): number => {
   if (Number.isNaN(value)) return min;
@@ -147,7 +150,7 @@ export const InputSlider = React.forwardRef<HTMLInputElement, InputSliderProps>(
     );
 
     const input = (
-      <div className={mergeClassNames("mt-2 flex items-center gap-3", containerClassName)}>
+      <div className={mergeClassNames("flex items-center gap-2", containerClassName)}>
         <input
           {...sliderProps}
           ref={ref}


### PR DESCRIPTION
## Summary
- refactor the shared `InputSlider` to render a synchronized slider + numeric input with sensible fallbacks
- update the slide inspector to consume the new slider control for opacity, focal point, and all numeric controls so values never go undefined

## Testing
- CI=1 npm run build *(fails: Next.js export expects prebuilt server pages in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6518671e88325bbacb86d5b971139