### PR TITLE
fix(customer-addons): align addon queries with schema

### DIFF
--- a/__tests__/menuBuilderApi.test.ts
+++ b/__tests__/menuBuilderApi.test.ts
@@ -14,7 +14,7 @@ describe('menu builder API', () => {
   }
 
   test('upsert draft then publish', async () => {
-    const supa = supaServer();
+    const supa = supaServer;
     const { data: restaurant } = await supa
       .from('restaurants')
       .insert({ name: 'Test R' })

--- a/components/AddonGroups.tsx
+++ b/components/AddonGroups.tsx
@@ -122,6 +122,18 @@ export default function AddonGroups({
     typeof brand?.brand === 'string' && brand.brand ? brand.brand : '#EB2BB9';
 
   useEffect(() => {
+    if (process.env.NODE_ENV === 'development') {
+      console.debug('[customer:addons] AddonGroups received groups', {
+        groupsCount: addons.length,
+        optionCounts: addons.map((group) => ({
+          groupId: group.group_id ?? group.id,
+          options: Array.isArray(group.addon_options) ? group.addon_options.length : 0,
+        })),
+      });
+    }
+  }, [addons]);
+
+  useEffect(() => {
     if (onChange) {
       onChange(selectedQuantities);
     }
@@ -203,6 +215,16 @@ export default function AddonGroups({
           group?.max_group_select ?? (group as any)?.maxGroupSelect ?? Infinity;
         const max_option_quantity =
           group?.max_option_quantity ?? (group as any)?.maxOptionQuantity ?? Infinity;
+        const options = Array.isArray(group.addon_options)
+          ? group.addon_options
+          : [];
+
+        if (process.env.NODE_ENV === 'development') {
+          console.debug('[customer:addons] rendering group', {
+            groupId: gid,
+            optionCount: options.length,
+          });
+        }
 
         return (
           <div
@@ -231,7 +253,7 @@ export default function AddonGroups({
               </div>
 
               <ScrollRow>
-                {group.addon_options.map((option) => {
+                {options.map((option) => {
                   const gid = group.group_id ?? group.id;
                   const quantity = selectedQuantities[gid]?.[option.id] || 0;
 

--- a/components/AddonsTab.tsx
+++ b/components/AddonsTab.tsx
@@ -36,14 +36,16 @@ export default function AddonsTab({ restaurantId }: { restaurantId: number }) {
   const load = async () => {
     const { data: grp } = await supabase
       .from('addon_groups')
-      .select('*')
+      .select('id,restaurant_id,name,multiple_choice,required,max_group_select,max_option_quantity')
       .eq('restaurant_id', restaurantId)
       .order('id');
     setGroups(grp || []);
     if (grp && grp.length) {
       const { data: opts } = await supabase
         .from('addon_options')
-        .select('*')
+        .select(
+          'id,group_id,name,price,available,out_of_stock_until,stock_status,stock_return_date,stock_last_updated_at'
+        )
         .in('group_id', grp.map((g) => g.id));
       const map: Record<number, any[]> = {};
       const priceMap: Record<number, string> = {};
@@ -165,7 +167,16 @@ export default function AddonsTab({ restaurantId }: { restaurantId: number }) {
       const groupOpts = options[g.id] || [];
       if (groupOpts.length) {
         await supabase.from('addon_options').insert(
-          groupOpts.map((o) => ({ name: o.name, price: o.price, available: o.available, group_id: newGroup.id }))
+          groupOpts.map((o) => ({
+            name: o.name,
+            price: o.price,
+            available: o.available,
+            group_id: newGroup.id,
+            out_of_stock_until: o.out_of_stock_until,
+            stock_status: o.stock_status,
+            stock_return_date: o.stock_return_date,
+            stock_last_updated_at: o.stock_last_updated_at,
+          }))
         );
       }
       load();

--- a/components/MenuItemCard.tsx
+++ b/components/MenuItemCard.tsx
@@ -111,13 +111,19 @@ export default function MenuItemCard({
     setLoading(true);
     try {
       const data = await getAddonsForItem(item.id);
-      setGroups(data);
+      const sanitized = Array.isArray(data) ? data : [];
+      setGroups(sanitized);
       if (process.env.NODE_ENV === 'development') {
-        console.debug('[addons]', {
+        console.debug('[customer:item-modal] fetched add-on groups', {
           itemId: item.id,
-          groupsCount: data?.length,
-          groups: data,
+          groupsCount: sanitized.length,
         });
+        if (!Array.isArray(data)) {
+          console.warn('[customer:item-modal] unexpected add-on payload', {
+            itemId: item.id,
+            receivedType: typeof data,
+          });
+        }
       }
     } catch (err) {
       console.error('Failed to load addons', err);
@@ -134,6 +140,15 @@ export default function MenuItemCard({
 
   const increment = () => setQty((q) => q + 1);
   const decrement = () => setQty((q) => (q > 1 ? q - 1 : 1));
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'development') {
+      console.debug('[customer:item-modal] rendering with add-on groups', {
+        itemId: item.id,
+        groupsCount: groups.length,
+      });
+    }
+  }, [groups, item.id]);
 
   const handleFinalAdd = () => {
     const errors = validateAddonSelections(groups, selections);

--- a/lib/supaServer.ts
+++ b/lib/supaServer.ts
@@ -1,10 +1,12 @@
 import { createClient } from '@supabase/supabase-js';
 
-export function supaServer() {
-  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const service = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (!url || !service)
-    throw new Error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
-  return createClient(url, service, { auth: { persistSession: false } });
+const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !serviceRoleKey) {
+  throw new Error('Missing SUPABASE_URL (or NEXT_PUBLIC_SUPABASE_URL) or SUPABASE_SERVICE_ROLE_KEY');
 }
 
+export const supaServer = createClient(supabaseUrl, serviceRoleKey, {
+  auth: { persistSession: false },
+});

--- a/pages/api/menu-builder.ts
+++ b/pages/api/menu-builder.ts
@@ -42,48 +42,33 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   try {
     if (req.method === 'GET') {
       const table = 'menu_drafts';
-      const line = 'pages/api/menu-builder.ts:60';
-      const { data, error } = await supabase
-        .from(table)
-        .select('draft, updated_at')
-        .eq('restaurant_id', restaurantId)
-        .maybeSingle();
-
-      if (error) {
-        console.error('[draft:load]', {
-          path,
-          restaurantId,
-          table,
-          line,
-          message: error.message,
-          details: error.details,
-          hint: error.hint,
-          error,
-        });
-        return res
-          .status(500)
-          .json({ message: error.message, table, line });
+      let data: { draft: DraftPayload; updated_at: string } | null = null;
+      try {
+        const response = await supabase
+          .from(table)
+          .select('draft, updated_at')
+          .eq('restaurant_id', restaurantId)
+          .maybeSingle()
+          .throwOnError();
+        data = response.data as typeof data;
+      } catch (error: any) {
+        console.error('Supabase error:', error?.message, error?.details, error?.hint);
+        return res.status(500).json({ error: error?.message, details: error?.details, hint: error?.hint });
       }
 
       if (!data) {
-        const initLine = 'pages/api/menu-builder.ts:75';
-        const { data: inserted, error: insertErr } = await supabase
-          .from(table)
-          .insert({ restaurant_id: restaurantId, draft: {} })
-          .select('draft, updated_at')
-          .single();
-        if (insertErr) {
-          console.error('[draft:init]', {
-            path,
-            restaurantId,
-            table,
-            line: initLine,
-            message: insertErr.message,
-            details: insertErr.details,
-            hint: insertErr.hint,
-            error: insertErr,
-          });
-          return res.status(500).json({ message: insertErr.message, table, line: initLine });
+        let inserted: { draft: DraftPayload; updated_at: string };
+        try {
+          const response = await supabase
+            .from(table)
+            .insert({ restaurant_id: restaurantId, draft: {} })
+            .select('draft, updated_at')
+            .single()
+            .throwOnError();
+          inserted = response.data as typeof inserted;
+        } catch (error: any) {
+          console.error('Supabase error:', error?.message, error?.details, error?.hint);
+          return res.status(500).json({ error: error?.message, details: error?.details, hint: error?.hint });
         }
         return res
           .status(200)
@@ -99,25 +84,18 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       if (!draft) return res.status(400).json({ message: 'draft is required' });
 
       const table = 'menu_drafts';
-      const line = 'pages/api/menu-builder.ts:103';
-      const { data, error } = await supabase
-        .from(table)
-        .upsert({ restaurant_id: restaurantId, draft }, { onConflict: 'restaurant_id' })
-        .select('draft, updated_at')
-        .single();
-
-      if (error) {
-        console.error('[draft:save]', {
-          path,
-          restaurantId,
-          table,
-          line,
-          message: error.message,
-          details: error.details,
-          hint: error.hint,
-          error,
-        });
-        return res.status(500).json({ message: error.message, table, line });
+      let data: { draft: DraftPayload; updated_at: string };
+      try {
+        const response = await supabase
+          .from(table)
+          .upsert({ restaurant_id: restaurantId, draft }, { onConflict: 'restaurant_id' })
+          .select('draft, updated_at')
+          .single()
+          .throwOnError();
+        data = response.data as typeof data;
+      } catch (error: any) {
+        console.error('Supabase error:', error?.message, error?.details, error?.hint);
+        return res.status(500).json({ error: error?.message, details: error?.details, hint: error?.hint });
       }
       return res
         .status(200)

--- a/pages/api/menu-builder.ts
+++ b/pages/api/menu-builder.ts
@@ -98,7 +98,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     res.setHeader('Allow', ['GET', 'PUT']);
     return res.status(405).end('Method Not Allowed');
   } catch (e: any) {
-    console.error('[draft:unhandled]', { path, restaurantId, error: e });
+    console.error('[draft:unhandled]', {
+      path,
+      restaurantId,
+      error: e,
+      message: e?.message,
+      code: e?.code,
+      details: e?.details,
+      hint: e?.hint,
+      stack: e?.stack,
+    });
     return res.status(500).json({ message: e?.message || 'server_error' });
   }
 }

--- a/pages/api/menu-builder.ts
+++ b/pages/api/menu-builder.ts
@@ -41,58 +41,87 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   try {
     if (req.method === 'GET') {
-      const table = 'menu_builder_drafts';
+      const table = 'menu_drafts';
       const line = 'pages/api/menu-builder.ts:60';
       const { data, error } = await supabase
         .from(table)
-        .select('payload, updated_at')
+        .select('draft, updated_at')
         .eq('restaurant_id', restaurantId)
         .maybeSingle();
 
       if (error) {
-        console.error('[draft:load]', { path, restaurantId, table, line, error });
+        console.error('[draft:load]', {
+          path,
+          restaurantId,
+          table,
+          line,
+          message: error.message,
+          details: error.details,
+          hint: error.hint,
+          error,
+        });
         return res
           .status(500)
           .json({ message: error.message, table, line });
       }
 
       if (!data) {
-        const initLine = 'pages/api/menu-builder.ts:72';
+        const initLine = 'pages/api/menu-builder.ts:75';
         const { data: inserted, error: insertErr } = await supabase
           .from(table)
-          .insert({ restaurant_id: restaurantId, payload: {} })
-          .select('payload, updated_at')
+          .insert({ restaurant_id: restaurantId, draft: {} })
+          .select('draft, updated_at')
           .single();
         if (insertErr) {
-          console.error('[draft:init]', { path, restaurantId, table, line: initLine, error: insertErr });
+          console.error('[draft:init]', {
+            path,
+            restaurantId,
+            table,
+            line: initLine,
+            message: insertErr.message,
+            details: insertErr.details,
+            hint: insertErr.hint,
+            error: insertErr,
+          });
           return res.status(500).json({ message: insertErr.message, table, line: initLine });
         }
-        return res.status(200).json({ draft: inserted.payload, payload: inserted.payload, updated_at: inserted.updated_at });
+        return res
+          .status(200)
+          .json({ draft: inserted.draft, payload: inserted.draft, updated_at: inserted.updated_at });
       }
       return res
         .status(200)
-        .json({ draft: data.payload, payload: data.payload, updated_at: data.updated_at });
+        .json({ draft: data.draft, payload: data.draft, updated_at: data.updated_at });
     }
 
     if (req.method === 'PUT') {
       const draft = (req.body as { draft?: DraftPayload }).draft;
       if (!draft) return res.status(400).json({ message: 'draft is required' });
 
-      const table = 'menu_builder_drafts';
-      const line = 'pages/api/menu-builder.ts:94';
+      const table = 'menu_drafts';
+      const line = 'pages/api/menu-builder.ts:103';
       const { data, error } = await supabase
         .from(table)
-        .upsert({ restaurant_id: restaurantId, payload: draft }, { onConflict: 'restaurant_id' })
-        .select('payload, updated_at')
+        .upsert({ restaurant_id: restaurantId, draft }, { onConflict: 'restaurant_id' })
+        .select('draft, updated_at')
         .single();
 
       if (error) {
-        console.error('[draft:save]', { path, restaurantId, table, line, error });
+        console.error('[draft:save]', {
+          path,
+          restaurantId,
+          table,
+          line,
+          message: error.message,
+          details: error.details,
+          hint: error.hint,
+          error,
+        });
         return res.status(500).json({ message: error.message, table, line });
       }
       return res
         .status(200)
-        .json({ draft: data.payload, payload: data.payload, updated_at: data.updated_at });
+        .json({ draft: data.draft, payload: data.draft, updated_at: data.updated_at });
     }
 
     res.setHeader('Allow', ['GET', 'PUT']);

--- a/pages/api/menu-builder.ts
+++ b/pages/api/menu-builder.ts
@@ -31,7 +31,7 @@ type DraftPayload = {
 };
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const supabase = supaServer();
+  const supabase = supaServer;
   const restaurantId = resolveRestaurantId(req);
   const path = req.url || '/api/menu-builder';
 

--- a/pages/api/menu-reorder.ts
+++ b/pages/api/menu-reorder.ts
@@ -12,7 +12,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(400).json({ message: 'restaurantId is required' });
   }
 
-  const supabase = supaServer();
+  const supabase = supaServer;
 
   try {
     if (Array.isArray(categories) && categories.length) {

--- a/pages/api/publish-menu.ts
+++ b/pages/api/publish-menu.ts
@@ -18,7 +18,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).end('Method Not Allowed');
   }
 
-  const supabase = supaServer();
+  const supabase = supaServer;
 
   const archivedSupport: Record<'menu_items' | 'menu_categories', boolean> = {
     menu_items: true,

--- a/pages/api/publish-menu.ts
+++ b/pages/api/publish-menu.ts
@@ -69,8 +69,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           const query = supabase
             .from('menu_items')
             .select('id')
-            .eq('restaurant_id', restaurantId);
-          return useArchived ? query.is('archived_at', null) : query;
+            .eq('restaurant_id', restaurantId) as PostgrestFilterBuilder<any, any, any>;
+          return useArchived ? query.filter('archived_at', 'is', null) : query;
         },
       );
       if (liveErr) throw liveErr;
@@ -93,8 +93,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             .from('menu_items')
             .delete()
             .eq('restaurant_id', restaurantId)
-            .select('id');
-          return useArchived ? query.is('archived_at', null) : query;
+            .select('id') as PostgrestFilterBuilder<any, any, any>;
+          return useArchived ? query.filter('archived_at', 'is', null) : query;
         },
       );
       if (delItemsErr) throw delItemsErr;
@@ -107,8 +107,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             .from('menu_categories')
             .delete()
             .eq('restaurant_id', restaurantId)
-            .select('id');
-          return useArchived ? query.is('archived_at', null) : query;
+            .select('id') as PostgrestFilterBuilder<any, any, any>;
+          return useArchived ? query.filter('archived_at', 'is', null) : query;
         },
       );
       if (delCatsErr) throw delCatsErr;
@@ -128,8 +128,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
               .from('menu_items')
               .update({ archived_at: new Date().toISOString() })
               .eq('restaurant_id', restaurantId)
-              .select('id');
-            return useArchived ? query.is('archived_at', null) : query;
+              .select('id') as PostgrestFilterBuilder<any, any, any>;
+            return useArchived ? query.filter('archived_at', 'is', null) : query;
           },
         ));
         if (archItemsErr && archItemsErr.code === '42703' && /archived_at/i.test(archItemsErr.message || '')) {
@@ -176,8 +176,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
               .from('menu_categories')
               .update({ archived_at: new Date().toISOString() })
               .eq('restaurant_id', restaurantId)
-              .select('id');
-            return useArchived ? query.is('archived_at', null) : query;
+              .select('id') as PostgrestFilterBuilder<any, any, any>;
+            return useArchived ? query.filter('archived_at', 'is', null) : query;
           },
         ));
         if (archCatsErr && archCatsErr.code === '42703' && /archived_at/i.test(archCatsErr.message || '')) {

--- a/pages/api/restaurants/menu-header.ts
+++ b/pages/api/restaurants/menu-header.ts
@@ -23,7 +23,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const restaurantId = resolveRestaurantId(req);
   if (!restaurantId) return res.status(400).json({ message: 'restaurant_id is required' });
 
-  const supabase = supaServer();
+  const supabase = supaServer;
   const { imageUrl, focalX, focalY } = req.body || {};
 
   const update = imageUrl

--- a/pages/dashboard/menu-builder.tsx
+++ b/pages/dashboard/menu-builder.tsx
@@ -281,20 +281,21 @@ export default function MenuBuilder() {
       const { data: groups } = await supabase
         .from('addon_groups')
         .select('id')
-        .eq('restaurant_id', rid)
-        .is('archived_at', null);
+        .eq('restaurant_id', rid);
       let mappedAddons: StockTabProps['addons'] = [];
       if (groups && groups.length) {
         const { data: opts } = await supabase
           .from('addon_options')
-          .select('id,name,group_id,stock_status,stock_return_date')
-          .in('group_id', groups.map((g) => g.id))
-          .is('archived_at', null);
+          .select('id,name,group_id,stock_status,stock_return_date,available,out_of_stock_until,stock_last_updated_at')
+          .in('group_id', groups.map((g) => g.id));
         mappedAddons = (opts || []).map((o) => ({
           id: String(o.id),
           name: o.name,
           stock_status: o.stock_status,
           stock_return_date: o.stock_return_date,
+          available: o.available,
+          out_of_stock_until: o.out_of_stock_until,
+          stock_last_updated_at: o.stock_last_updated_at,
         }));
       }
 

--- a/pages/restaurant/index.tsx
+++ b/pages/restaurant/index.tsx
@@ -91,7 +91,7 @@ export const getServerSideProps: GetServerSideProps = async ctx => {
     null;
   let initialBrand = null;
   if (id) {
-    const { data } = await supaServer()
+    const { data } = await supaServer
       .from('restaurants')
       .select('id,website_title,name,logo_url,logo_shape,brand_primary_color,brand_secondary_color,cover_image_url,website_description')
       .eq('id', id)

--- a/pages/restaurant/menu.tsx
+++ b/pages/restaurant/menu.tsx
@@ -141,12 +141,10 @@ export default function RestaurantMenuPage({ initialBrand }: { initialBrand: any
           .select(
             `item_id, addon_groups!inner(
               id,name,multiple_choice,required,max_group_select,max_option_quantity,
-              addon_options!inner(id,name,price,is_vegetarian,is_vegan,is_18_plus,image_url)
+              addon_options!inner(id,name,price,image_url)
             )`
           )
-          .in('item_id', liveItemIds)
-          .is('addon_groups.archived_at', null)
-          .is('addon_groups.addon_options.archived_at', null);
+          .in('item_id', liveItemIds);
         if (addonErr) console.error('Failed to fetch addons', addonErr);
         addonRows = addData || [];
       }

--- a/pages/restaurant/menu.tsx
+++ b/pages/restaurant/menu.tsx
@@ -416,7 +416,7 @@ export const getServerSideProps: GetServerSideProps = async ctx => {
     null;
   let initialBrand = null;
   if (id) {
-    const { data } = await supaServer()
+    const { data } = await supaServer
       .from('restaurants')
       .select('id,website_title,name,logo_url,logo_shape,brand_primary_color,brand_secondary_color')
       .eq('id', id)

--- a/pages/restaurant/menu.tsx
+++ b/pages/restaurant/menu.tsx
@@ -140,8 +140,8 @@ export default function RestaurantMenuPage({ initialBrand }: { initialBrand: any
           .from('item_addon_links')
           .select(
             `item_id, addon_groups!inner(
-              id,name,multiple_choice,required,max_group_select,max_option_quantity,
-              addon_options!inner(id,name,price,image_url)
+              id,restaurant_id,name,multiple_choice,required,max_group_select,max_option_quantity,
+              addon_options!inner(id,group_id,name,price,available,out_of_stock_until,stock_status,stock_return_date,stock_last_updated_at)
             )`
           )
           .in('item_id', liveItemIds);
@@ -152,7 +152,15 @@ export default function RestaurantMenuPage({ initialBrand }: { initialBrand: any
       const addonMap: Record<number, any[]> = {};
       addonRows.forEach((row) => {
         const arr = addonMap[row.item_id] || [];
-        if (row.addon_groups) arr.push(row.addon_groups);
+        if (row.addon_groups) {
+          const group = {
+            ...row.addon_groups,
+            addon_options: (row.addon_groups.addon_options || []).filter(
+              (opt: any) => opt?.available !== false
+            ),
+          };
+          arr.push(group);
+        }
         addonMap[row.item_id] = arr;
       });
       const itemsWithAddons = (itemData || []).map((it: any) => ({

--- a/pages/restaurant/more.tsx
+++ b/pages/restaurant/more.tsx
@@ -92,7 +92,7 @@ export const getServerSideProps: GetServerSideProps = async ctx => {
     null
   let initialBrand = null
   if (id) {
-    const { data } = await supaServer()
+    const { data } = await supaServer
       .from('restaurants')
       .select('id,website_title,name,logo_url,logo_shape,brand_primary_color,brand_secondary_color')
       .eq('id', id)

--- a/pages/restaurant/orders.tsx
+++ b/pages/restaurant/orders.tsx
@@ -238,7 +238,7 @@ export const getServerSideProps: GetServerSideProps = async ctx => {
     null
   let initialBrand = null
   if (id) {
-    const { data } = await supaServer()
+    const { data } = await supaServer
       .from('restaurants')
       .select('id,website_title,name,logo_url,logo_shape,brand_primary_color,brand_secondary_color')
       .eq('id', id)

--- a/utils/getAddonsForItem.ts
+++ b/utils/getAddonsForItem.ts
@@ -11,8 +11,10 @@ export async function getAddonsForItem(
     .from('item_addon_links')
     .select(
       `addon_groups!inner(
-        id,name,required,multiple_choice,max_group_select,max_option_quantity,
-        addon_options!inner(id,name,price,image_url)
+        id,restaurant_id,name,required,multiple_choice,max_group_select,max_option_quantity,
+        addon_options!inner(
+          id,group_id,name,price,available,out_of_stock_until,stock_status,stock_return_date,stock_last_updated_at
+        )
       )`
     )
     .eq('item_id', itemId);
@@ -38,14 +40,17 @@ export async function getAddonsForItem(
     }
     const group = map.get(gid)!;
     (g.addon_options || []).forEach((opt: any) => {
+      if (opt?.available === false) return;
       group.addon_options.push({
         id: String(opt.id),
+        group_id: opt.group_id ? String(opt.group_id) : gid,
         name: opt.name,
         price: opt.price,
-        image_url: opt.image_url,
-        is_vegetarian: opt.is_vegetarian,
-        is_vegan: opt.is_vegan,
-        is_18_plus: opt.is_18_plus,
+        available: opt.available,
+        out_of_stock_until: opt.out_of_stock_until,
+        stock_status: opt.stock_status,
+        stock_return_date: opt.stock_return_date,
+        stock_last_updated_at: opt.stock_last_updated_at,
       });
     });
   });

--- a/utils/getAddonsForItem.ts
+++ b/utils/getAddonsForItem.ts
@@ -12,12 +12,10 @@ export async function getAddonsForItem(
     .select(
       `addon_groups!inner(
         id,name,required,multiple_choice,max_group_select,max_option_quantity,
-        addon_options!inner(id,name,price,is_vegetarian,is_vegan,is_18_plus,image_url)
+        addon_options!inner(id,name,price,image_url)
       )`
     )
-    .eq('item_id', itemId)
-    .is('addon_groups.archived_at', null)
-    .is('addon_groups.addon_options.archived_at', null);
+    .eq('item_id', itemId);
 
   if (error) throw error;
 

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -1,15 +1,18 @@
 export interface AddonOption {
   id: string;
+  group_id?: string;
   name: string;
   price: number | null;
-  image_url?: string | null;
-  is_vegetarian?: boolean | null;
-  is_vegan?: boolean | null;
-  is_18_plus?: boolean | null;
+  available?: boolean | null;
+  out_of_stock_until?: string | null;
+  stock_status?: string | null;
+  stock_return_date?: string | null;
+  stock_last_updated_at?: string | null;
 }
 
 export interface AddonGroup {
   id: string;
+  restaurant_id?: string;
   /**
    * Some queries may return `group_id` instead of `id` for the group
    * identifier (e.g. from `view_addons_for_item`). Include it here so


### PR DESCRIPTION
## Summary
- stop selecting archived_at and dietary columns that do not exist on addon option records when loading add-ons for a menu item
- mirror the corrected projection in the menu preload query so server-side fetches no longer fail silently

## Testing
- npm run test:ci *(fails: repository Jest setup lacks TSX transformer and aborts on "Unexpected token '<'")*

------
https://chatgpt.com/codex/tasks/task_e_68e9500c071483259b60e240a13654a9