### PR TITLE
Fix add-on groups display in item modal

### DIFF
--- a/components/MenuItemCard.tsx
+++ b/components/MenuItemCard.tsx
@@ -43,7 +43,7 @@ export default function MenuItemCard({
 }) {
   const [showModal, setShowModal] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [groups, setGroups] = useState<AddonGroup[]>([]);
+  const [addonGroups, setAddonGroups] = useState<AddonGroup[]>([]);
   const [qty, setQty] = useState(1);
   const [notes, setNotes] = useState('');
   const [selections, setSelections] = useState<
@@ -112,7 +112,7 @@ export default function MenuItemCard({
     try {
       const data = await getAddonsForItem(item.id);
       const sanitized = Array.isArray(data) ? data : [];
-      setGroups(sanitized);
+      setAddonGroups(sanitized);
       if (process.env.NODE_ENV === 'development') {
         console.debug('[customer:item-modal] fetched add-on groups', {
           itemId: item.id,
@@ -127,7 +127,7 @@ export default function MenuItemCard({
       }
     } catch (err) {
       console.error('Failed to load addons', err);
-      setGroups([]);
+      setAddonGroups([]);
     } finally {
       setLoading(false);
     }
@@ -145,19 +145,19 @@ export default function MenuItemCard({
     if (process.env.NODE_ENV === 'development') {
       console.debug('[customer:item-modal] rendering with add-on groups', {
         itemId: item.id,
-        groupsCount: groups.length,
+        groupsCount: addonGroups.length,
       });
     }
-  }, [groups, item.id]);
+  }, [addonGroups, item.id]);
 
   const handleFinalAdd = () => {
-    const errors = validateAddonSelections(groups, selections);
+    const errors = validateAddonSelections(addonGroups, selections);
     if (Object.keys(errors).length) {
       alert('Please complete required add-ons');
       return;
     }
 
-    const addons = groups.flatMap((g) => {
+    const addons = addonGroups.flatMap((g) => {
       const gid = g.group_id ?? g.id;
       const opts = selections[gid] || {};
       return g.addon_options
@@ -279,8 +279,8 @@ export default function MenuItemCard({
         <div className="flex-1 overflow-y-auto px-4 md:px-6 py-3 space-y-4">
           {loading ? (
             <p className="text-center text-gray-500">Loading...</p>
-          ) : groups.length > 0 ? (
-            <AddonGroups addons={groups} onChange={setSelections} />
+          ) : addonGroups.length > 0 ? (
+            <AddonGroups addons={addonGroups} onChange={setSelections} />
           ) : null}
           <textarea
             className="w-full border rounded p-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"

--- a/utils/getAddonsForItem.ts
+++ b/utils/getAddonsForItem.ts
@@ -10,30 +10,28 @@ export async function getAddonsForItem(
   const query = supabase
     .from('item_addon_links')
     .select(
-      `id,
-       addon_groups (
-         id,
-         restaurant_id,
-         name,
-         required,
-         multiple_choice,
-         max_group_select,
-         max_option_quantity,
-         addon_options (
-           id,
-           group_id,
-           name,
-           price,
-           available,
-           out_of_stock_until,
-           stock_status,
-           stock_return_date,
-           stock_last_updated_at
-         )
-       )`
+      `
+      id,
+      addon_groups (
+        id,
+        name,
+        multiple_choice,
+        required,
+        max_group_select,
+        max_option_quantity,
+        addon_options (
+          id,
+          name,
+          price,
+          available,
+          stock_status,
+          stock_return_date,
+          stock_last_updated_at
+        )
+      )
+    `
     )
-    .eq('item_id', itemId)
-    .is('addon_groups.archived_at', null);
+    .eq('item_id', itemId);
 
   const requestUrl = (query as unknown as { url?: URL }).url?.toString();
 
@@ -80,7 +78,6 @@ export async function getAddonsForItem(
       : [];
 
     options.forEach((opt) => {
-      if (opt?.archived_at) return;
       const optionId = String(opt.id);
       if (optionIds.has(optionId)) return;
       optionIds.add(optionId);

--- a/utils/getAddonsForItem.ts
+++ b/utils/getAddonsForItem.ts
@@ -10,45 +10,86 @@ export async function getAddonsForItem(
   const query = supabase
     .from('item_addon_links')
     .select(
-      `addon_groups!inner(
-        id,restaurant_id,name,required,multiple_choice,max_group_select,max_option_quantity,
-        addon_options!inner(
-          id,group_id,name,price,available,out_of_stock_until,stock_status,stock_return_date,stock_last_updated_at
-        )
-      )`
+      `id,
+       addon_groups (
+         id,
+         restaurant_id,
+         name,
+         required,
+         multiple_choice,
+         max_group_select,
+         max_option_quantity,
+         addon_options (
+           id,
+           group_id,
+           name,
+           price,
+           available,
+           out_of_stock_until,
+           stock_status,
+           stock_return_date,
+           stock_last_updated_at
+         )
+       )`
     )
-    .eq('item_id', itemId);
+    .eq('item_id', itemId)
+    .is('addon_groups.archived_at', null);
 
   const requestUrl = (query as unknown as { url?: URL }).url?.toString();
 
   const { data, error } = await query;
 
-  if (error) throw error;
-
-  const map = new Map<string, AddonGroup>();
-  (data || []).forEach((row: any) => {
-    const g = row.addon_groups;
-    if (!g) return;
-    const gid = String(g.id);
-    if (!map.has(gid)) {
-      map.set(gid, {
-        id: gid,
-        group_id: gid,
-        name: g.name,
-        required: g.required,
-        multiple_choice: g.multiple_choice,
-        max_group_select: g.max_group_select,
-        max_option_quantity: g.max_option_quantity,
-        addon_options: [],
+  if (error) {
+    if (process.env.NODE_ENV === 'development') {
+      console.error('[customer:addons] failed to fetch add-ons', {
+        itemId,
+        requestUrl,
+        error,
       });
     }
-    const group = map.get(gid)!;
-    (g.addon_options || []).forEach((opt: any) => {
-      group.addon_options.push({
-        id: String(opt.id),
+    throw error;
+  }
+
+  const addonGroups = new Map<string, AddonGroup>();
+  const optionIdsByGroup = new Map<string, Set<string>>();
+
+  (data ?? []).forEach((row: any) => {
+    const group = row?.addon_groups;
+    if (!group) return;
+
+    const gid = String(group.id);
+    if (!addonGroups.has(gid)) {
+      addonGroups.set(gid, {
+        id: gid,
+        group_id: gid,
+        restaurant_id: group.restaurant_id ? String(group.restaurant_id) : undefined,
+        name: group.name,
+        required: group.required,
+        multiple_choice: group.multiple_choice,
+        max_group_select: group.max_group_select,
+        max_option_quantity: group.max_option_quantity,
+        addon_options: [],
+      });
+      optionIdsByGroup.set(gid, new Set());
+    }
+
+    const targetGroup = addonGroups.get(gid)!;
+    const optionIds = optionIdsByGroup.get(gid)!;
+    const options: any[] = Array.isArray(group.addon_options)
+      ? group.addon_options
+      : [];
+
+    options.forEach((opt) => {
+      if (opt?.archived_at) return;
+      const optionId = String(opt.id);
+      if (optionIds.has(optionId)) return;
+      optionIds.add(optionId);
+
+      targetGroup.addon_options.push({
+        id: optionId,
         group_id: opt.group_id ? String(opt.group_id) : gid,
         name: opt.name,
-        price: opt.price,
+        price: typeof opt.price === 'number' ? opt.price : opt.price == null ? null : Number(opt.price),
         available: opt.available,
         out_of_stock_until: opt.out_of_stock_until,
         stock_status: opt.stock_status,
@@ -58,19 +99,21 @@ export async function getAddonsForItem(
     });
   });
 
+  const result = Array.from(addonGroups.values());
+
   if (process.env.NODE_ENV === 'development') {
-    console.debug('[customer:addons]', {
+    console.debug('[customer:addons] fetched add-ons for item', {
       itemId,
-      rawRows: data?.length ?? 0,
-      groups: map.size,
-      options: Array.from(map.values()).reduce(
+      requestUrl,
+      rows: data?.length ?? 0,
+      addonGroups: result.length,
+      addonOptions: result.reduce(
         (sum, group) => sum + (group.addon_options?.length ?? 0),
         0,
       ),
-      requestUrl,
     });
   }
 
-  return Array.from(map.values());
+  return result;
 }
 


### PR DESCRIPTION
## Summary
- query add-on groups and options from Supabase via item_addon_links with the expected relationships
- pass the fetched addonGroups state from MenuItemCard into the modal and AddonGroups component
- simplify AddonGroups rendering with direct group/option mapping and add debugging logs for incoming data

## Testing
- CI=1 npm run build
- npm run test:ci -- components/__tests__/AddonGroups.test.tsx *(fails: Jest ts-jest transform not applied)*

------
https://chatgpt.com/codex/tasks/task_e_68e99190846c83258471b2b13d64a56f