### PR TITLE
fix: prevent mobile double tap text focus

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -73,3 +73,10 @@ body {
 .scrollbar-hide::-webkit-scrollbar {
   display: none; /* Chrome, Safari, Opera */
 }
+
+.readonlyText {
+  user-select: none;
+  -webkit-user-select: none;
+  caret-color: transparent;
+  touch-action: manipulation;
+}


### PR DESCRIPTION
## Summary
- open the inspector from mobile double-tap on canvas text without triggering inline focus
- mark non-editing canvas text as read-only to block selection/press-and-hold UX and add supporting styles

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68dff473111483259e48090ebb9e1a71