### PR TITLE
Fix page builder modal scrolling and zoom behavior

### DIFF
--- a/components/PageBuilderModal.tsx
+++ b/components/PageBuilderModal.tsx
@@ -419,6 +419,16 @@ export default function PageBuilderModal({ open, onClose, pageId, restaurantId }
     })();
   }, [open, pageId, restaurantId]);
 
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    if (!open) return;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = previousOverflow || '';
+    };
+  }, [open]);
+
   // undo stack helper
   const pushHistory = useCallback((next: Block[]) => {
     history.current.push(next);
@@ -878,17 +888,105 @@ export default function PageBuilderModal({ open, onClose, pageId, restaurantId }
           opacity: 0.6;
           cursor: not-allowed;
         }
-        .wb-device-toggle {
+        .builder-header {
+          position: relative;
           display: flex;
+          flex-wrap: wrap;
           align-items: center;
           justify-content: center;
-          gap: 6px;
-          margin: 6px 0 8px;
+          gap: 8px;
+          padding: 12px clamp(16px, 4vw, 32px);
+          min-height: 64px;
         }
-        .wb-device-toggle button {
-          height: 28px;
-          padding: 0 10px;
+        .builder-header .device-controls {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          gap: 8px;
+        }
+        .builder-header .zoom-controls {
+          position: absolute;
+          top: 12px;
+          right: clamp(16px, 4vw, 32px);
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+        }
+        .builder-header .zoom-btn {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          width: 32px;
+          height: 32px;
+          border-radius: 9999px;
+          border: 1px solid rgba(15, 23, 42, 0.12);
+          background: var(--surface-1);
+          color: rgba(15, 23, 42, 0.75);
+          cursor: pointer;
+          transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+        }
+        .builder-header .zoom-btn:hover:not(:disabled) {
+          background: var(--surface-hover);
+        }
+        .builder-header .zoom-btn:disabled {
+          opacity: 0.5;
+          cursor: not-allowed;
+        }
+        .builder-header .zoom-readout {
+          min-width: 44px;
+          text-align: center;
           font-size: 12px;
+          font-variant-numeric: tabular-nums;
+          color: rgba(15, 23, 42, 0.7);
+        }
+        .builder-scroll {
+          background: var(--surface-muted, #f1f5f9);
+        }
+        .builder-preview {
+          display: flex;
+          justify-content: center;
+          align-items: flex-start;
+          min-height: calc(100vh - 120px);
+          padding: 40px clamp(16px, 5vw, 64px);
+        }
+        .preview-shell {
+          width: 100%;
+        }
+        .preview-scale {
+          display: flex;
+          justify-content: center;
+        }
+        .preview-inner {
+          width: 100%;
+          max-width: 1280px;
+        }
+        .preview-inner[data-device='tablet'] {
+          max-width: 768px;
+        }
+        .preview-inner[data-device='mobile'] {
+          max-width: 420px;
+        }
+        @media (max-width: 1024px) {
+          .builder-header {
+            min-height: 60px;
+            padding: 12px clamp(12px, 5vw, 24px);
+          }
+          .builder-preview {
+            padding: 32px clamp(12px, 5vw, 40px);
+          }
+        }
+        @media (max-width: 768px) {
+          .builder-header {
+            min-height: 56px;
+          }
+          .builder-header .zoom-controls {
+            top: 10px;
+            right: clamp(12px, 6vw, 20px);
+          }
+          .builder-preview {
+            padding: 24px clamp(12px, 6vw, 24px);
+            min-height: calc(100vh - 120px);
+          }
         }
       `}</style>
     </div>

--- a/components/webpage/WebpageBuilder.tsx
+++ b/components/webpage/WebpageBuilder.tsx
@@ -52,6 +52,8 @@ export default function WebpageBuilder({
     saveDisabled: false,
     saveLabel: 'Save',
   });
+  const pillButtonClasses =
+    'inline-flex items-center justify-center rounded-full px-3 py-1.5 text-sm font-medium transition-colors cursor-pointer';
   const shellStyle = useMemo<React.CSSProperties>(
     () => ({
       background: tokens.colors.canvas,
@@ -66,22 +68,6 @@ export default function WebpageBuilder({
     }),
     [],
   );
-  const deviceToggleStyle = useMemo<React.CSSProperties>(
-    () => ({
-      textTransform: 'capitalize',
-      padding: '0 10px',
-      borderRadius: tokens.radius.lg,
-      borderWidth: tokens.border.thin,
-      borderStyle: 'solid',
-      transition: `color 160ms ${tokens.easing.standard}, background-color 160ms ${tokens.easing.standard}, border-color 160ms ${tokens.easing.standard}`,
-      fontSize: 12,
-      fontWeight: tokens.fontWeight.medium,
-      height: 28,
-      cursor: 'pointer',
-    }),
-    []
-  );
-
   const toolbarButtonBase = useMemo<React.CSSProperties>(
     () => ({
       display: 'inline-flex',
@@ -466,13 +452,11 @@ export default function WebpageBuilder({
                   key={value}
                   type="button"
                   onClick={() => setDevice(value)}
-                  style={{
-                    ...deviceToggleStyle,
-                    borderColor: isActive ? tokens.colors.accent : tokens.colors.borderLight,
-                    background: isActive ? tokens.colors.surfaceSubtle : tokens.colors.surface,
-                    color: isActive ? tokens.colors.accent : tokens.colors.textSecondary,
-                    boxShadow: isActive ? tokens.shadow.sm : 'none',
-                  }}
+                  className={`${pillButtonClasses} capitalize ${
+                    isActive
+                      ? 'bg-primary text-white shadow-sm'
+                      : 'bg-neutral-100 text-neutral-700 hover:bg-neutral-200'
+                  }`}
                 >
                   {value}
                 </button>
@@ -485,11 +469,11 @@ export default function WebpageBuilder({
               onClick={handleZoomOut}
               aria-label="Zoom out"
               disabled={zoomOutDisabled}
-              style={{
-                ...iconButtonStyle,
-                opacity: zoomOutDisabled ? 0.5 : 1,
-                cursor: zoomOutDisabled ? 'not-allowed' : 'pointer',
-              }}
+              className={`${pillButtonClasses} ${
+                zoomOutDisabled
+                  ? 'bg-neutral-100 text-neutral-400 cursor-not-allowed opacity-60'
+                  : 'bg-neutral-100 text-neutral-700 hover:bg-neutral-200'
+              }`}
             >
               <ZoomOut size={16} />
             </button>
@@ -499,11 +483,11 @@ export default function WebpageBuilder({
               onClick={handleZoomIn}
               aria-label="Zoom in"
               disabled={zoomInDisabled}
-              style={{
-                ...iconButtonStyle,
-                opacity: zoomInDisabled ? 0.5 : 1,
-                cursor: zoomInDisabled ? 'not-allowed' : 'pointer',
-              }}
+              className={`${pillButtonClasses} ${
+                zoomInDisabled
+                  ? 'bg-neutral-100 text-neutral-400 cursor-not-allowed opacity-60'
+                  : 'bg-neutral-100 text-neutral-700 hover:bg-neutral-200'
+              }`}
             >
               <ZoomIn size={16} />
             </button>

--- a/components/webpage/WebpageBuilder.tsx
+++ b/components/webpage/WebpageBuilder.tsx
@@ -46,6 +46,7 @@ export default function WebpageBuilder({
       flexDirection: 'column',
       height: '100%',
       minHeight: 0,
+      overflow: 'hidden',
     }),
     [],
   );
@@ -137,6 +138,14 @@ export default function WebpageBuilder({
     setZoom(100);
   }, [device]);
 
+  useEffect(() => {
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = previousOverflow || 'auto';
+    };
+  }, []);
+
   const adjustZoom = (delta: number) => {
     setZoom((previous) => {
       const next = Math.round(previous + delta);
@@ -216,7 +225,7 @@ export default function WebpageBuilder({
   );
 
   return (
-    <div className="builder-modal" style={shellStyle}>
+    <div className="builder-wrapper fixed inset-0 z-50 flex flex-col" style={shellStyle}>
       <div
         className="builder-header"
         style={{
@@ -248,7 +257,18 @@ export default function WebpageBuilder({
             );
           })}
         </div>
-        <div className="zoom-controls">
+        <div
+          className="zoom-controls"
+          style={{
+            position: 'absolute',
+            top: tokens.spacing.sm,
+            right: tokens.spacing.lg,
+            display: 'flex',
+            alignItems: 'center',
+            gap: tokens.spacing.xs,
+            zIndex: 60,
+          }}
+        >
           <button
             type="button"
             onClick={handleZoomOut}
@@ -271,17 +291,21 @@ export default function WebpageBuilder({
         </div>
       </div>
       <div
-        className="builder-scroll"
+        className="builder-scroll flex-1 overflow-y-auto overflow-x-hidden"
         style={{
-          flex: 1,
-          overflowY: 'auto',
-          overflowX: 'hidden',
           background: tokens.colors.canvas,
           minHeight: 0,
         }}
       >
-        <div className="builder-preview">
-          <div className="preview-shell" style={{ width: '100%' }}>
+        <div className="builder-preview flex justify-center py-10">
+          <div
+            className="preview-shell"
+            style={{
+              width: '100%',
+              display: 'flex',
+              justifyContent: 'center',
+            }}
+          >
             <div className="preview-scale" style={previewScaleStyle}>
               {previewContent}
             </div>

--- a/components/webpage/WebpageBuilder.tsx
+++ b/components/webpage/WebpageBuilder.tsx
@@ -225,15 +225,19 @@ export default function WebpageBuilder({
   );
 
   return (
-    <div className="builder-wrapper fixed inset-0 z-50 flex flex-col" style={shellStyle}>
+    <div
+      className="builder-wrapper fixed inset-0 z-50 flex flex-col bg-background"
+      style={shellStyle}
+    >
       <div
-        className="builder-header"
+        className="builder-toolbar sticky top-0 z-50 flex items-center justify-between px-4 py-2 border-b bg-white"
         style={{
           position: 'sticky',
           top: 0,
-          zIndex: 40,
+          zIndex: 60,
           borderBottom: `${tokens.border.thin}px solid ${tokens.colors.borderLight}`,
           background: tokens.colors.surface,
+          minHeight: 52,
         }}
       >
         <div className="device-controls" aria-label="Preview device selector">

--- a/src/styles/webpage-builder.css
+++ b/src/styles/webpage-builder.css
@@ -173,3 +173,53 @@
   align-items:center;
   gap:8px;
 }
+
+.wb-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 60;
+  background: #fff;
+  border-bottom: 1px solid #e5e7eb;
+  backdrop-filter: saturate(1.2) blur(4px);
+}
+
+.wb-toolbar.flex {
+  display: none;
+}
+
+.wb-toolbar-inner {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 8px 12px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 8px;
+}
+
+.wb-left,
+.wb-center,
+.wb-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.wb-left {
+  justify-content: flex-start;
+}
+
+.wb-center {
+  justify-content: center;
+}
+
+.wb-right {
+  justify-content: flex-end;
+}
+
+.wb-zoom-readout {
+  width: 48px;
+  text-align: center;
+  font-size: 12px;
+  color: #4b5563;
+}

--- a/src/styles/webpage-builder.css
+++ b/src/styles/webpage-builder.css
@@ -96,13 +96,12 @@
 }
 
 .builder-toolbar {
-  flex-shrink:0;
-  padding:0.5rem 1rem;
-  display:flex;
-  justify-content:space-between;
-  align-items:center;
-  background:var(--wb-toolbar-bg, #fff);
-  border-bottom:1px solid rgba(0,0,0,0.05);
+  position:sticky;
+  top:0;
+  background:#fff;
+  border-bottom:1px solid #e5e7eb;
+  z-index:60;
+  height:52px;
 }
 
 .builder-canvas-wrapper {

--- a/src/styles/webpage-builder.css
+++ b/src/styles/webpage-builder.css
@@ -138,3 +138,39 @@
 .builder-canvas .add-block-row > * {
   pointer-events:auto;
 }
+
+.builder-wrapper {
+  height:100vh;
+  width:100%;
+  overflow:hidden;
+}
+
+.builder-wrapper .builder-scroll {
+  height:100%;
+  overflow-y:auto;
+  overflow-x:hidden;
+}
+
+.builder-wrapper .builder-preview {
+  display:flex;
+  justify-content:center;
+  align-items:flex-start;
+  min-height:calc(100vh - 100px);
+}
+
+.builder-wrapper .preview-shell {
+  background:#fff;
+  width:100%;
+  display:flex;
+  justify-content:center;
+}
+
+.builder-wrapper .zoom-controls {
+  position:absolute;
+  top:8px;
+  right:12px;
+  z-index:60;
+  display:flex;
+  align-items:center;
+  gap:8px;
+}


### PR DESCRIPTION
## Summary
- disable document scrolling while the page builder modal is open and refresh preview styling so the canvas stays centered
- refactor the webpage builder preview to live in its own scroll container with responsive max widths per device size
- clamp zoom controls between 50%-150%, reset them on device switches, and keep the buttons fixed above the preview

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e94c8289148325b9c9f2ae64a53d11