### PR TITLE
fix(kiosk): restore header and fullscreen

### DIFF
--- a/components/kiosk/HomeScreen.tsx
+++ b/components/kiosk/HomeScreen.tsx
@@ -1,11 +1,13 @@
 import Image from 'next/image';
 import { useMemo } from 'react';
-import { FALLBACK_PLACEHOLDER_SRC, normalizeSource } from '@/lib/media/placeholders';
+import { normalizeSource } from '@/lib/media/placeholders';
 
 export type KioskRestaurant = {
   id: string;
   name?: string | null;
   logo_url?: string | null;
+  kiosk_hero_image_url?: string | null;
+  kiosk_hero_image_updated_at?: string | null;
   website_description?: string | null;
   menu_header_image_url?: string | null;
   menu_header_image_updated_at?: string | null;
@@ -29,14 +31,19 @@ function formatImageUrl(url?: string | null, updatedAt?: string | null) {
 }
 
 export default function HomeScreen({ restaurant, onStart, fadingOut }: HomeScreenProps) {
-  const heroUrl = useMemo(
-    () => formatImageUrl(restaurant?.menu_header_image_url, restaurant?.menu_header_image_updated_at),
-    [restaurant?.menu_header_image_updated_at, restaurant?.menu_header_image_url]
+  const kioskHero = useMemo(
+    () => formatImageUrl(restaurant?.kiosk_hero_image_url, restaurant?.kiosk_hero_image_updated_at),
+    [restaurant?.kiosk_hero_image_updated_at, restaurant?.kiosk_hero_image_url]
   );
+
+  const heroUrl = useMemo(() => {
+    const menuHero = formatImageUrl(restaurant?.menu_header_image_url, restaurant?.menu_header_image_updated_at);
+    return kioskHero || menuHero || null;
+  }, [kioskHero, restaurant?.menu_header_image_updated_at, restaurant?.menu_header_image_url]);
 
   const logoUrl = useMemo(() => normalizeSource(restaurant?.logo_url), [restaurant?.logo_url]);
 
-  const backgroundImage = heroUrl || logoUrl || FALLBACK_PLACEHOLDER_SRC;
+  const backgroundImage = heroUrl;
 
   const focalX = restaurant?.menu_header_focal_x ?? 0.5;
   const focalY = restaurant?.menu_header_focal_y ?? 0.5;
@@ -53,7 +60,8 @@ export default function HomeScreen({ restaurant, onStart, fadingOut }: HomeScree
         <div
           className="absolute inset-0"
           style={{
-            backgroundImage: `url(${backgroundImage})`,
+            backgroundImage: backgroundImage ? `url(${backgroundImage})` : undefined,
+            backgroundColor: backgroundImage ? undefined : '#f8fafc',
             backgroundSize: 'cover',
             backgroundPosition: `${focalX * 100}% ${focalY * 100}%`,
           }}
@@ -65,14 +73,19 @@ export default function HomeScreen({ restaurant, onStart, fadingOut }: HomeScree
         <div className="w-full rounded-[32px] border border-neutral-200 bg-white/95 p-8 shadow-2xl shadow-neutral-300/50 backdrop-blur">
           <div className="flex flex-col items-center gap-4">
             <div className="relative h-24 w-24 overflow-hidden rounded-full border border-neutral-200 bg-white shadow-lg shadow-neutral-200">
-              <Image
-                src={logoUrl || FALLBACK_PLACEHOLDER_SRC}
-                alt={restaurant?.name || 'Restaurant logo'}
-                fill
-                sizes="120px"
-                className={`${logoUrl ? '' : 'grayscale'} object-cover`}
-                style={{ filter: logoUrl ? undefined : 'grayscale(100%) blur(0px)' }}
-              />
+              {logoUrl ? (
+                <Image
+                  src={logoUrl}
+                  alt={restaurant?.name || 'Restaurant logo'}
+                  fill
+                  sizes="120px"
+                  className="object-cover"
+                />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center bg-neutral-50 text-3xl font-semibold text-neutral-500">
+                  {(restaurant?.name || 'R').slice(0, 1)}
+                </div>
+              )}
             </div>
             <div className="space-y-1">
               <h1 className="text-3xl font-semibold leading-tight text-neutral-900 sm:text-4xl">

--- a/components/kiosk/HomeScreen.tsx
+++ b/components/kiosk/HomeScreen.tsx
@@ -46,55 +46,57 @@ export default function HomeScreen({ restaurant, onStart, fadingOut }: HomeScree
 
   return (
     <div
-      className={`fixed inset-0 z-[60] flex items-center justify-center bg-slate-900/80 text-white transition-opacity duration-200 ${
+      className={`fixed inset-0 z-[60] flex items-center justify-center bg-white text-neutral-900 transition-opacity duration-200 ${
         fadingOut ? 'opacity-0' : 'opacity-100'
       }`}
     >
       <div className="absolute inset-0 overflow-hidden">
         <div
-          className="absolute inset-0 scale-105 transform"
+          className="absolute inset-0 opacity-20"
           style={{
             backgroundImage: `url(${backgroundImage})`,
             backgroundSize: 'cover',
             backgroundPosition: `${focalX * 100}% ${focalY * 100}%`,
-            filter: isFallback ? 'blur(12px) grayscale(100%)' : 'blur(0px)',
-            transform: 'scale(1.05)',
+            filter: isFallback ? 'blur(12px) grayscale(100%)' : 'none',
           }}
         />
-        <div className="absolute inset-0 bg-gradient-to-b from-black/55 via-black/45 to-black/35" />
       </div>
 
       <div className="relative z-10 flex w-full max-w-xl flex-col items-center gap-6 px-6 text-center">
-        <div className="flex flex-col items-center gap-4">
-          <div className="relative h-24 w-24 overflow-hidden rounded-full border border-white/30 bg-white/10 shadow-lg shadow-black/40">
-            <Image
-              src={logoUrl || FALLBACK_PLACEHOLDER_SRC}
-              alt={restaurant?.name || 'Restaurant logo'}
-              fill
-              sizes="120px"
-              className={`${logoUrl ? '' : 'grayscale'} object-cover`}
-              style={{ filter: logoUrl ? undefined : 'grayscale(100%) blur(0px)' }}
-            />
+        <div className="w-full rounded-[32px] border border-neutral-200 bg-white/95 p-8 shadow-2xl shadow-neutral-300/50 backdrop-blur">
+          <div className="flex flex-col items-center gap-4">
+            <div className="relative h-24 w-24 overflow-hidden rounded-full border border-neutral-200 bg-white shadow-lg shadow-neutral-200">
+              <Image
+                src={logoUrl || FALLBACK_PLACEHOLDER_SRC}
+                alt={restaurant?.name || 'Restaurant logo'}
+                fill
+                sizes="120px"
+                className={`${logoUrl ? '' : 'grayscale'} object-cover`}
+                style={{ filter: logoUrl ? undefined : 'grayscale(100%) blur(0px)' }}
+              />
+            </div>
+            <div className="space-y-1">
+              <h1 className="text-3xl font-semibold leading-tight text-neutral-900 sm:text-4xl">
+                {restaurant?.name || 'Restaurant'}
+              </h1>
+              {restaurant?.website_description ? (
+                <p className="text-base text-neutral-600 sm:text-lg">{restaurant.website_description}</p>
+              ) : null}
+            </div>
           </div>
-          <div className="space-y-1">
-            <h1 className="text-3xl font-semibold leading-tight sm:text-4xl">{restaurant?.name || 'Restaurant'}</h1>
-            {restaurant?.website_description ? (
-              <p className="text-base text-white/80 sm:text-lg">{restaurant.website_description}</p>
-            ) : null}
-          </div>
-        </div>
 
-        <button
-          type="button"
-          onClick={onStart}
-          className="w-full max-w-[280px] rounded-full px-8 text-lg font-semibold text-white shadow-xl shadow-black/30 transition focus:outline-none"
-          style={{
-            backgroundColor: primaryColor,
-            minHeight: '64px',
-          }}
-        >
-          Tap to Order
-        </button>
+          <button
+            type="button"
+            onClick={onStart}
+            className="mt-8 w-full max-w-[280px] rounded-full px-8 text-lg font-semibold text-white shadow-lg shadow-neutral-400 transition focus-visible:outline-none"
+            style={{
+              backgroundColor: primaryColor,
+              minHeight: '64px',
+            }}
+          >
+            Tap to Order
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/components/kiosk/HomeScreen.tsx
+++ b/components/kiosk/HomeScreen.tsx
@@ -37,7 +37,6 @@ export default function HomeScreen({ restaurant, onStart, fadingOut }: HomeScree
   const logoUrl = useMemo(() => normalizeSource(restaurant?.logo_url), [restaurant?.logo_url]);
 
   const backgroundImage = heroUrl || logoUrl || FALLBACK_PLACEHOLDER_SRC;
-  const isFallback = !heroUrl;
 
   const focalX = restaurant?.menu_header_focal_x ?? 0.5;
   const focalY = restaurant?.menu_header_focal_y ?? 0.5;
@@ -52,14 +51,14 @@ export default function HomeScreen({ restaurant, onStart, fadingOut }: HomeScree
     >
       <div className="absolute inset-0 overflow-hidden">
         <div
-          className="absolute inset-0 opacity-20"
+          className="absolute inset-0"
           style={{
             backgroundImage: `url(${backgroundImage})`,
             backgroundSize: 'cover',
             backgroundPosition: `${focalX * 100}% ${focalY * 100}%`,
-            filter: isFallback ? 'blur(12px) grayscale(100%)' : 'none',
           }}
         />
+        <div className="kiosk-hero-dim" />
       </div>
 
       <div className="relative z-10 flex w-full max-w-xl flex-col items-center gap-6 px-6 text-center">
@@ -98,6 +97,15 @@ export default function HomeScreen({ restaurant, onStart, fadingOut }: HomeScree
           </button>
         </div>
       </div>
+
+      <style jsx>{`
+        .kiosk-hero-dim {
+          position: absolute;
+          inset: 0;
+          background: rgba(255, 255, 255, 0.275);
+          pointer-events: none;
+        }
+      `}</style>
     </div>
   );
 }

--- a/components/kiosk/KioskActionButton.tsx
+++ b/components/kiosk/KioskActionButton.tsx
@@ -1,0 +1,45 @@
+import Link, { type LinkProps } from 'next/link';
+import type { AnchorHTMLAttributes, ButtonHTMLAttributes, ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+const baseClasses =
+  'inline-flex items-center justify-center gap-2 rounded-full border border-transparent px-5 py-2 text-base font-semibold tracking-wide text-white shadow-md shadow-black/5 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--kiosk-accent,#111827)]/40';
+
+const accentClasses = 'bg-[var(--kiosk-accent,#111827)] hover:brightness-110 active:translate-y-px';
+
+type KioskButtonBaseProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+type ButtonVariantProps = KioskButtonBaseProps &
+  ButtonHTMLAttributes<HTMLButtonElement> & {
+    href?: undefined;
+  };
+
+type LinkVariantProps = KioskButtonBaseProps &
+  AnchorHTMLAttributes<HTMLAnchorElement> &
+  LinkProps & {
+    href: LinkProps['href'];
+  };
+
+type KioskActionButtonProps = ButtonVariantProps | LinkVariantProps;
+
+export default function KioskActionButton(props: KioskActionButtonProps) {
+  if ('href' in props && typeof props.href !== 'undefined') {
+    const { className, children, href, ...linkProps } = props as LinkVariantProps;
+    return (
+      <Link href={href} className={cn(baseClasses, accentClasses, className)} {...linkProps}>
+        {children}
+      </Link>
+    );
+  }
+
+  const { className, children, type = 'button', ...buttonProps } = props as ButtonVariantProps;
+
+  return (
+    <button type={type} className={cn(baseClasses, accentClasses, className)} {...buttonProps}>
+      {children}
+    </button>
+  );
+}

--- a/components/kiosk/KioskCategories.tsx
+++ b/components/kiosk/KioskCategories.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useMemo, useRef } from 'react';
 import KioskCategoryTile from './KioskCategoryTile';
 
 interface KioskCategoriesProps {
@@ -7,20 +8,45 @@ interface KioskCategoriesProps {
 }
 
 export default function KioskCategories({ categories, activeCategoryId, onSelect }: KioskCategoriesProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const buttonRefs = useRef<Record<number, HTMLButtonElement | null>>({});
+
+  const orderedCategories = useMemo(() => categories, [categories]);
+
+  useEffect(() => {
+    if (activeCategoryId == null) return;
+    const btn = buttonRefs.current[activeCategoryId];
+    if (!btn) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    const btnRect = btn.getBoundingClientRect();
+    const containerRect = container.getBoundingClientRect();
+    const isFullyVisible = btnRect.left >= containerRect.left && btnRect.right <= containerRect.right;
+
+    if (!isFullyVisible) {
+      btn.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
+    }
+  }, [activeCategoryId]);
+
   return (
     <div
+      ref={containerRef}
       className="-mx-4 overflow-x-auto pb-3 scroll-smooth sm:-mx-6"
       role="tablist"
       aria-label="Categories"
     >
       <div className="flex min-h-[56px] items-center gap-3 px-4 sm:min-h-[60px] sm:gap-4 sm:px-6 snap-x snap-mandatory">
-        {categories.map((category) => (
+        {orderedCategories.map((category) => (
           <KioskCategoryTile
             key={category.id}
             category={category}
             active={category.id === activeCategoryId}
             onSelect={onSelect}
             className="snap-start"
+            buttonRef={(el) => {
+              buttonRefs.current[category.id] = el;
+            }}
           />
         ))}
       </div>

--- a/components/kiosk/KioskCategories.tsx
+++ b/components/kiosk/KioskCategories.tsx
@@ -8,14 +8,19 @@ interface KioskCategoriesProps {
 
 export default function KioskCategories({ categories, activeCategoryId, onSelect }: KioskCategoriesProps) {
   return (
-    <div className="-mx-4 overflow-x-auto pb-3 sm:-mx-6" role="tablist" aria-label="Categories">
-      <div className="flex min-h-[56px] items-center gap-3 px-4 sm:min-h-[60px] sm:gap-4 sm:px-6">
+    <div
+      className="-mx-4 overflow-x-auto pb-3 scroll-smooth sm:-mx-6"
+      role="tablist"
+      aria-label="Categories"
+    >
+      <div className="flex min-h-[56px] items-center gap-3 px-4 sm:min-h-[60px] sm:gap-4 sm:px-6 snap-x snap-mandatory">
         {categories.map((category) => (
           <KioskCategoryTile
             key={category.id}
             category={category}
             active={category.id === activeCategoryId}
             onSelect={onSelect}
+            className="snap-start"
           />
         ))}
       </div>

--- a/components/kiosk/KioskCategories.tsx
+++ b/components/kiosk/KioskCategories.tsx
@@ -1,0 +1,24 @@
+import KioskCategoryTile from './KioskCategoryTile';
+
+interface KioskCategoriesProps {
+  categories: { id: number; name: string; image_url?: string | null }[];
+  activeCategoryId?: number | null;
+  onSelect?: (categoryId: number) => void;
+}
+
+export default function KioskCategories({ categories, activeCategoryId, onSelect }: KioskCategoriesProps) {
+  return (
+    <div className="-mx-4 overflow-x-auto pb-3 sm:-mx-6" role="tablist" aria-label="Categories">
+      <div className="flex min-h-[56px] items-center gap-3 px-4 sm:min-h-[60px] sm:gap-4 sm:px-6">
+        {categories.map((category) => (
+          <KioskCategoryTile
+            key={category.id}
+            category={category}
+            active={category.id === activeCategoryId}
+            onSelect={onSelect}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/kiosk/KioskCategoryTile.tsx
+++ b/components/kiosk/KioskCategoryTile.tsx
@@ -10,9 +10,10 @@ interface KioskCategoryTileProps {
   };
   active?: boolean;
   onSelect?: (categoryId: number) => void;
+  className?: string;
 }
 
-export default function KioskCategoryTile({ category, active = false, onSelect }: KioskCategoryTileProps) {
+export default function KioskCategoryTile({ category, active = false, onSelect, className }: KioskCategoryTileProps) {
   const categoryImage = category.image_url ? normalizeSource(category.image_url) : null;
 
   const handleClick = () => {
@@ -22,19 +23,17 @@ export default function KioskCategoryTile({ category, active = false, onSelect }
   return (
     <Button
       type="button"
-      variant="secondary"
+      variant={active ? 'primary' : 'secondary'}
       size="lg"
       onClick={handleClick}
       className={cn(
-        'flex min-h-[52px] items-center gap-3 whitespace-nowrap px-4 text-left sm:min-h-[60px] sm:px-5',
-        active
-          ? 'border-[var(--kiosk-accent,#111827)] bg-white shadow-md ring-2 ring-[var(--kiosk-accent,#111827)]/15'
-          : 'border-neutral-200 bg-white/90 shadow-sm hover:bg-white',
-        'transition-all duration-200 ease-out'
+        'flex min-h-[52px] shrink-0 items-center gap-3 whitespace-nowrap px-4 text-left transition-all duration-200 ease-out sm:min-h-[60px] sm:px-6',
+        active ? 'shadow-md' : 'shadow-sm',
+        className
       )}
     >
       {categoryImage ? (
-        <span className="relative h-10 w-10 overflow-hidden rounded-2xl bg-white shadow-sm sm:h-11 sm:w-11">
+        <span className="relative h-10 w-10 overflow-hidden rounded-xl bg-white shadow-sm sm:h-11 sm:w-11">
           <img src={categoryImage} alt={category.name} className="h-full w-full object-cover" loading="lazy" />
         </span>
       ) : null}

--- a/components/kiosk/KioskCategoryTile.tsx
+++ b/components/kiosk/KioskCategoryTile.tsx
@@ -10,9 +10,16 @@ interface KioskCategoryTileProps {
   active?: boolean;
   onSelect?: (categoryId: number) => void;
   className?: string;
+  buttonRef?: (el: HTMLButtonElement | null) => void;
 }
 
-export default function KioskCategoryTile({ category, active = false, onSelect, className }: KioskCategoryTileProps) {
+export default function KioskCategoryTile({
+  category,
+  active = false,
+  onSelect,
+  className,
+  buttonRef,
+}: KioskCategoryTileProps) {
   const categoryImage = category.image_url ? normalizeSource(category.image_url) : null;
 
   const handleClick = () => {
@@ -31,6 +38,7 @@ export default function KioskCategoryTile({ category, active = false, onSelect, 
     <button
       type="button"
       onClick={handleClick}
+      ref={buttonRef}
       className={cn(baseClasses, active ? activeClasses : inactiveClasses, className)}
     >
       {categoryImage ? (

--- a/components/kiosk/KioskCategoryTile.tsx
+++ b/components/kiosk/KioskCategoryTile.tsx
@@ -1,4 +1,6 @@
+import Button from '@/components/ui/Button';
 import { normalizeSource } from '@/lib/media/placeholders';
+import { cn } from '@/lib/utils';
 
 interface KioskCategoryTileProps {
   category: {
@@ -18,23 +20,25 @@ export default function KioskCategoryTile({ category, active = false, onSelect }
   };
 
   return (
-    <button
+    <Button
       type="button"
+      variant="secondary"
+      size="lg"
       onClick={handleClick}
-      className={`flex min-h-[52px] items-center gap-3 rounded-full border px-4 text-left shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--kiosk-accent,#111827)]/30 sm:min-h-[60px] sm:px-5 ${
+      className={cn(
+        'flex min-h-[52px] items-center gap-3 whitespace-nowrap px-4 text-left sm:min-h-[60px] sm:px-5',
         active
-          ? 'border-[var(--kiosk-accent,#111827)]/20 bg-white shadow-md'
-          : 'border-neutral-200 bg-[#f7f7f7] hover:bg-white'
-      }`}
+          ? 'border-[var(--kiosk-accent,#111827)] bg-white shadow-md ring-2 ring-[var(--kiosk-accent,#111827)]/15'
+          : 'border-neutral-200 bg-white/90 shadow-sm hover:bg-white',
+        'transition-all duration-200 ease-out'
+      )}
     >
       {categoryImage ? (
-        <div className="relative h-10 w-10 overflow-hidden rounded-[14px] border border-neutral-200 bg-white shadow-inner sm:h-11 sm:w-11">
+        <span className="relative h-10 w-10 overflow-hidden rounded-2xl bg-white shadow-sm sm:h-11 sm:w-11">
           <img src={categoryImage} alt={category.name} className="h-full w-full object-cover" loading="lazy" />
-        </div>
+        </span>
       ) : null}
-      <div className="flex flex-1 items-center">
-        <span className="text-sm font-semibold leading-tight text-neutral-900 sm:text-base">{category.name}</span>
-      </div>
-    </button>
+      <span className="text-sm font-semibold leading-tight text-neutral-900 sm:text-base">{category.name}</span>
+    </Button>
   );
 }

--- a/components/kiosk/KioskCategoryTile.tsx
+++ b/components/kiosk/KioskCategoryTile.tsx
@@ -1,0 +1,50 @@
+import type { CSSProperties } from 'react';
+import { FALLBACK_PLACEHOLDER_SRC, normalizeSource } from '@/lib/media/placeholders';
+
+interface KioskCategoryTileProps {
+  category: {
+    id: number;
+    name: string;
+    image_url?: string | null;
+  };
+  restaurantLogoUrl?: string | null;
+  onSelect?: (categoryId: number) => void;
+}
+
+export default function KioskCategoryTile({ category, restaurantLogoUrl, onSelect }: KioskCategoryTileProps) {
+  const categoryImage = normalizeSource(category.image_url);
+  const restaurantLogo = normalizeSource(restaurantLogoUrl);
+  const fallbackImage = categoryImage || restaurantLogo || FALLBACK_PLACEHOLDER_SRC;
+
+  const isLogoFallback = !categoryImage && !!restaurantLogo;
+
+  const handleClick = () => {
+    onSelect?.(category.id);
+  };
+
+  const imageStyle: CSSProperties | undefined = isLogoFallback
+    ? { filter: 'grayscale(60%)', opacity: 0.9 }
+    : undefined;
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="group relative block h-full min-h-[80px] w-full overflow-hidden rounded-2xl bg-white shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+    >
+      <div className="absolute inset-0">
+        <img
+          src={fallbackImage}
+          alt=""
+          className="h-full w-full object-cover"
+          style={imageStyle}
+          loading="lazy"
+        />
+      </div>
+      <div className="absolute inset-0 bg-gradient-to-t from-black/25 via-black/10 to-transparent" />
+      <div className="absolute inset-x-2 bottom-2 rounded-xl bg-white/60 px-3 py-2 text-center text-base font-semibold text-neutral-900 backdrop-blur-md">
+        <span className="line-clamp-2 leading-tight">{category.name}</span>
+      </div>
+    </button>
+  );
+}

--- a/components/kiosk/KioskCategoryTile.tsx
+++ b/components/kiosk/KioskCategoryTile.tsx
@@ -1,6 +1,5 @@
-import Button from '@/components/ui/Button';
-import { normalizeSource } from '@/lib/media/placeholders';
 import { cn } from '@/lib/utils';
+import { normalizeSource } from '@/lib/media/placeholders';
 
 interface KioskCategoryTileProps {
   category: {
@@ -20,24 +19,33 @@ export default function KioskCategoryTile({ category, active = false, onSelect, 
     onSelect?.(category.id);
   };
 
+  const baseClasses =
+    'inline-flex min-h-[52px] shrink-0 items-center justify-center gap-3 whitespace-nowrap rounded-full px-5 py-2 text-base font-semibold tracking-wide transition-all duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--kiosk-accent,#111827)]/40 sm:min-h-[60px] sm:px-6';
+
+  const activeClasses =
+    'border border-transparent bg-[var(--kiosk-accent,#111827)] text-white shadow-md shadow-black/5 hover:brightness-110 active:translate-y-px';
+
+  const inactiveClasses = 'border border-neutral-200 bg-white text-neutral-900 shadow-sm hover:bg-neutral-50';
+
   return (
-    <Button
+    <button
       type="button"
-      variant={active ? 'primary' : 'secondary'}
-      size="lg"
       onClick={handleClick}
-      className={cn(
-        'flex min-h-[52px] shrink-0 items-center gap-3 whitespace-nowrap px-4 text-left transition-all duration-200 ease-out sm:min-h-[60px] sm:px-6',
-        active ? 'shadow-md' : 'shadow-sm',
-        className
-      )}
+      className={cn(baseClasses, active ? activeClasses : inactiveClasses, className)}
     >
       {categoryImage ? (
         <span className="relative h-10 w-10 overflow-hidden rounded-xl bg-white shadow-sm sm:h-11 sm:w-11">
           <img src={categoryImage} alt={category.name} className="h-full w-full object-cover" loading="lazy" />
         </span>
       ) : null}
-      <span className="text-sm font-semibold leading-tight text-neutral-900 sm:text-base">{category.name}</span>
-    </Button>
+      <span
+        className={cn(
+          'text-sm font-semibold leading-tight sm:text-base',
+          active ? 'text-white' : 'text-neutral-900'
+        )}
+      >
+        {category.name}
+      </span>
+    </button>
   );
 }

--- a/components/kiosk/KioskCategoryTile.tsx
+++ b/components/kiosk/KioskCategoryTile.tsx
@@ -6,10 +6,11 @@ interface KioskCategoryTileProps {
     name: string;
     image_url?: string | null;
   };
+  active?: boolean;
   onSelect?: (categoryId: number) => void;
 }
 
-export default function KioskCategoryTile({ category, onSelect }: KioskCategoryTileProps) {
+export default function KioskCategoryTile({ category, active = false, onSelect }: KioskCategoryTileProps) {
   const categoryImage = category.image_url ? normalizeSource(category.image_url) : null;
 
   const handleClick = () => {
@@ -20,16 +21,19 @@ export default function KioskCategoryTile({ category, onSelect }: KioskCategoryT
     <button
       type="button"
       onClick={handleClick}
-      className="flex w-full items-center gap-4 rounded-2xl border border-neutral-200 bg-white/85 p-4 text-left shadow-sm transition hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--kiosk-accent,#111827)]/30 sm:gap-5 sm:p-5 backdrop-blur"
-      style={{ minHeight: '84px' }}
+      className={`flex min-h-[52px] items-center gap-3 rounded-full border px-4 text-left shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--kiosk-accent,#111827)]/30 sm:min-h-[60px] sm:px-5 ${
+        active
+          ? 'border-[var(--kiosk-accent,#111827)]/20 bg-white shadow-md'
+          : 'border-neutral-200 bg-[#f7f7f7] hover:bg-white'
+      }`}
     >
       {categoryImage ? (
-        <div className="relative h-20 w-20 shrink-0 overflow-hidden rounded-xl border border-neutral-200 bg-white/60 shadow-inner">
+        <div className="relative h-10 w-10 overflow-hidden rounded-[14px] border border-neutral-200 bg-white shadow-inner sm:h-11 sm:w-11">
           <img src={categoryImage} alt={category.name} className="h-full w-full object-cover" loading="lazy" />
         </div>
       ) : null}
-      <div className="flex min-h-[64px] flex-1 items-center">
-        <span className="text-lg font-semibold leading-tight text-neutral-900">{category.name}</span>
+      <div className="flex flex-1 items-center">
+        <span className="text-sm font-semibold leading-tight text-neutral-900 sm:text-base">{category.name}</span>
       </div>
     </button>
   );

--- a/components/kiosk/KioskCategoryTile.tsx
+++ b/components/kiosk/KioskCategoryTile.tsx
@@ -1,5 +1,4 @@
-import type { CSSProperties } from 'react';
-import { FALLBACK_PLACEHOLDER_SRC, normalizeSource } from '@/lib/media/placeholders';
+import { normalizeSource } from '@/lib/media/placeholders';
 
 interface KioskCategoryTileProps {
   category: {
@@ -7,43 +6,30 @@ interface KioskCategoryTileProps {
     name: string;
     image_url?: string | null;
   };
-  restaurantLogoUrl?: string | null;
   onSelect?: (categoryId: number) => void;
 }
 
-export default function KioskCategoryTile({ category, restaurantLogoUrl, onSelect }: KioskCategoryTileProps) {
-  const categoryImage = normalizeSource(category.image_url);
-  const restaurantLogo = normalizeSource(restaurantLogoUrl);
-  const fallbackImage = categoryImage || restaurantLogo || FALLBACK_PLACEHOLDER_SRC;
-
-  const isLogoFallback = !categoryImage && !!restaurantLogo;
+export default function KioskCategoryTile({ category, onSelect }: KioskCategoryTileProps) {
+  const categoryImage = category.image_url ? normalizeSource(category.image_url) : null;
 
   const handleClick = () => {
     onSelect?.(category.id);
   };
 
-  const imageStyle: CSSProperties | undefined = isLogoFallback
-    ? { filter: 'grayscale(60%)', opacity: 0.9 }
-    : undefined;
-
   return (
     <button
       type="button"
       onClick={handleClick}
-      className="group relative block h-full min-h-[80px] w-full overflow-hidden rounded-2xl bg-white shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+      className="flex w-full items-center gap-4 rounded-2xl border border-neutral-200 bg-white/85 p-4 text-left shadow-sm transition hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--kiosk-accent,#111827)]/30 sm:gap-5 sm:p-5 backdrop-blur"
+      style={{ minHeight: '84px' }}
     >
-      <div className="absolute inset-0">
-        <img
-          src={fallbackImage}
-          alt=""
-          className="h-full w-full object-cover"
-          style={imageStyle}
-          loading="lazy"
-        />
-      </div>
-      <div className="absolute inset-0 bg-gradient-to-t from-black/25 via-black/10 to-transparent" />
-      <div className="absolute inset-x-2 bottom-2 rounded-xl bg-white/60 px-3 py-2 text-center text-base font-semibold text-neutral-900 backdrop-blur-md">
-        <span className="line-clamp-2 leading-tight">{category.name}</span>
+      {categoryImage ? (
+        <div className="relative h-20 w-20 shrink-0 overflow-hidden rounded-xl border border-neutral-200 bg-white/60 shadow-inner">
+          <img src={categoryImage} alt={category.name} className="h-full w-full object-cover" loading="lazy" />
+        </div>
+      ) : null}
+      <div className="flex min-h-[64px] flex-1 items-center">
+        <span className="text-lg font-semibold leading-tight text-neutral-900">{category.name}</span>
       </div>
     </button>
   );

--- a/pages/kiosk/[restaurantId]/cart.tsx
+++ b/pages/kiosk/[restaurantId]/cart.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react';
-import Link from 'next/link';
 import { useRouter } from 'next/router';
 import CartDrawer from '@/components/CartDrawer';
 import KioskLayout from '@/components/layouts/KioskLayout';
 import { useCart } from '@/context/CartContext';
 import { supabase } from '@/lib/supabaseClient';
+import KioskActionButton from '@/components/kiosk/KioskActionButton';
 
 type Restaurant = {
   id: string;
@@ -64,12 +64,9 @@ export default function KioskCartPage() {
       <div className="mx-auto w-full max-w-3xl space-y-6">
         {restaurantId && cartCount > 0 ? (
           <div className="flex justify-end">
-            <Link
-              href={`/kiosk/${restaurantId}/confirm`}
-              className="rounded-full bg-slate-900 px-5 py-2 text-sm font-semibold uppercase tracking-wide text-white shadow transition hover:bg-slate-800"
-            >
+            <KioskActionButton href={`/kiosk/${restaurantId}/confirm`} className="px-5 py-2 text-sm uppercase tracking-wide">
               Place order
-            </Link>
+            </KioskActionButton>
           </div>
         ) : null}
         <CartDrawer inline />

--- a/pages/kiosk/[restaurantId]/confirm.tsx
+++ b/pages/kiosk/[restaurantId]/confirm.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
-import Link from 'next/link';
 import { useRouter } from 'next/router';
 import KioskLayout from '@/components/layouts/KioskLayout';
 import { supabase } from '@/lib/supabaseClient';
+import KioskActionButton from '@/components/kiosk/KioskActionButton';
 
 type Restaurant = {
   id: string;
@@ -57,19 +57,16 @@ export default function KioskConfirmPage() {
 
   return (
     <KioskLayout restaurantId={restaurantId} restaurant={restaurant}>
-      <div className="mx-auto w-full max-w-4xl rounded-3xl border border-slate-200 bg-white p-10 text-center shadow-xl">
-        <h2 className="text-3xl font-semibold tracking-tight text-slate-900">Order placed</h2>
-        <p className="mt-4 text-base text-slate-600">
+      <div className="mx-auto w-full max-w-4xl rounded-3xl border border-neutral-200 bg-white p-10 text-center shadow-xl">
+        <h2 className="text-3xl font-semibold tracking-tight text-neutral-900">Order placed</h2>
+        <p className="mt-4 text-base text-neutral-600">
           Your order is being prepared. Please wait for the staff to confirm your pickup number on screen.
         </p>
         {restaurantId ? (
           <div className="mt-8 flex justify-center">
-            <Link
-              href={`/kiosk/${restaurantId}/menu`}
-              className="rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold uppercase tracking-wide text-white shadow transition hover:bg-slate-800"
-            >
+            <KioskActionButton href={`/kiosk/${restaurantId}/menu`} className="px-6 py-3 text-sm uppercase tracking-wide">
               Start a new order
-            </Link>
+            </KioskActionButton>
           </div>
         ) : null}
       </div>

--- a/pages/kiosk/[restaurantId]/index.tsx
+++ b/pages/kiosk/[restaurantId]/index.tsx
@@ -50,7 +50,7 @@ export default function KioskHomePage() {
 
   return (
     <KioskLayout restaurantId={restaurantId} restaurant={restaurant} forceHome>
-      <div className="flex min-h-[50vh] items-center justify-center text-sm text-slate-500">
+      <div className="flex min-h-[50vh] items-center justify-center text-sm text-neutral-500">
         Preparing kiosk experience...
       </div>
     </KioskLayout>

--- a/pages/kiosk/[restaurantId]/menu.tsx
+++ b/pages/kiosk/[restaurantId]/menu.tsx
@@ -219,9 +219,9 @@ export default function KioskMenuPage() {
           {categorizedItems.map((category) => (
             <section key={category.id} className="flex flex-col gap-4">
               <header className="flex flex-col gap-1">
-                <h2 className="text-2xl font-semibold tracking-tight text-slate-900">{category.name}</h2>
+                <h2 className="text-2xl font-semibold tracking-tight text-neutral-900">{category.name}</h2>
                 {category.description ? (
-                  <p className="text-sm text-slate-600">{category.description}</p>
+                  <p className="text-sm text-neutral-600">{category.description}</p>
                 ) : null}
               </header>
               <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
@@ -241,7 +241,7 @@ export default function KioskMenuPage() {
           {hasUncategorizedItems ? (
             <section className="flex flex-col gap-4">
               <header>
-                <h2 className="text-2xl font-semibold tracking-tight text-slate-900">Other items</h2>
+                <h2 className="text-2xl font-semibold tracking-tight text-neutral-900">Other items</h2>
               </header>
               <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
                 {uncategorizedItems.map((item) => (
@@ -258,7 +258,7 @@ export default function KioskMenuPage() {
           ) : null}
 
           {!hasCategoryItems && !hasUncategorizedItems ? (
-            <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-8 text-center text-slate-600">
+            <div className="rounded-2xl border border-dashed border-neutral-300 bg-white p-8 text-center text-neutral-600">
               This menu is currently empty.
             </div>
           ) : null}

--- a/pages/kiosk/[restaurantId]/menu.tsx
+++ b/pages/kiosk/[restaurantId]/menu.tsx
@@ -6,7 +6,7 @@ import { supabase } from '@/lib/supabaseClient';
 import { ITEM_ADDON_LINK_WITH_GROUPS_SELECT } from '@/lib/queries/addons';
 import Skeleton from '@/components/ui/Skeleton';
 import { useCart } from '@/context/CartContext';
-import KioskCategoryTile from '@/components/kiosk/KioskCategoryTile';
+import KioskCategories from '@/components/kiosk/KioskCategories';
 
 type Category = {
   id: number;
@@ -54,6 +54,7 @@ export default function KioskMenuPage() {
   const [items, setItems] = useState<Item[]>([]);
   const [itemLinks, setItemLinks] = useState<ItemLink[]>([]);
   const [loading, setLoading] = useState(true);
+  const [activeCategoryId, setActiveCategoryId] = useState<number | null>(null);
   const scrollAnimationRef = useRef<number | null>(null);
   const lastScrollTargetRef = useRef<number | null>(null);
   const { cart } = useCart();
@@ -216,6 +217,7 @@ export default function KioskMenuPage() {
 
   const handleCategorySelect = useCallback((categoryId: number) => {
     if (categoryId === lastScrollTargetRef.current) return;
+    setActiveCategoryId(categoryId);
 
     const el = document.getElementById(`cat-${categoryId}`);
     if (!el) return;
@@ -265,11 +267,11 @@ export default function KioskMenuPage() {
       ) : (
         <div className="flex flex-col gap-10">
           {categorizedItems.length ? (
-            <div className="flex flex-col gap-3 sm:gap-4">
-              {categorizedItems.map((category) => (
-                <KioskCategoryTile key={category.id} category={category} onSelect={handleCategorySelect} />
-              ))}
-            </div>
+            <KioskCategories
+              categories={categorizedItems}
+              activeCategoryId={activeCategoryId}
+              onSelect={handleCategorySelect}
+            />
           ) : null}
           {categorizedItems.map((category) => (
             <section key={category.id} id={`cat-${category.id}`} className="flex flex-col gap-4">


### PR DESCRIPTION
## Summary
- restore the kiosk header on every surface, refresh the layout styling, and add a shared kiosk action button for consistent CTAs
- rework fullscreen handling with proactive requests, a user prompt modal, and auto-reentry when fullscreen changes
- brighten the kiosk experience by removing the dark theme remnants across home, menu, cart, and confirm screens

## Testing
- `SUPABASE_URL=https://example.supabase.co SUPABASE_SERVICE_ROLE_KEY=dummy NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy CI=1 npm run build`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691df8b9a7b8832584e87b90a36762c6)