### PR TITLE
fix(menu-manager): kiosk skeletons, header name and add-on quantity pricing

### DIFF
--- a/components/CartDrawer.tsx
+++ b/components/CartDrawer.tsx
@@ -72,11 +72,12 @@ function CartContent({
         ) : (
           <div className="space-y-3.5 sm:space-y-4">
             {cart.items.map((item) => {
+              const itemQuantity = item.quantity;
               const addonsTotal = (item.addons || []).reduce(
-                (sum, a) => sum + a.price * a.quantity,
+                (sum, a) => sum + a.price * a.quantity * itemQuantity,
                 0
               );
-              const itemTotal = item.price * item.quantity + addonsTotal;
+              const itemTotal = item.price * itemQuantity + addonsTotal;
               const formattedItemTotal = formatPrice(itemTotal, currencyCode);
               const formattedItemPrice = formatPrice(item.price, currencyCode);
               return (
@@ -94,14 +95,17 @@ function CartContent({
                       </div>
                       {item.addons && item.addons.length > 0 && (
                         <ul className="space-y-0.5 pl-4 text-base text-slate-600 sm:text-lg">
-                          {item.addons.map((addon) => (
-                            <li key={addon.option_id} className="flex justify-between gap-3">
-                              <span className="flex-1">{addon.name} × {addon.quantity}</span>
-                              <span className="font-medium text-slate-700">
-                                {formatPrice(addon.price * addon.quantity, currencyCode)}
-                              </span>
-                            </li>
-                          ))}
+                          {item.addons.map((addon) => {
+                            const addonQuantity = addon.quantity * itemQuantity;
+                            return (
+                              <li key={addon.option_id} className="flex justify-between gap-3">
+                                <span className="flex-1">{addon.name} × {addonQuantity}</span>
+                                <span className="font-medium text-slate-700">
+                                  {formatPrice(addon.price * addonQuantity, currencyCode)}
+                                </span>
+                              </li>
+                            );
+                          })}
                         </ul>
                       )}
                       {item.notes && (

--- a/components/DashboardLayout.tsx
+++ b/components/DashboardLayout.tsx
@@ -142,7 +142,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   const highlight = 'text-teal-600';
 
   return (
-    <div className="min-h-screen flex bg-gray-100">
+    <div className="min-h-screen bg-gray-100 md:flex">
       {/* Mobile sidebar overlay */}
       <div
         className={`fixed inset-0 bg-black/40 z-40 md:hidden transition-opacity${open ? ' opacity-100' : ' opacity-0 pointer-events-none'}`}
@@ -300,7 +300,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
       </aside>
 
       {/* Main content */}
-      <main className={`flex-1 p-6 transition-all ${collapsed ? 'md:ml-20' : 'md:ml-60'}`}
+      <main className={`w-full flex-1 p-6 transition-all ${collapsed ? 'md:ml-20' : 'md:ml-60'}`}
       >
         {/* Mobile toggle button */}
         <button

--- a/components/DashboardLayout.tsx
+++ b/components/DashboardLayout.tsx
@@ -142,7 +142,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   const highlight = 'text-teal-600';
 
   return (
-    <div className="min-h-screen bg-gray-100 md:flex">
+    <div className="min-h-screen bg-gray-100">
       {/* Mobile sidebar overlay */}
       <div
         className={`fixed inset-0 bg-black/40 z-40 md:hidden transition-opacity${open ? ' opacity-100' : ' opacity-0 pointer-events-none'}`}
@@ -300,7 +300,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
       </aside>
 
       {/* Main content */}
-      <main className={`w-full flex-1 p-6 transition-all ${collapsed ? 'md:ml-20' : 'md:ml-60'}`}
+      <main className={`w-full flex-1 p-6 transition-all ${collapsed ? 'md:pl-20' : 'md:pl-60'}`}
       >
         {/* Mobile toggle button */}
         <button

--- a/components/kiosk/HomeScreen.tsx
+++ b/components/kiosk/HomeScreen.tsx
@@ -22,6 +22,7 @@ interface HomeScreenProps {
   restaurant: KioskRestaurant | null;
   onStart: () => void;
   fadingOut?: boolean;
+  loading?: boolean;
 }
 
 function formatImageUrl(url?: string | null, updatedAt?: string | null) {
@@ -32,7 +33,8 @@ function formatImageUrl(url?: string | null, updatedAt?: string | null) {
   return `${normalized}?v=${ts}`;
 }
 
-export default function HomeScreen({ restaurant, onStart, fadingOut }: HomeScreenProps) {
+export default function HomeScreen({ restaurant, onStart, fadingOut, loading }: HomeScreenProps) {
+  const showSkeleton = Boolean(loading);
   const kioskHero = useMemo(
     () => formatImageUrl(restaurant?.kiosk_hero_image_url, restaurant?.kiosk_hero_image_updated_at),
     [restaurant?.kiosk_hero_image_updated_at, restaurant?.kiosk_hero_image_url]
@@ -47,7 +49,7 @@ export default function HomeScreen({ restaurant, onStart, fadingOut }: HomeScree
 
   const logoUrl = useMemo(() => normalizeSource(restaurant?.logo_url), [restaurant?.logo_url]);
 
-  const backgroundImage = heroUrl;
+  const backgroundImage = showSkeleton ? null : heroUrl;
 
   const focalX = restaurant?.menu_header_focal_x ?? 0.5;
   const focalY = restaurant?.menu_header_focal_y ?? 0.5;
@@ -62,10 +64,10 @@ export default function HomeScreen({ restaurant, onStart, fadingOut }: HomeScree
     >
       <div className="absolute inset-0 overflow-hidden">
         <div
-          className="absolute inset-0"
+          className={`absolute inset-0 ${showSkeleton ? 'animate-pulse' : ''}`}
           style={{
             backgroundImage: backgroundImage ? `url(${backgroundImage})` : undefined,
-            backgroundColor: backgroundImage ? undefined : '#f8fafc',
+            backgroundColor: showSkeleton ? '#e5e7eb' : backgroundImage ? undefined : '#f8fafc',
             backgroundSize: 'cover',
             backgroundPosition: `${focalX * 100}% ${focalY * 100}%`,
           }}
@@ -77,7 +79,9 @@ export default function HomeScreen({ restaurant, onStart, fadingOut }: HomeScree
         <div className="w-full rounded-[32px] border border-neutral-200 bg-white/95 p-8 shadow-2xl shadow-neutral-300/50 backdrop-blur">
           <div className="flex flex-col items-center gap-4">
             <div className="relative h-24 w-24 overflow-hidden rounded-full border border-neutral-200 bg-white shadow-lg shadow-neutral-200">
-              {logoUrl ? (
+              {showSkeleton ? (
+                <div className="h-full w-full rounded-full bg-neutral-200/80 animate-pulse" />
+              ) : logoUrl ? (
                 <Image
                   src={logoUrl}
                   alt={restaurant?.name || 'Restaurant logo'}
@@ -92,12 +96,21 @@ export default function HomeScreen({ restaurant, onStart, fadingOut }: HomeScree
               )}
             </div>
             <div className="space-y-1">
-              <h1 className="text-3xl font-semibold leading-tight text-neutral-900 sm:text-4xl">
-                {restaurant?.website_title || restaurant?.name || 'Restaurant'}
-              </h1>
-              {restaurant?.website_description ? (
-                <p className="text-base text-neutral-600 sm:text-lg">{restaurant.website_description}</p>
-              ) : null}
+              {showSkeleton ? (
+                <div className="flex flex-col items-center gap-2">
+                  <div className="h-8 w-52 rounded-full bg-neutral-200/80 animate-pulse sm:h-9 sm:w-64" />
+                  <div className="h-4 w-40 rounded-full bg-neutral-200/70 animate-pulse sm:w-48" />
+                </div>
+              ) : (
+                <>
+                  <h1 className="text-3xl font-semibold leading-tight text-neutral-900 sm:text-4xl">
+                    {restaurant?.website_title || restaurant?.name || 'Restaurant'}
+                  </h1>
+                  {restaurant?.website_description ? (
+                    <p className="text-base text-neutral-600 sm:text-lg">{restaurant.website_description}</p>
+                  ) : null}
+                </>
+              )}
             </div>
           </div>
 

--- a/lib/orderDisplay.ts
+++ b/lib/orderDisplay.ts
@@ -49,7 +49,7 @@ export function calculateCartTotals(
       for (const addon of item.addons) {
         const addonPrice = Number(addon?.price) || 0;
         const addonQty = Number(addon?.quantity) || 0;
-        addonSubtotal += addonPrice * addonQty;
+        addonSubtotal += addonPrice * addonQty * quantity;
       }
     }
   }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -4,6 +4,7 @@ export default function Document() {
   return (
     <Html>
       <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
         <link
           rel="apple-touch-icon"

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -281,11 +281,12 @@ export default function CheckoutPage() {
               <h2 className="text-lg font-semibold mb-2">Order Summary</h2>
               <ul className="space-y-4">
                 {cart.items.map((item) => {
+                  const itemQuantity = item.quantity;
                   const addonsTotal = (item.addons || []).reduce(
-                    (sum, a) => sum + a.price * a.quantity,
+                    (sum, a) => sum + a.price * a.quantity * itemQuantity,
                     0
                   );
-                  const total = item.price * item.quantity + addonsTotal;
+                  const total = item.price * itemQuantity + addonsTotal;
                   return (
                     <li key={item.item_id} className="border rounded p-3 text-sm">
                     <div className="flex justify-between">
@@ -296,14 +297,17 @@ export default function CheckoutPage() {
                     </div>
                       {item.addons && item.addons.length > 0 && (
                         <ul className="mt-2 space-y-1 pl-4 text-gray-600">
-                          {item.addons.map((a) => (
-                            <li key={a.option_id} className="flex justify-between">
-                              <span>
-                                {a.name} × {a.quantity}
-                              </span>
-                              <span>{formatAmount(a.price * a.quantity)}</span>
-                            </li>
-                          ))}
+                          {item.addons.map((a) => {
+                            const addonQuantity = a.quantity * itemQuantity;
+                            return (
+                              <li key={a.option_id} className="flex justify-between">
+                                <span>
+                                  {a.name} × {addonQuantity}
+                                </span>
+                                <span>{formatAmount(a.price * addonQuantity)}</span>
+                              </li>
+                            );
+                          })}
                         </ul>
                       )}
                       {item.notes && (

--- a/pages/dashboard/menu-builder.tsx
+++ b/pages/dashboard/menu-builder.tsx
@@ -795,7 +795,7 @@ export default function MenuBuilder() {
 
       {/* Tab bar */}
       <div className="border-b border-gray-200 mb-4">
-        <nav className="flex space-x-4 overflow-x-auto">
+        <nav className="flex flex-wrap gap-2 sm:flex-nowrap sm:gap-4 sm:overflow-x-auto">
           {[
             { key: 'menu', label: 'Menu' },
             { key: 'addons', label: 'Addons' },

--- a/pages/dashboard/menu-builder.tsx
+++ b/pages/dashboard/menu-builder.tsx
@@ -1037,8 +1037,8 @@ export default function MenuBuilder() {
                     <SortableWrapper key={cat.id} id={cat.id}>
                       {({ setNodeRef, style, attributes, listeners }) => (
                         <div ref={setNodeRef} style={style} className="bg-white rounded-xl shadow mb-4">
-                          <div className="flex items-start justify-between p-4">
-                            <div className="flex items-start space-x-3">
+                          <div className="flex flex-col gap-3 p-4 sm:flex-row sm:items-start sm:justify-between">
+                            <div className="flex items-start gap-3">
                               <span
                                 {...attributes}
                                 {...listeners}
@@ -1047,7 +1047,7 @@ export default function MenuBuilder() {
                                 ☰
                               </span>
                               <div>
-                                <div className="flex items-center space-x-2">
+                                <div className="flex flex-wrap items-center gap-2">
                                   <h2 className="font-semibold text-lg">{cat.name}</h2>
                                   <span className="text-xs bg-gray-200 rounded-full px-2">
                                     {buildItems.filter((i) => i.category_id === cat.id).length}
@@ -1058,7 +1058,7 @@ export default function MenuBuilder() {
                                 )}
                               </div>
                             </div>
-                            <div className="flex items-center space-x-2">
+                            <div className="flex flex-wrap items-center gap-2">
                               <button
                                 onClick={() => toggleCollapse(cat.id)}
                                 className="p-2 rounded hover:bg-gray-100"
@@ -1128,9 +1128,9 @@ export default function MenuBuilder() {
                                             <div ref={setNodeRef} style={style}>
                                               <div
                                                 onClick={() => handleItemClick(item)}
-                                                className="bg-gray-50 rounded-lg p-3 flex items-start justify-between cursor-pointer"
+                                                className="bg-gray-50 rounded-lg p-3 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between cursor-pointer"
                                               >
-                                                <div className="flex items-start space-x-2 overflow-hidden">
+                                                <div className="flex items-start gap-2 overflow-hidden">
                                                   <span
                                                     {...attributes}
                                                     {...listeners}
@@ -1152,7 +1152,7 @@ export default function MenuBuilder() {
                                                     <p className="text-xs text-gray-500 truncate">{item.description}</p>
                                                   </div>
                                                 </div>
-                                                <div className="flex items-center space-x-2">
+                                                <div className="flex items-center gap-2">
                                                   <span className="text-sm font-medium">
                                                     {formatCurrency(item.price ?? 0, currencyCode)}
                                                   </span>

--- a/pages/dashboard/menu-builder.tsx
+++ b/pages/dashboard/menu-builder.tsx
@@ -895,11 +895,11 @@ export default function MenuBuilder() {
             transition={{ duration: 0.2 }}
           >
             <div className="mb-6">
-              <div className="flex items-center justify-between">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <h2 className="text-2xl font-bold flex items-center gap-2">
                   <span role="img" aria-label="plates">🍽️</span> Live Menu
                 </h2>
-                <div className="flex items-center space-x-3">
+                <div className="flex flex-wrap items-center gap-2 sm:gap-3">
                   <button onClick={expandAll} className="p-2 rounded hover:bg-gray-200" aria-label="Expand all">
                     <ChevronDownIcon className="w-5 h-5" />
                   </button>
@@ -922,8 +922,8 @@ export default function MenuBuilder() {
               <div>
                 {categories.map((cat) => (
                   <div key={cat.id} className="bg-white rounded-xl shadow mb-4">
-                    <div className="flex items-start justify-between p-4">
-                      <div>
+                    <div className="flex flex-col gap-3 p-4 sm:flex-row sm:items-start sm:justify-between">
+                      <div className="min-w-0">
                         <div className="flex items-center space-x-2">
                           <h2 className="font-semibold text-lg">{cat.name}</h2>
                           <span className="text-xs bg-gray-200 rounded-full px-2">

--- a/pages/dashboard/menu-builder.tsx
+++ b/pages/dashboard/menu-builder.tsx
@@ -924,7 +924,7 @@ export default function MenuBuilder() {
                   <div key={cat.id} className="bg-white rounded-xl shadow mb-4">
                     <div className="flex flex-col gap-3 p-4 sm:flex-row sm:items-start sm:justify-between">
                       <div className="min-w-0">
-                        <div className="flex items-center space-x-2">
+                        <div className="flex min-w-0 items-center space-x-2">
                           <h2 className="font-semibold text-lg">{cat.name}</h2>
                           <span className="text-xs bg-gray-200 rounded-full px-2">
                             {items.filter((i) => i.category_id === cat.id).length}
@@ -949,19 +949,19 @@ export default function MenuBuilder() {
                     </div>
                     {!collapsedCats.has(cat.id) && (
                       <div className="px-4 pb-4">
-                        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">
-                          {items
-                            .filter((item) => item.category_id === cat.id)
-                            .sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0))
-                            .map((item) => (
-                              <MenuItemCard
-                                key={item.id}
-                                item={item}
-                                restaurantId={restaurantId!}
-                                currencyCode={currencyCode}
-                              />
-                            ))}
-                        </div>
+                          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                            {items
+                              .filter((item) => item.category_id === cat.id)
+                              .sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0))
+                              .map((item) => (
+                                <MenuItemCard
+                                  key={item.id}
+                                  item={item}
+                                  restaurantId={restaurantId!}
+                                  currencyCode={currencyCode}
+                                />
+                              ))}
+                          </div>
                       </div>
                     )}
                   </div>
@@ -1038,7 +1038,7 @@ export default function MenuBuilder() {
                       {({ setNodeRef, style, attributes, listeners }) => (
                         <div ref={setNodeRef} style={style} className="bg-white rounded-xl shadow mb-4">
                           <div className="flex flex-col gap-3 p-4 sm:flex-row sm:items-start sm:justify-between">
-                            <div className="flex items-start gap-3">
+                            <div className="flex min-w-0 items-start gap-3">
                               <span
                                 {...attributes}
                                 {...listeners}
@@ -1046,9 +1046,9 @@ export default function MenuBuilder() {
                               >
                                 ☰
                               </span>
-                              <div>
-                                <div className="flex flex-wrap items-center gap-2">
-                                  <h2 className="font-semibold text-lg">{cat.name}</h2>
+                              <div className="min-w-0">
+                                <div className="flex min-w-0 flex-wrap items-center gap-2">
+                                  <h2 className="truncate font-semibold text-lg">{cat.name}</h2>
                                   <span className="text-xs bg-gray-200 rounded-full px-2">
                                     {buildItems.filter((i) => i.category_id === cat.id).length}
                                   </span>
@@ -1130,7 +1130,7 @@ export default function MenuBuilder() {
                                                 onClick={() => handleItemClick(item)}
                                                 className="bg-gray-50 rounded-lg p-3 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between cursor-pointer"
                                               >
-                                                <div className="flex items-start gap-2 overflow-hidden">
+                                                <div className="flex min-w-0 items-start gap-2 overflow-hidden">
                                                   <span
                                                     {...attributes}
                                                     {...listeners}
@@ -1147,7 +1147,7 @@ export default function MenuBuilder() {
                                                       />
                                                     )}
                                                   </div>
-                                                  <div className="truncate">
+                                                  <div className="min-w-0">
                                                     <p className="font-semibold truncate text-sm">{item.name}</p>
                                                     <p className="text-xs text-gray-500 truncate">{item.description}</p>
                                                   </div>

--- a/pages/dashboard/menu-builder.tsx
+++ b/pages/dashboard/menu-builder.tsx
@@ -814,7 +814,7 @@ export default function MenuBuilder() {
       </div>
 
       {activeTab === 'build' && (
-        <div className="mb-6 flex flex-wrap items-center justify-between gap-2">
+        <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
           <div className="flex flex-wrap items-center gap-2">
             <button
               onClick={() => {
@@ -851,7 +851,7 @@ export default function MenuBuilder() {
           <button
             onClick={publishLiveMenu}
             disabled={!restaurantId || !hasBuildChanges || publishing}
-            className="flex items-center bg-teal-600 text-white px-3 py-2 rounded-lg hover:bg-teal-700 disabled:opacity-50"
+            className="flex items-center bg-teal-600 text-white px-3 py-2 rounded-lg hover:bg-teal-700 disabled:opacity-50 sm:self-auto"
           >
             Publish Changes
           </button>
@@ -859,12 +859,12 @@ export default function MenuBuilder() {
       )}
 
       {activeTab === 'build' && (
-        <div className="mb-6 flex items-center justify-between">
-          <div className="flex items-center text-sm text-gray-500 space-x-2">
+        <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-wrap items-center gap-2 text-sm text-gray-500">
             <ArrowsUpDownIcon className="w-4 h-4" />
             <span>Drag categories and items to reorder</span>
           </div>
-          <div className="flex items-center space-x-3">
+          <div className="flex flex-wrap items-center gap-2 sm:gap-3">
             <button onClick={expandAll} className="p-2 rounded hover:bg-gray-200" aria-label="Expand all">
               <ChevronDownIcon className="w-5 h-5" />
             </button>

--- a/pages/kiosk/[restaurantId]/cart.tsx
+++ b/pages/kiosk/[restaurantId]/cart.tsx
@@ -65,6 +65,7 @@ function KioskCartScreen({ restaurantId }: { restaurantId?: string | null }) {
   const { resetKioskToStart, registerActivity } = useKioskSession();
   const cartCount = cart.items.reduce((sum, it) => sum + it.quantity, 0);
   const [restaurant, setRestaurant] = useState<Restaurant | null>(null);
+  const [restaurantLoading, setRestaurantLoading] = useState(true);
   const currencyCode = restaurant?.currency_code || undefined;
   const [placingOrder, setPlacingOrder] = useState(false);
   const [showLoadingOverlay, setShowLoadingOverlay] = useState(false);
@@ -138,10 +139,17 @@ function KioskCartScreen({ restaurantId }: { restaurantId?: string | null }) {
   }, []);
 
   useEffect(() => {
+    if (!restaurantId) {
+      setRestaurantLoading(false);
+    }
+  }, [restaurantId]);
+
+  useEffect(() => {
     if (!restaurantId) return;
     let active = true;
 
     const load = async () => {
+      setRestaurantLoading(true);
       try {
         const { data, error } = await supabase
           .from('restaurants')
@@ -159,6 +167,8 @@ function KioskCartScreen({ restaurantId }: { restaurantId?: string | null }) {
       } catch (err) {
         if (!active) return;
         console.error('[kiosk] failed to load restaurant info', err);
+      } finally {
+        if (active) setRestaurantLoading(false);
       }
     };
 
@@ -436,6 +446,7 @@ function KioskCartScreen({ restaurantId }: { restaurantId?: string | null }) {
     <KioskLayout
       restaurantId={restaurantId}
       restaurant={restaurant}
+      restaurantLoading={restaurantLoading}
       cartCount={cartCount}
       customHeaderContent={headerContent}
     >

--- a/pages/kiosk/[restaurantId]/confirm.tsx
+++ b/pages/kiosk/[restaurantId]/confirm.tsx
@@ -35,6 +35,7 @@ export default function KioskConfirmPage() {
 function KioskConfirmScreen({ restaurantId }: { restaurantId?: string | null }) {
   const router = useRouter();
   const [restaurant, setRestaurant] = useState<Restaurant | null>(null);
+  const [restaurantLoading, setRestaurantLoading] = useState(true);
   const { resetKioskToStart } = useKioskSession();
   const resetTimeoutRef = useRef<number | null>(null);
   const tempOrderNumber = useMemo(() => {
@@ -47,10 +48,17 @@ function KioskConfirmScreen({ restaurantId }: { restaurantId?: string | null }) 
   const [displayOrderNumber, setDisplayOrderNumber] = useState<number | null>(null);
 
   useEffect(() => {
+    if (!restaurantId) {
+      setRestaurantLoading(false);
+    }
+  }, [restaurantId]);
+
+  useEffect(() => {
     if (!restaurantId) return;
     let active = true;
 
     const load = async () => {
+      setRestaurantLoading(true);
       try {
         const { data, error } = await supabase
           .from('restaurants')
@@ -68,6 +76,8 @@ function KioskConfirmScreen({ restaurantId }: { restaurantId?: string | null }) 
       } catch (err) {
         if (!active) return;
         console.error('[kiosk] failed to load restaurant info', err);
+      } finally {
+        if (active) setRestaurantLoading(false);
       }
     };
 
@@ -145,7 +155,12 @@ function KioskConfirmScreen({ restaurantId }: { restaurantId?: string | null }) 
   }, [resetAfterOrderPlaced]);
 
   return (
-    <KioskLayout restaurantId={restaurantId} restaurant={restaurant} customHeaderContent={minimalHeader}>
+    <KioskLayout
+      restaurantId={restaurantId}
+      restaurant={restaurant}
+      restaurantLoading={restaurantLoading}
+      customHeaderContent={minimalHeader}
+    >
       <div className="mx-auto flex min-h-[70vh] w-full max-w-2xl flex-col items-center justify-center px-4 py-10 sm:py-14">
         <div className="w-full rounded-[32px] border border-neutral-200 bg-white/95 px-7 py-10 text-center shadow-2xl shadow-neutral-300/40 backdrop-blur sm:px-9 sm:py-12">
           <div className="mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-emerald-50 text-emerald-600 shadow-[0_15px_50px_-30px_rgba(16,185,129,0.9)]">

--- a/pages/kiosk/[restaurantId]/index.tsx
+++ b/pages/kiosk/[restaurantId]/index.tsx
@@ -23,12 +23,20 @@ export default function KioskHomePage() {
 
 function KioskHomeScreen({ restaurantId }: { restaurantId?: string | null }) {
   const [restaurant, setRestaurant] = useState<RestaurantRow | null>(null);
+  const [restaurantLoading, setRestaurantLoading] = useState(true);
+
+  useEffect(() => {
+    if (!restaurantId) {
+      setRestaurantLoading(false);
+    }
+  }, [restaurantId]);
 
   useEffect(() => {
     if (!restaurantId) return;
     let active = true;
 
     const load = async () => {
+      setRestaurantLoading(true);
       try {
         const { data, error } = await supabase
           .from('restaurants')
@@ -48,6 +56,8 @@ function KioskHomeScreen({ restaurantId }: { restaurantId?: string | null }) {
       } catch (err) {
         if (!active) return;
         console.error('[kiosk] failed to load restaurant info', err);
+      } finally {
+        if (active) setRestaurantLoading(false);
       }
     };
 
@@ -59,7 +69,12 @@ function KioskHomeScreen({ restaurantId }: { restaurantId?: string | null }) {
   }, [restaurantId]);
 
   return (
-    <KioskLayout restaurantId={restaurantId} restaurant={restaurant} forceHome>
+    <KioskLayout
+      restaurantId={restaurantId}
+      restaurant={restaurant}
+      restaurantLoading={restaurantLoading}
+      forceHome
+    >
       <div className="flex min-h-[50vh] items-center justify-center text-sm text-neutral-500">
         Preparing kiosk experience...
       </div>

--- a/pages/kiosk/[restaurantId]/menu.tsx
+++ b/pages/kiosk/[restaurantId]/menu.tsx
@@ -65,6 +65,7 @@ export default function KioskMenuPage() {
 
 function KioskMenuScreen({ restaurantId }: { restaurantId?: string | null }) {
   const [restaurant, setRestaurant] = useState<Restaurant | null>(null);
+  const [restaurantLoading, setRestaurantLoading] = useState(true);
   const [categories, setCategories] = useState<Category[]>([]);
   const [items, setItems] = useState<Item[]>([]);
   const [itemLinks, setItemLinks] = useState<ItemLink[]>([]);
@@ -77,6 +78,7 @@ function KioskMenuScreen({ restaurantId }: { restaurantId?: string | null }) {
   useEffect(() => {
     if (!restaurantId) {
       setLoading(false);
+      setRestaurantLoading(false);
     }
   }, [restaurantId]);
 
@@ -86,6 +88,7 @@ function KioskMenuScreen({ restaurantId }: { restaurantId?: string | null }) {
 
     const load = async () => {
       setLoading(true);
+      setRestaurantLoading(true);
 
       try {
         const restPromise = supabase
@@ -197,7 +200,10 @@ function KioskMenuScreen({ restaurantId }: { restaurantId?: string | null }) {
       } catch (error) {
         console.error('[kiosk] failed to load menu', error);
       } finally {
-        if (active) setLoading(false);
+        if (active) {
+          setLoading(false);
+          setRestaurantLoading(false);
+        }
       }
     };
 
@@ -272,6 +278,7 @@ function KioskMenuScreen({ restaurantId }: { restaurantId?: string | null }) {
     <KioskLayout
       restaurantId={restaurantId}
       restaurant={restaurant}
+      restaurantLoading={restaurantLoading}
       cartCount={cartCount}
       categoryBar={
         categorizedItems.length ? (


### PR DESCRIPTION
### Motivation
- Improve kiosk UX by showing neutral skeleton placeholders while restaurant assets load to avoid stock placeholder flicker and layout shifts.
- Ensure the kiosk header and home screen show the real restaurant title (prefer `website_title` then `name`) rather than hardcoded/demo text during and after load.
- Fix incorrect add-on math so add-on costs scale with the parent item quantity everywhere totals are calculated and displayed.
- Restore small, non-invasive layout adjustments to bring back mobile responsiveness to the Menu Builder "Menu" tab.

### Description
- Kiosk loading placeholders: added a `loading`/`restaurantLoading` flow and pulse skeletons for the Tap-to-Order home screen and the kiosk header, avoiding showing stock placeholders until data arrives by gating background image/logo rendering while loading; wired `restaurantLoading` through `KioskLayout` and kiosk pages (`pages/kiosk/*`).
- Header text and branding: prefer `website_title` then `name` for header/title display and render skeletons while loading to avoid flicker and hardcoded fallbacks.
- Add-on pricing fixes: updated `calculateCartTotals` in `lib/orderDisplay.ts` to multiply add-on totals by the parent item `quantity`, and updated `CartDrawer` and `checkout` summary presentations to use scaled add-on quantities/prices so cart line totals, subtotal, and checkout summary reflect `(addonPrice * addonQtyPerItem) * itemQty`.
- Menu Builder mobile layout: adjusted the Menu tab header and category card layout markup to allow stacking/wrapping on small screens (minor CSS/structure changes only) to restore previous mobile behaviour.

### Testing
- Ran `npm run build` to validate typecheck and build pipeline and it failed due to missing server env: `Error: Missing SUPABASE_URL for server Supabase client` (build aborted); this is an environment configuration issue rather than a code compile error.
- Started dev server (`next dev`) and produced a kiosk home smoke screenshot to verify skeletons render during slow/initial load in a local dev run (dev compile succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971fc0c21b08325aa40091d6b161d60)