### PR TITLE
Add currency setting + server-side add-on inline edits with autosave

### DIFF
--- a/components/AddonGroups.tsx
+++ b/components/AddonGroups.tsx
@@ -121,6 +121,7 @@ export default function AddonGroups({
   const brand = useBrand?.();
   const accent =
     typeof brand?.brand === 'string' && brand.brand ? brand.brand : '#EB2BB9';
+  const currencyCode = brand?.currencyCode;
 
   useEffect(() => {
     if (process.env.NODE_ENV === 'development') {
@@ -351,7 +352,7 @@ export default function AddonGroups({
                       <div className="font-medium">{option.name}</div>
                       {option.price && option.price > 0 && (
                         <div className="text-sm text-gray-500">
-                          +{formatPrice(option.price)}
+                          +{formatPrice(option.price, currencyCode)}
                         </div>
                       )}
 

--- a/components/AssignAddonGroupModal.tsx
+++ b/components/AssignAddonGroupModal.tsx
@@ -23,6 +23,7 @@ type AssignAddonGroupModalProps = {
   initialSelectedItemIds: string[];
   onClose: () => void;
   onSaved: (itemIds: string[], externalKeyMap: Record<string, string>) => void;
+  onAutosaveStatus?: (status: 'saving' | 'saved' | 'error', message?: string) => void;
 };
 
 function CategoryCheckbox({
@@ -76,6 +77,7 @@ export default function AssignAddonGroupModal({
   initialSelectedItemIds,
   onClose,
   onSaved,
+  onAutosaveStatus,
 }: AssignAddonGroupModalProps) {
   const normalizedItems = useMemo(
     () => items.map((it) => ({ ...it, id: String(it.id), category_id: it.category_id ? String(it.category_id) : null })),
@@ -158,6 +160,7 @@ export default function AssignAddonGroupModal({
   const saveAssignments = async () => {
     try {
       setSaving(true);
+      onAutosaveStatus?.('saving');
       const selectedIds = Array.from(selectedItems);
       const selectedItemRecords = normalizedItems.filter((item) => selectedIds.includes(item.id));
       const { externalKeyMap } = await updateAddonGroupAssignments({
@@ -166,9 +169,11 @@ export default function AssignAddonGroupModal({
         items: selectedItemRecords,
       });
       onSaved(selectedIds, externalKeyMap);
+      onAutosaveStatus?.('saved');
       onClose();
     } catch (error) {
       console.error('[assign-addon-group-modal] save failed', error);
+      onAutosaveStatus?.('error', 'Failed to save assignments');
       alert('Failed to save assignments. Please try again.');
     } finally {
       setSaving(false);

--- a/components/CartDrawer.tsx
+++ b/components/CartDrawer.tsx
@@ -6,6 +6,7 @@ import { Trash2 } from 'lucide-react';
 import PlateIcon from '@/components/icons/PlateIcon';
 import { randomEmptyPlateMessage } from '@/lib/uiCopy';
 import { formatPrice } from '@/lib/orderDisplay';
+import { useBrand } from '@/components/branding/BrandProvider';
 
 interface CartDrawerProps {
   /**
@@ -29,6 +30,8 @@ function CartContent({
   onInteraction?: () => void;
 }) {
   const { cart, subtotal, updateQuantity, removeFromCart, clearCart } = useCart();
+  const brand = useBrand?.();
+  const currencyCode = brand?.currencyCode;
 
   const handleRemove = (item_id: string) => {
     onInteraction?.();
@@ -74,8 +77,8 @@ function CartContent({
                 0
               );
               const itemTotal = item.price * item.quantity + addonsTotal;
-              const formattedItemTotal = formatPrice(itemTotal);
-              const formattedItemPrice = formatPrice(item.price);
+              const formattedItemTotal = formatPrice(itemTotal, currencyCode);
+              const formattedItemPrice = formatPrice(item.price, currencyCode);
               return (
                 <div
                   key={item.item_id}
@@ -95,7 +98,7 @@ function CartContent({
                             <li key={addon.option_id} className="flex justify-between gap-3">
                               <span className="flex-1">{addon.name} × {addon.quantity}</span>
                               <span className="font-medium text-slate-700">
-                                {formatPrice(addon.price * addon.quantity)}
+                                {formatPrice(addon.price * addon.quantity, currencyCode)}
                               </span>
                             </li>
                           ))}
@@ -164,7 +167,7 @@ function CartContent({
       ) : (
         <div className="flex items-center justify-between border-t px-4 py-3 text-sm text-slate-600">
           <span className="text-base font-semibold text-slate-900 sm:text-lg">
-            Subtotal: {formatPrice(subtotal)}
+            Subtotal: {formatPrice(subtotal, currencyCode)}
           </span>
           <button
             type="button"
@@ -184,7 +187,6 @@ export default function CartDrawer({ inline = false, onInteraction, mode = 'cust
   const { cart, subtotal } = useCart();
   const [emptyMessage] = useState(() => randomEmptyPlateMessage());
   const [open, setOpen] = useState(false);
-  const currency = 'GBP';
   const isKioskMode = mode === 'kiosk';
 
   const toggle = () => setOpen((o) => !o);
@@ -213,7 +215,7 @@ export default function CartDrawer({ inline = false, onInteraction, mode = 'cust
             <div className="flex items-center justify-between rounded-2xl bg-slate-50 px-4 py-3 text-slate-700 shadow-inner shadow-slate-100">
               <span className="text-base font-semibold text-slate-900 sm:text-lg">Subtotal</span>
               <span className="text-lg font-bold text-slate-900 sm:text-xl">
-                {formatPrice(subtotal)}
+                {formatPrice(subtotal, currencyCode)}
               </span>
             </div>
             <button

--- a/components/CartDrawer.tsx
+++ b/components/CartDrawer.tsx
@@ -187,6 +187,8 @@ export default function CartDrawer({ inline = false, onInteraction, mode = 'cust
   const { cart, subtotal } = useCart();
   const [emptyMessage] = useState(() => randomEmptyPlateMessage());
   const [open, setOpen] = useState(false);
+  const brand = useBrand?.();
+  const currencyCode = brand?.currencyCode || 'GBP';
   const isKioskMode = mode === 'kiosk';
 
   const toggle = () => setOpen((o) => !o);

--- a/components/MenuItemCard.tsx
+++ b/components/MenuItemCard.tsx
@@ -42,18 +42,21 @@ export default function MenuItemCard({
   restaurantLogoUrl,
   mode,
   onInteraction,
+  currencyCode,
 }: {
   item: MenuItem;
   restaurantId?: string | number;
   restaurantLogoUrl?: string | null;
   mode?: 'customer' | 'kiosk';
   onInteraction?: () => void;
+  currencyCode?: string | null;
 }) {
   const [showModal, setShowModal] = useState(false);
   const { addToCart } = useCart();
   const brand = useBrand?.();
   const accent =
     typeof brand?.brand === 'string' && brand.brand ? brand.brand : undefined;
+  const resolvedCurrencyCode = currencyCode ?? brand?.currencyCode;
   const sec = 'var(--brand-secondary, var(--brand-primary))';
   const [secText, setSecText] = useState('#fff');
   const [mix, setMix] = useState(false);
@@ -105,7 +108,7 @@ export default function MenuItemCard({
     return source ?? undefined;
   }, [item?.image_url]);
   const normalizedPrice = normalizePriceValue(price);
-  const formattedPrice = formatPrice(normalizedPrice);
+  const formattedPrice = formatPrice(normalizedPrice, resolvedCurrencyCode);
   const badges = useMemo(() => {
     const list: string[] = [];
     if (item?.is_vegan) list.push('Vegan');
@@ -391,4 +394,3 @@ export default function MenuItemCard({
     </>
   );
 }
-

--- a/components/branding/BrandProvider.tsx
+++ b/components/branding/BrandProvider.tsx
@@ -1,6 +1,7 @@
 // slides/brand: added
 import React, { createContext, useContext, useMemo } from 'react';
 import { useRouter } from 'next/router';
+import { normalizeCurrencyCode } from '@/lib/currency';
 
 type BrandCtx = {
   brand: string;
@@ -10,6 +11,7 @@ type BrandCtx = {
   initials: string;
   logoUrl?: string | null;
   logoShape?: string | null;
+  currencyCode: string;
 };
 const Ctx = createContext<BrandCtx | null>(null);
 
@@ -25,7 +27,13 @@ const hashHSL = (name: string) => {
 
 export const useBrand = (): BrandCtx => {
   // SSR-safe default if provider is missing
-  return React.useContext(Ctx) ?? { ...hashHSL('Restaurant'), name: 'Restaurant', initials: 'R', logoUrl: null };
+  return React.useContext(Ctx) ?? {
+    ...hashHSL('Restaurant'),
+    name: 'Restaurant',
+    initials: 'R',
+    logoUrl: null,
+    currencyCode: normalizeCurrencyCode(),
+  };
 };
 
 export const BrandProvider: React.FC<{
@@ -43,6 +51,7 @@ export const BrandProvider: React.FC<{
     'Restaurant';
   const logoUrl = (source as any)?.logo_url || qp('logo') || null;
   const logoShape = (source as any)?.logo_shape || null;
+  const currencyCode = normalizeCurrencyCode((source as any)?.currency_code || qp('currency'));
   const primary =
     (source as any)?.brand_primary_color ||
     (source as any)?.brand_color ||
@@ -64,8 +73,8 @@ export const BrandProvider: React.FC<{
     .toUpperCase() || 'R';
 
   const value = useMemo(
-    () => ({ ...colors, name, initials, logoUrl, logoShape }),
-    [colors.brand, colors.brand600, colors.brand700, name, initials, logoUrl, logoShape]
+    () => ({ ...colors, name, initials, logoUrl, logoShape, currencyCode }),
+    [colors.brand, colors.brand600, colors.brand700, name, initials, logoUrl, logoShape, currencyCode]
   );
 
   return (
@@ -91,4 +100,3 @@ export const BrandProvider: React.FC<{
 };
 
 export default BrandProvider;
-

--- a/components/customer/OrderDetailsModal.tsx
+++ b/components/customer/OrderDetailsModal.tsx
@@ -3,10 +3,13 @@ import OrderProgress from '@/components/customer/OrderProgress';
 import { randomCancelledMessage } from '@/lib/uiCopy';
 import { displayOrderNo, extractCancelReason, formatPrice } from '@/lib/orderDisplay';
 import { useRouter } from 'next/router';
+import { useBrand } from '@/components/branding/BrandProvider';
 
 export default function OrderDetailsModal({ order, onClose }: { order: any; onClose: () => void; }) {
   if (!order) return null;
   const router = useRouter();
+  const brand = useBrand?.();
+  const currencyCode = brand?.currencyCode;
   const qp = router?.query || {};
   const status = String(order?.status || 'pending').toLowerCase();
   const canCancel = !['accepted','ready','completed','cancelled'].includes(status);
@@ -69,7 +72,7 @@ export default function OrderDetailsModal({ order, onClose }: { order: any; onCl
                       {typeof it.quantity === 'number' && <span> × {it.quantity}</span>}
                     </span>
                     {typeof it.price === 'number' && (
-                      <span>{formatPrice(it.price)}</span>
+                      <span>{formatPrice(it.price, currencyCode)}</span>
                     )}
                   </div>
                   {it.notes && <div className="text-xs text-gray-500 mt-0.5">Notes: {it.notes}</div>}
@@ -78,7 +81,7 @@ export default function OrderDetailsModal({ order, onClose }: { order: any; onCl
                       {it.addons.map((a: any) => (
                         <li key={a.id} className="flex justify-between text-xs text-gray-700">
                           <span>{a.name ?? 'Addon'}{typeof a.quantity === 'number' && <> × {a.quantity}</>}</span>
-                          {typeof a.price === 'number' && <span>{formatPrice(a.price)}</span>}
+                          {typeof a.price === 'number' && <span>{formatPrice(a.price, currencyCode)}</span>}
                         </li>
                       ))}
                     </ul>
@@ -96,25 +99,25 @@ export default function OrderDetailsModal({ order, onClose }: { order: any; onCl
             {typeof order.itemSubtotal === 'number' && (
               <div className="flex justify-between">
                 <span className="text-gray-600">Items subtotal</span>
-                <span className="font-medium">{formatPrice(order.itemSubtotal)}</span>
+                <span className="font-medium">{formatPrice(order.itemSubtotal, currencyCode)}</span>
               </div>
             )}
             {typeof order.delivery_fee === 'number' && (
               <div className="flex justify-between">
                 <span className="text-gray-600">Delivery fee</span>
-                <span className="font-medium">{formatPrice(order.delivery_fee)}</span>
+                <span className="font-medium">{formatPrice(order.delivery_fee, currencyCode)}</span>
               </div>
             )}
             {typeof order.service_fee === 'number' && (
               <div className="flex justify-between">
                 <span className="text-gray-600">Service fee</span>
-                <span className="font-medium">{formatPrice(order.service_fee)}</span>
+                <span className="font-medium">{formatPrice(order.service_fee, currencyCode)}</span>
               </div>
             )}
             {typeof order.total_price === 'number' && (
               <div className="flex justify-between">
                 <span className="text-gray-800">Total</span>
-                <span className="font-semibold">{formatPrice(order.total_price)}</span>
+                <span className="font-semibold">{formatPrice(order.total_price, currencyCode)}</span>
               </div>
             )}
           </div>

--- a/components/modals/ItemModal.tsx
+++ b/components/modals/ItemModal.tsx
@@ -40,6 +40,7 @@ export default function ItemModal({ item, restaurantId, onAddToCart }: ItemModal
   const [mix, setMix] = useState(false);
   const brand = useBrand?.();
   const accent = typeof brand?.brand === 'string' && brand.brand ? brand.brand : undefined;
+  const currencyCode = brand?.currencyCode;
   const sec = 'var(--brand-secondary, var(--brand-primary))';
 
   useEffect(() => setMounted(true), []);
@@ -134,7 +135,7 @@ export default function ItemModal({ item, restaurantId, onAddToCart }: ItemModal
 
   const price = typeof item?.price === 'number' ? item.price : Number(item?.price || 0);
   const normalizedPrice = normalizePriceValue(price);
-  const formattedPrice = formatPrice(normalizedPrice);
+  const formattedPrice = formatPrice(normalizedPrice, currencyCode);
   const imageUrl = item?.image_url || undefined;
   const focalXRaw = typeof item?.menu_header_focal_x === 'number' ? item.menu_header_focal_x : undefined;
   const focalYRaw = typeof item?.menu_header_focal_y === 'number' ? item.menu_header_focal_y : undefined;

--- a/lib/currency.ts
+++ b/lib/currency.ts
@@ -1,0 +1,37 @@
+export const DEFAULT_CURRENCY_CODE = 'GBP';
+
+export function normalizeCurrencyCode(code?: string | null) {
+  if (typeof code === 'string' && code.trim()) {
+    return code.trim().toUpperCase();
+  }
+  return DEFAULT_CURRENCY_CODE;
+}
+
+export function formatCurrency(amount: number, currencyCode?: string | null) {
+  const normalizedCode = normalizeCurrencyCode(currencyCode);
+  try {
+    return new Intl.NumberFormat('en-GB', {
+      style: 'currency',
+      currency: normalizedCode,
+    }).format(amount);
+  } catch {
+    const numeric = Number(amount);
+    const safeAmount = Number.isFinite(numeric) ? numeric : 0;
+    return `${normalizedCode} ${safeAmount.toFixed(2)}`;
+  }
+}
+
+export function getCurrencySymbol(currencyCode?: string | null) {
+  const normalizedCode = normalizeCurrencyCode(currencyCode);
+  try {
+    const parts = new Intl.NumberFormat('en-GB', {
+      style: 'currency',
+      currency: normalizedCode,
+      currencyDisplay: 'symbol',
+    }).formatToParts(0);
+    const symbol = parts.find((part) => part.type === 'currency')?.value;
+    return symbol || normalizedCode;
+  } catch {
+    return normalizedCode;
+  }
+}

--- a/lib/orderDisplay.ts
+++ b/lib/orderDisplay.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_CURRENCY_CODE, formatCurrency } from './currency';
+
 export function displayOrderNo(order: any): string {
   // prefer explicit short/sequence numbers if present
   const n =
@@ -14,16 +16,9 @@ export function displayOrderNo(order: any): string {
   return `#${tail}`;
 }
 
-export function formatPrice(amount: number) {
+export function formatPrice(amount: number, currencyCode: string = DEFAULT_CURRENCY_CODE) {
   const normalized = normalizePriceValue(amount);
-  try {
-    return new Intl.NumberFormat('en-GB', {
-      style: 'currency',
-      currency: 'GBP',
-    }).format(normalized);
-  } catch {
-    return `£${Number(normalized).toFixed(2)}`;
-  }
+  return formatCurrency(normalized, currencyCode);
 }
 
 export function normalizePriceValue(amount: number) {

--- a/pages/dashboard/website/settings.tsx
+++ b/pages/dashboard/website/settings.tsx
@@ -27,6 +27,7 @@ export default function WebsitePage() {
   const [brandPrimary, setBrandPrimary] = useState('#008080');
   const [brandSecondary, setBrandSecondary] = useState('#004c4c');
   const [logoShape, setLogoShape] = useState<'square' | 'round' | 'rectangular'>('square');
+  const [currencyCode, setCurrencyCode] = useState('GBP');
   const [colorExtracted, setColorExtracted] = useState(false);
   const [autoAcceptKioskOrders, setAutoAcceptKioskOrders] = useState(false);
   const [autoAcceptAppOrders, setAutoAcceptAppOrders] = useState(false);
@@ -84,6 +85,7 @@ export default function WebsitePage() {
           setAutoAcceptKioskOrders(!!rest.auto_accept_kiosk_orders);
           setAutoAcceptAppOrders(!!rest.auto_accept_app_orders);
           setAutoAcceptPosOrders(!!rest.auto_accept_pos_orders);
+          setCurrencyCode(rest.currency_code || 'GBP');
         }
         const { data: contact } = await supabase
           .from('website_contact_settings')
@@ -231,6 +233,7 @@ export default function WebsitePage() {
         auto_accept_kiosk_orders: autoAcceptKioskOrders,
         auto_accept_app_orders: autoAcceptAppOrders,
         auto_accept_pos_orders: autoAcceptPosOrders,
+        currency_code: currencyCode,
       })
       .eq('id', restaurantId);
     const { error: contactErr } = await supabase
@@ -355,6 +358,18 @@ export default function WebsitePage() {
                 <option value="square">Square</option>
                 <option value="round">Round</option>
                 <option value="rectangular">Rectangular</option>
+              </select>
+            </div>
+            <div>
+              <label className="block font-semibold">Currency</label>
+              <select
+                value={currencyCode}
+                onChange={(e) => setCurrencyCode(e.target.value)}
+                className="mt-1 w-full border border-gray-300 rounded p-2"
+              >
+                <option value="GBP">GBP (£)</option>
+                <option value="EUR">EUR (€)</option>
+                <option value="USD">USD ($)</option>
               </select>
             </div>
             <div>

--- a/pages/kiosk/[restaurantId]/cart.tsx
+++ b/pages/kiosk/[restaurantId]/cart.tsx
@@ -26,6 +26,7 @@ type Restaurant = {
   auto_accept_kiosk_orders?: boolean | null;
   auto_accept_app_orders?: boolean | null;
   auto_accept_pos_orders?: boolean | null;
+  currency_code?: string | null;
 };
 
 type KioskOrderRaceResult =
@@ -64,6 +65,7 @@ function KioskCartScreen({ restaurantId }: { restaurantId?: string | null }) {
   const { resetKioskToStart, registerActivity } = useKioskSession();
   const cartCount = cart.items.reduce((sum, it) => sum + it.quantity, 0);
   const [restaurant, setRestaurant] = useState<Restaurant | null>(null);
+  const currencyCode = restaurant?.currency_code || undefined;
   const [placingOrder, setPlacingOrder] = useState(false);
   const [showLoadingOverlay, setShowLoadingOverlay] = useState(false);
   const placeOrderDisabled = cartCount === 0 || placingOrder;
@@ -144,7 +146,7 @@ function KioskCartScreen({ restaurantId }: { restaurantId?: string | null }) {
         const { data, error } = await supabase
           .from('restaurants')
           .select(
-            'id,name,website_title,website_description,logo_url,theme_primary_color,menu_header_image_url,menu_header_image_updated_at,menu_header_focal_x,menu_header_focal_y,auto_accept_kiosk_orders,auto_accept_app_orders,auto_accept_pos_orders'
+            'id,name,website_title,website_description,logo_url,theme_primary_color,menu_header_image_url,menu_header_image_updated_at,menu_header_focal_x,menu_header_focal_y,auto_accept_kiosk_orders,auto_accept_app_orders,auto_accept_pos_orders,currency_code'
           )
           .eq('id', restaurantId)
           .maybeSingle();
@@ -449,7 +451,7 @@ function KioskCartScreen({ restaurantId }: { restaurantId?: string | null }) {
           <div className="mx-auto flex w-full max-w-5xl flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4 sm:py-3.5">
             <div className="flex flex-1 flex-col gap-1 text-slate-900">
               <span className="text-[11px] uppercase tracking-[0.12em] text-slate-500">Subtotal</span>
-              <span className="text-xl font-semibold sm:text-2xl">{formatPrice(subtotal)}</span>
+              <span className="text-xl font-semibold sm:text-2xl">{formatPrice(subtotal, currencyCode)}</span>
               <span className="text-xs text-slate-500 sm:text-sm">Includes items and add-ons</span>
             </div>
             <div className="flex-1 sm:flex-none sm:w-80">

--- a/pages/restaurant/index.tsx
+++ b/pages/restaurant/index.tsx
@@ -93,7 +93,7 @@ export const getServerSideProps: GetServerSideProps = async ctx => {
   if (id) {
     const { data } = await supaServer
       .from('restaurants')
-      .select('id,website_title,name,logo_url,logo_shape,brand_primary_color,brand_secondary_color,cover_image_url,website_description')
+      .select('id,website_title,name,logo_url,logo_shape,brand_primary_color,brand_secondary_color,cover_image_url,website_description,currency_code')
       .eq('id', id)
       .maybeSingle();
     initialBrand = data;
@@ -102,4 +102,3 @@ export const getServerSideProps: GetServerSideProps = async ctx => {
     props: { initialBrand },
   };
 };
-

--- a/pages/restaurant/menu.tsx
+++ b/pages/restaurant/menu.tsx
@@ -35,6 +35,7 @@ interface Restaurant {
   menu_header_focal_x?: number | null;
   menu_header_focal_y?: number | null;
   menu_header_image_updated_at?: string | null;
+  currency_code?: string | null;
 }
 
 interface Category {
@@ -292,6 +293,7 @@ export default function RestaurantMenuPage({ initialBrand }: { initialBrand: any
                     item={item}
                     restaurantId={effectiveRestaurantId as string}
                     restaurantLogoUrl={restaurant?.logo_url ?? null}
+                    currencyCode={restaurant?.currency_code ?? undefined}
                   />
                 </div>
               ))}
@@ -428,7 +430,7 @@ export const getServerSideProps: GetServerSideProps = async ctx => {
   if (id) {
     const { data } = await supaServer
       .from('restaurants')
-      .select('id,website_title,name,logo_url,logo_shape,brand_primary_color,brand_secondary_color')
+      .select('id,website_title,name,logo_url,logo_shape,brand_primary_color,brand_secondary_color,currency_code')
       .eq('id', id)
       .maybeSingle();
     initialBrand = data;

--- a/pages/restaurant/more.tsx
+++ b/pages/restaurant/more.tsx
@@ -94,11 +94,10 @@ export const getServerSideProps: GetServerSideProps = async ctx => {
   if (id) {
     const { data } = await supaServer
       .from('restaurants')
-      .select('id,website_title,name,logo_url,logo_shape,brand_primary_color,brand_secondary_color')
+      .select('id,website_title,name,logo_url,logo_shape,brand_primary_color,brand_secondary_color,currency_code')
       .eq('id', id)
       .maybeSingle()
     initialBrand = data
   }
   return { props: { initialBrand } }
 }
-

--- a/pages/restaurant/orders.tsx
+++ b/pages/restaurant/orders.tsx
@@ -240,7 +240,7 @@ export const getServerSideProps: GetServerSideProps = async ctx => {
   if (id) {
     const { data } = await supaServer
       .from('restaurants')
-      .select('id,website_title,name,logo_url,logo_shape,brand_primary_color,brand_secondary_color')
+      .select('id,website_title,name,logo_url,logo_shape,brand_primary_color,brand_secondary_color,currency_code')
       .eq('id', id)
       .maybeSingle()
     initialBrand = data

--- a/supabase/migrations/20251210120000_add_currency_code_to_restaurants.sql
+++ b/supabase/migrations/20251210120000_add_currency_code_to_restaurants.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.restaurants
+ADD COLUMN IF NOT EXISTS currency_code text NOT NULL DEFAULT 'GBP';

--- a/utils/updateAddonGroupAssignments.ts
+++ b/utils/updateAddonGroupAssignments.ts
@@ -1,17 +1,7 @@
-import { supabase } from './supabaseClient';
-import { ensureItemExternalKey } from './updateItemAddonLinks';
-
 type AssignmentItem = {
   id: string;
   external_key?: string | null;
 };
-
-function generateId() {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return crypto.randomUUID();
-  }
-  return `${Date.now()}-${Math.random()}`;
-}
 
 export async function updateAddonGroupAssignments({
   restaurantId,
@@ -27,108 +17,22 @@ export async function updateAddonGroupAssignments({
   }
 
   const uniqueItems = Array.from(new Map(items.map((item) => [String(item.id), item])).values());
-
-  const externalKeyMap: Record<string, string> = {};
-
-  for (const item of uniqueItems) {
-    const normalizedId = String(item.id);
-    if (item.external_key) {
-      externalKeyMap[normalizedId] = String(item.external_key);
-      continue;
-    }
-    const { restaurantId: itemRestaurantId, externalKey } = await ensureItemExternalKey(normalizedId);
-    if (String(itemRestaurantId) !== String(restaurantId)) {
-      throw new Error('Item does not belong to the current restaurant');
-    }
-    externalKeyMap[normalizedId] = externalKey;
-  }
-
-  console.info('[addon-assignments:drafts:delete]', { restaurantId, groupId, itemCount: uniqueItems.length });
-
-  const { error: deleteError } = await supabase
-    .from('item_addon_links_drafts')
-    .delete()
-    .eq('restaurant_id', restaurantId)
-    .eq('group_id', groupId);
-
-  if (deleteError) {
-    console.error('[addon-assignments:drafts:delete:error]', deleteError.message);
-    throw deleteError;
-  }
-
-  const rows = uniqueItems.map((item) => {
-    const normalizedId = String(item.id);
-    const externalKey = externalKeyMap[normalizedId];
-    return {
-      id: generateId(),
-      restaurant_id: restaurantId,
-      item_id: normalizedId,
-      item_external_key: externalKey,
-      group_id: groupId,
-      state: 'draft',
-    };
+  const response = await fetch('/api/menu-builder', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      restaurantId,
+      action: 'assign_addon_group',
+      groupId,
+      items: uniqueItems,
+    }),
   });
 
-  if (rows.length) {
-    const { error: insertError } = await supabase.from('item_addon_links_drafts').insert(rows);
-    if (insertError) {
-      console.error('[addon-assignments:drafts:insert:error]', insertError.message, { rows: rows.length });
-      throw insertError;
-    }
+  const json = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const msg = json?.message || json?.error || 'Failed to save assignments';
+    throw new Error(msg);
   }
 
-  console.info('[addon-assignments:drafts:inserted]', { groupId, inserted: rows.length });
-
-  const itemIds = uniqueItems.map((item) => String(item.id));
-
-  const { data: draftGroup, error: draftGroupError } = await supabase
-    .from('addon_groups_drafts')
-    .select('name')
-    .eq('id', groupId)
-    .eq('restaurant_id', restaurantId)
-    .maybeSingle();
-
-  if (draftGroupError) {
-    console.error('[addon-assignments:live:load-draft]', draftGroupError.message);
-  }
-
-  if (draftGroup?.name) {
-    const { data: liveGroup, error: liveGroupError } = await supabase
-      .from('addon_groups')
-      .select('id')
-      .eq('restaurant_id', restaurantId)
-      .eq('name', draftGroup.name)
-      .is('archived_at', null)
-      .maybeSingle();
-
-    if (liveGroupError) {
-      console.error('[addon-assignments:live:load]', liveGroupError.message);
-    }
-
-    if (liveGroup?.id && itemIds.length) {
-      const { error: deleteLiveError } = await supabase
-        .from('item_addon_links')
-        .delete()
-        .eq('group_id', liveGroup.id)
-        .in('item_id', itemIds);
-
-      if (deleteLiveError) {
-        console.error('[addon-assignments:live:delete]', deleteLiveError.message);
-      }
-
-      const liveRows = itemIds.map((itemId) => ({ item_id: itemId, group_id: liveGroup.id }));
-
-      const { error: liveInsertError } = await supabase
-        .from('item_addon_links')
-        .upsert(liveRows, { onConflict: 'item_id,group_id' });
-
-      if (liveInsertError) {
-        console.error('[addon-assignments:live:insert]', liveInsertError.message);
-      } else {
-        console.info('[addon-assignments:live:saved]', { groupId: liveGroup.id, items: liveRows.length });
-      }
-    }
-  }
-
-  return { externalKeyMap };
+  return { externalKeyMap: json?.externalKeyMap || {} };
 }


### PR DESCRIPTION
### Motivation

- Provide a per-restaurant currency setting so prices render using the correct currency instead of hardcoded symbols.
- Use a single shared formatter to ensure currency formatting is consistent across Menu Builder and customer pages.
- Keep all add‑on writes server‑side and integrate them into the existing menu drafts/publish workflow so Publish enables when add‑on drafts change.
- Provide a faster inline add‑item UX in Add‑ons with autosave feedback matching the Menu Builder save lifecycle.

### Description

- Database and settings: add migration `supabase/migrations/20251210120000_add_currency_code_to_restaurants.sql` to add `restaurants.currency_code` and wire a dropdown in `pages/dashboard/website/settings.tsx` that upserts `currency_code` on save.
- Currency utilities and wiring: add `lib/currency.ts` with `formatCurrency`, `normalizeCurrencyCode`, and `getCurrencySymbol`, update `lib/orderDisplay.ts` to use the formatter and thread `currencyCode` through `BrandProvider` (`currencyCode`) and into UI components (`MenuItemCard`, `ItemModal`, `CartDrawer`, `AddonGroups`, `OrderDetailsModal`, kiosk/checkout pages, and `pages/dashboard/menu-builder.tsx`).
- Server-side add-ons: extend the existing `pages/api/menu-builder.ts` endpoint to accept `POST` actions for add‑on operations (`create_addon_group`, `update_addon_group`, `delete_addon_group`, `duplicate_addon_group`, `reorder_addon_groups`, `create_addon_option`, `update_addon_option`, `delete_addon_option`, `reorder_addon_options`, `assign_addon_group`) and to optionally return published add‑on groups via `includePublishedAddons` so draft vs published comparisons are possible.
- Addons UI + save flows: overhaul `components/AddonsTab.tsx` so the client no longer writes directly with client Supabase calls for option/group CRUD; instead it creates an inline draft row for `Add item`, focuses inputs, persists via the `menu-builder` API (`POST` actions), shows autosave toast feedback via `onToastMessage`/`showAutosaveStatus`, prevents multiple blank rows, and debounces autosave indicators to avoid spam.
- Assignment and publish integration: `utils/updateAddonGroupAssignments.ts` now calls the `menu-builder` API to save draft assignments and returns the external key map; menu draft loading in `pages/dashboard/menu-builder.tsx` now fetches both draft and published add‑on groups and includes add‑on diffs in `hasBuildChanges` so Publish is enabled when add‑on drafts differ from published state.

### Testing

- Automated tests: none were executed as part of this rollout (no CI/test run was requested). 
- Notes: changes are limited to wiring and migrations; the server route `POST /api/menu-builder` reuses the existing service-role Supabase client and respects `restaurant_id` scoping and `archived_at IS NULL` filters.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e8dd61f488325a44b3614733e1757)