### PR TITLE
feat(slide-editor): enhance media inspector controls

### DIFF
--- a/components/blocks/GalleryBlock.tsx
+++ b/components/blocks/GalleryBlock.tsx
@@ -1,0 +1,117 @@
+import React, { useMemo } from "react";
+import { getAspectRatio, type AspectRatio } from "./ImageBlock";
+
+type GalleryItem = { url: string; alt?: string };
+type GalleryLayout = "grid" | "carousel";
+
+type GalleryBlockProps = {
+  items: GalleryItem[];
+  layout?: GalleryLayout;
+  radius?: number;
+  shadow?: boolean;
+  aspectRatio?: AspectRatio;
+  className?: string;
+};
+
+const GalleryImage: React.FC<{ item: GalleryItem; aspectValue?: string }> = ({
+  item,
+  aspectValue,
+}) => {
+  const style: React.CSSProperties = {
+    objectFit: "cover",
+    width: "100%",
+    maxWidth: "100%",
+    maxHeight: "100%",
+    height: aspectValue ? "auto" : "100%",
+  };
+  if (aspectValue) {
+    style.aspectRatio = aspectValue;
+  }
+
+  return <img src={item.url} alt={item.alt || ""} style={style} />;
+};
+
+const GalleryBlock: React.FC<GalleryBlockProps> = ({
+  items,
+  layout = "grid",
+  radius = 0,
+  shadow = false,
+  aspectRatio = "original",
+  className,
+}) => {
+  const aspectValue = useMemo(() => getAspectRatio(aspectRatio), [aspectRatio]);
+
+  const wrapperClasses = ["flex", "h-full", "w-full", "overflow-hidden"];
+  if (shadow) wrapperClasses.push("shadow-lg");
+  if (className) wrapperClasses.push(className);
+
+  const wrapperStyle: React.CSSProperties = { borderRadius: radius };
+
+  if (!items || items.length === 0) {
+    return (
+      <div className={wrapperClasses.join(" ")} style={wrapperStyle}>
+        <div className="flex w-full items-center justify-center text-xs text-neutral-500">
+          No images
+        </div>
+      </div>
+    );
+  }
+
+  if (layout === "carousel") {
+    return (
+      <div className={wrapperClasses.join(" ")} style={wrapperStyle}>
+        <div className="flex h-full w-full snap-x snap-mandatory overflow-x-auto">
+          {items.map((item, index) => (
+            <div
+              key={`${item.url}-${index}`}
+              className="flex h-full w-full flex-none snap-center items-center justify-center"
+              style={{ minWidth: "100%" }}
+            >
+              <div
+                className="flex h-full w-full items-center justify-center overflow-hidden"
+                style={
+                  aspectValue
+                    ? { aspectRatio: aspectValue, height: "auto", width: "100%" }
+                    : undefined
+                }
+              >
+                <GalleryImage item={item} aspectValue={aspectValue} />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  const columns = Math.min(items.length, 3) || 1;
+
+  return (
+    <div className={wrapperClasses.join(" ")} style={wrapperStyle}>
+      <div
+        className="grid h-full w-full gap-2"
+        style={{
+          gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+          gridAutoRows: aspectValue ? "auto" : "1fr",
+        }}
+      >
+        {items.map((item, index) => (
+          <div
+            key={`${item.url}-${index}`}
+            className="flex h-full w-full items-center justify-center overflow-hidden"
+            style={
+              aspectValue
+                ? { aspectRatio: aspectValue, height: "auto", width: "100%" }
+                : undefined
+            }
+          >
+            <GalleryImage item={item} aspectValue={aspectValue} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default GalleryBlock;
+export type { GalleryItem, GalleryBlockProps, GalleryLayout };

--- a/components/blocks/ImageBlock.tsx
+++ b/components/blocks/ImageBlock.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+
+type AspectRatio = "original" | "square" | "4:3" | "16:9";
+
+type ImageBlockProps = {
+  url: string;
+  alt?: string;
+  fit?: "cover" | "contain";
+  focalX?: number;
+  focalY?: number;
+  radius?: number;
+  shadow?: boolean;
+  aspectRatio?: AspectRatio;
+  className?: string;
+};
+
+const ASPECT_RATIO_VALUE: Record<Exclude<AspectRatio, "original">, string> = {
+  square: "1 / 1",
+  "4:3": "4 / 3",
+  "16:9": "16 / 9",
+};
+
+const getAspectRatio = (aspectRatio?: AspectRatio): string | undefined => {
+  if (!aspectRatio || aspectRatio === "original") {
+    return undefined;
+  }
+  return ASPECT_RATIO_VALUE[aspectRatio];
+};
+
+const ImageBlock: React.FC<ImageBlockProps> = ({
+  url,
+  alt = "",
+  fit = "cover",
+  focalX = 0.5,
+  focalY = 0.5,
+  radius = 0,
+  shadow = false,
+  aspectRatio = "original",
+  className,
+}) => {
+  const aspectValue = getAspectRatio(aspectRatio);
+  const wrapperClasses = [
+    "flex",
+    "w-full",
+    "items-center",
+    "justify-center",
+    "overflow-hidden",
+    "rounded",
+  ];
+  if (shadow) wrapperClasses.push("shadow-lg");
+  if (className) wrapperClasses.push(className);
+
+  const wrapperStyle: React.CSSProperties = { borderRadius: radius };
+  if (aspectValue) {
+    wrapperStyle.aspectRatio = aspectValue;
+    wrapperStyle.height = "auto";
+  }
+
+  if (!url) {
+    wrapperClasses.push("bg-neutral-200");
+    return (
+      <div className={wrapperClasses.join(" ")} style={wrapperStyle} aria-hidden>
+        <span className="text-xs text-neutral-500">No image</span>
+      </div>
+    );
+  }
+
+  const imageStyle: React.CSSProperties = {
+    objectFit: fit,
+    objectPosition: `${focalX * 100}% ${focalY * 100}%`,
+    borderRadius: radius,
+    width: "100%",
+    maxWidth: "100%",
+    maxHeight: "100%",
+    height: aspectValue ? "auto" : "100%",
+  };
+  if (aspectValue) {
+    imageStyle.aspectRatio = aspectValue;
+  }
+
+  return (
+    <div className={wrapperClasses.join(" ")} style={wrapperStyle}>
+      <img src={url} alt={alt} style={imageStyle} />
+    </div>
+  );
+};
+
+export default ImageBlock;
+export { getAspectRatio };
+export type { AspectRatio, ImageBlockProps };


### PR DESCRIPTION
## Summary
- add shared aspect ratio handling for image and gallery blocks in the slide manager
- introduce drag-and-drop gallery inspector rows with per-image alt text editing
- add reusable media block components to support consistent aspect ratio rendering

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da628c645c8325adb081d832257df4