### PR TITLE
feat(kod): reuse Live Orders reject flow and header controls; restore open-order regression

### DIFF
--- a/components/BreakCountdown.tsx
+++ b/components/BreakCountdown.tsx
@@ -3,9 +3,16 @@ import { useEffect, useState } from 'react';
 interface BreakCountdownProps {
   breakUntil: string;
   onEnd: () => void;
+  variant?: 'dashboard' | 'kod';
+  className?: string;
 }
 
-export default function BreakCountdown({ breakUntil, onEnd }: BreakCountdownProps) {
+export default function BreakCountdown({
+  breakUntil,
+  onEnd,
+  variant = 'dashboard',
+  className = '',
+}: BreakCountdownProps) {
   const [timeLeft, setTimeLeft] = useState<number>(
     new Date(breakUntil).getTime() - Date.now()
   );
@@ -34,11 +41,22 @@ export default function BreakCountdown({ breakUntil, onEnd }: BreakCountdownProp
     minute: '2-digit',
   });
 
+  const baseClass =
+    variant === 'kod'
+      ? 'rounded-xl border border-rose-400/40 bg-rose-500/10 px-3 py-2 text-rose-100 shadow-lg shadow-black/30 backdrop-blur'
+      : 'bg-red-100 text-red-800 font-bold rounded p-2 mb-2 inline-block';
+
+  const labelClass = variant === 'kod' ? 'text-[10px]' : 'text-sm';
+  const timeClass = variant === 'kod' ? 'text-base' : 'text-lg';
+  const subClass = variant === 'kod' ? 'text-[10px]' : 'text-xs font-normal';
+
   return (
-    <div className="bg-red-100 text-red-800 font-bold rounded p-2 mb-2 inline-block">
-      <div className="text-sm">On Break</div>
-      <div className="text-lg">{String(mins).padStart(2, '0')}:{String(secs).padStart(2, '0')}</div>
-      <div className="text-xs font-normal">Resumes at {resumeAt}</div>
+    <div className={`${baseClass} ${className}`}>
+      <div className={labelClass}>On Break</div>
+      <div className={timeClass}>
+        {String(mins).padStart(2, '0')}:{String(secs).padStart(2, '0')}
+      </div>
+      <div className={subClass}>Resumes at {resumeAt}</div>
     </div>
   );
 }

--- a/components/BreakModal.tsx
+++ b/components/BreakModal.tsx
@@ -4,17 +4,30 @@ interface BreakModalProps {
   show: boolean;
   onClose: () => void;
   onSelect: (mins: number) => void;
+  variant?: 'dashboard' | 'kod';
 }
 
-export default function BreakModal({ show, onClose, onSelect }: BreakModalProps) {
+export default function BreakModal({
+  show,
+  onClose,
+  onSelect,
+  variant = 'dashboard',
+}: BreakModalProps) {
   if (!show) return null;
+  const isKod = variant === 'kod';
   return (
     <div
-      className="fixed inset-0 bg-black/30 flex items-start justify-center pt-20 z-[1000]"
+      className={`fixed inset-0 flex items-start justify-center pt-20 z-[1000] ${
+        isKod ? 'bg-black/60' : 'bg-black/30'
+      }`}
       onClick={(e) => e.target === e.currentTarget && onClose()}
     >
       <div
-        className="bg-white rounded-xl shadow-lg p-4 w-72"
+        className={`w-72 rounded-2xl p-4 shadow-2xl ${
+          isKod
+            ? 'border border-white/10 bg-neutral-950 text-white shadow-black/40'
+            : 'bg-white text-neutral-900'
+        }`}
         onClick={(e) => e.stopPropagation()}
       >
         <h3 className="text-lg font-semibold mb-3">Take a Break</h3>
@@ -22,11 +35,16 @@ export default function BreakModal({ show, onClose, onSelect }: BreakModalProps)
           {[10, 20, 30, 60].map((m) => (
             <button
               key={m}
+              type="button"
               onClick={() => {
                 onSelect(m);
                 onClose();
               }}
-              className="px-3 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+              className={`px-3 py-2 text-sm font-semibold rounded-xl transition ${
+                isKod
+                  ? 'border border-white/10 bg-white/5 text-white hover:bg-white/10'
+                  : 'bg-blue-600 text-white hover:bg-blue-700'
+              }`}
             >
               {m} min
             </button>

--- a/components/OrderDetailsModal.tsx
+++ b/components/OrderDetailsModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import RejectOrderModal from './RejectOrderModal';
+import OrderRejectButton from './OrderRejectButton';
 import { formatPrice } from '@/lib/orderDisplay';
 
 interface OrderAddon {
@@ -54,9 +55,6 @@ const formatAddress = (addr: any) => {
 export default function OrderDetailsModal({ order, onClose, onUpdateStatus }: Props) {
   const overlayRef = useRef<HTMLDivElement | null>(null);
   const [showReject, setShowReject] = useState(false);
-  const lastTap = useRef<number>(0);
-  const [showRejectHint, setShowRejectHint] = useState(false);
-  const hintTimer = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     if (!order) return;
@@ -131,7 +129,7 @@ export default function OrderDetailsModal({ order, onClose, onUpdateStatus }: Pr
             )}
           </div>
           <ul className="space-y-3 text-sm">
-            {order.order_items.map((it) => (
+            {(order.order_items ?? []).map((it) => (
               <li key={it.id} className="border rounded-lg p-3">
                 <div className="flex justify-between">
                   <span className="font-semibold">
@@ -198,41 +196,13 @@ export default function OrderDetailsModal({ order, onClose, onUpdateStatus }: Pr
               ) : null;
             })()}
             {!kioskOrder && !['completed', 'cancelled', 'rejected'].includes(order.status) && (
-              <div className="relative">
-                <button
-                  type="button"
-                  onClick={() => {
-                    const now = Date.now();
-                    if (now - lastTap.current < 500) {
-                      if (hintTimer.current) clearTimeout(hintTimer.current);
-                      setShowRejectHint(false);
-                      setShowReject(true);
-                    } else {
-                      lastTap.current = now;
-                      setShowRejectHint(true);
-                      if (hintTimer.current) clearTimeout(hintTimer.current);
-                      hintTimer.current = setTimeout(() => setShowRejectHint(false), 1800);
-                    }
-                  }}
-                  onDoubleClick={() => setShowReject(true)}
-                  className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
-                >
-                  {order.status === 'pending' ? 'Reject' : 'Cancel'}
-                </button>
-                <div
-                  className={`absolute -top-8 right-0 text-xs transition-opacity duration-300 ${
-                    showRejectHint ? 'opacity-100' : 'opacity-0 pointer-events-none'
-                  }`}
-                  role="tooltip"
-                >
-                  <div className="relative bg-white rounded shadow px-2 py-1">
-                    {order.status === 'pending'
-                      ? 'Double tap to reject'
-                      : 'Double tap to cancel'}
-                    <div className="absolute left-1/2 -bottom-1 w-2 h-2 bg-white rotate-45 shadow -translate-x-1/2"></div>
-                  </div>
-                </div>
-              </div>
+              <OrderRejectButton
+                status={order.status}
+                onConfirm={() => setShowReject(true)}
+                buttonClassName="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
+                tooltipBubbleClassName="bg-white text-gray-900"
+                tooltipArrowClassName="bg-white shadow"
+              />
             )}
           </div>
         </div>

--- a/components/OrderRejectButton.tsx
+++ b/components/OrderRejectButton.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface OrderRejectButtonProps {
+  status: string;
+  onConfirm: () => void;
+  disabled?: boolean;
+  buttonClassName?: string;
+  tooltipClassName?: string;
+  tooltipBubbleClassName?: string;
+  tooltipArrowClassName?: string;
+}
+
+export default function OrderRejectButton({
+  status,
+  onConfirm,
+  disabled = false,
+  buttonClassName = '',
+  tooltipClassName = '',
+  tooltipBubbleClassName = '',
+  tooltipArrowClassName = '',
+}: OrderRejectButtonProps) {
+  const lastTap = useRef<number>(0);
+  const [showRejectHint, setShowRejectHint] = useState(false);
+  const hintTimer = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (hintTimer.current) {
+        clearTimeout(hintTimer.current);
+      }
+    };
+  }, []);
+
+  const label = status === 'pending' ? 'Reject' : 'Cancel';
+  const hintText = status === 'pending' ? 'Double tap to reject' : 'Double tap to cancel';
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => {
+          if (disabled) return;
+          const now = Date.now();
+          if (now - lastTap.current < 500) {
+            if (hintTimer.current) clearTimeout(hintTimer.current);
+            setShowRejectHint(false);
+            onConfirm();
+          } else {
+            lastTap.current = now;
+            setShowRejectHint(true);
+            if (hintTimer.current) clearTimeout(hintTimer.current);
+            hintTimer.current = setTimeout(() => setShowRejectHint(false), 1800);
+          }
+        }}
+        onDoubleClick={() => {
+          if (disabled) return;
+          onConfirm();
+        }}
+        disabled={disabled}
+        className={buttonClassName}
+      >
+        {label}
+      </button>
+      <div
+        className={`absolute -top-8 right-0 text-xs transition-opacity duration-300 ${
+          showRejectHint ? 'opacity-100' : 'opacity-0 pointer-events-none'
+        } ${tooltipClassName}`}
+        role="tooltip"
+      >
+        <div
+          className={`relative rounded px-2 py-1 shadow ${tooltipBubbleClassName}`}
+        >
+          {hintText}
+          <div
+            className={`absolute left-1/2 -bottom-1 h-2 w-2 -translate-x-1/2 rotate-45 ${tooltipArrowClassName}`}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/RejectOrderModal.tsx
+++ b/components/RejectOrderModal.tsx
@@ -1,15 +1,43 @@
 import { useState } from 'react';
 import { supabase } from '../utils/supabaseClient';
-import { Order } from './OrderDetailsModal';
+
+export interface RejectOrderAddon {
+  id: number;
+  option_id: number;
+  name: string;
+  quantity: number;
+}
+
+export interface RejectOrderItem {
+  id: number;
+  item_id: number;
+  name: string;
+  quantity: number;
+  notes?: string | null;
+  order_addons: RejectOrderAddon[];
+}
+
+export interface RejectableOrder {
+  id: string;
+  status: string;
+  order_items: RejectOrderItem[];
+}
 
 interface Props {
-  order: Order;
+  order: RejectableOrder;
   show: boolean;
   onClose: () => void;
   onRejected: (status: string) => void;
+  tone?: 'dashboard' | 'kod';
 }
 
-export default function RejectOrderModal({ order, show, onClose, onRejected }: Props) {
+export default function RejectOrderModal({
+  order,
+  show,
+  onClose,
+  onRejected,
+  tone = 'dashboard',
+}: Props) {
   const [reason, setReason] = useState('Item out of stock');
   const [message, setMessage] = useState('');
   const [itemIds, setItemIds] = useState<Set<number>>(new Set());
@@ -60,90 +88,206 @@ export default function RejectOrderModal({ order, show, onClose, onRejected }: P
     }
   };
 
+  const isKod = tone === 'kod';
+  const reasonOptions = [
+    'Item out of stock',
+    'Closing early',
+    'Problem in the kitchen',
+    'Other',
+  ];
+
   return (
     <div
-      className="fixed inset-0 bg-black/40 flex items-center justify-center p-4 z-[1000]"
+      className={`fixed inset-0 z-[1000] flex items-center justify-center p-4 ${
+        isKod ? 'bg-black/70' : 'bg-black/40'
+      }`}
       onClick={(e) => e.target === e.currentTarget && onClose()}
     >
       <div
-        className="bg-white rounded-xl shadow-lg w-full max-w-sm sm:max-w-md overflow-hidden"
+        className={`w-full max-w-lg overflow-hidden rounded-2xl shadow-2xl ${
+          isKod
+            ? 'border border-white/10 bg-neutral-950 text-white shadow-black/50'
+            : 'bg-white text-neutral-900'
+        }`}
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="bg-gray-100 px-4 py-2 font-bold text-center">
+        <div
+          className={`px-6 py-4 text-center text-sm font-semibold uppercase tracking-[0.3em] ${
+            isKod ? 'border-b border-white/10 text-neutral-200' : 'bg-neutral-100 text-neutral-700'
+          }`}
+        >
           {order.status === 'pending' ? 'Reject Order' : 'Cancel Order'}
         </div>
-        <div className="p-4 space-y-4 text-sm">
-          <div className="space-y-2 bg-gray-50 p-3 rounded">
-            <p className="font-medium">Reason for rejecting</p>
-            {['Item out of stock', 'Closing early', 'Problem in the kitchen', 'Other'].map((r) => (
-              <label key={r} className="flex items-center space-x-2">
-                <input
-                  type="radio"
-                  name="reason"
-                  value={r}
-                  checked={reason === r}
-                  onChange={() => setReason(r)}
-                />
-                <span>{r}</span>
-              </label>
-            ))}
+        <div className="space-y-6 px-6 py-5 text-sm">
+          <div className="space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-400">
+              Reason
+            </p>
+            <div className="grid gap-3">
+              {reasonOptions.map((r) => (
+                <label
+                  key={r}
+                  className={`flex cursor-pointer items-center gap-3 rounded-xl border px-4 py-3 transition ${
+                    reason === r
+                      ? isKod
+                        ? 'border-teal-400/60 bg-teal-500/10 text-white'
+                        : 'border-teal-500/40 bg-teal-50'
+                      : isKod
+                      ? 'border-white/10 bg-white/5 text-neutral-200 hover:bg-white/10'
+                      : 'border-neutral-200 bg-white hover:bg-neutral-50'
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="reason"
+                    value={r}
+                    checked={reason === r}
+                    onChange={() => setReason(r)}
+                    className="sr-only"
+                  />
+                  <span
+                    className={`flex h-5 w-5 items-center justify-center rounded-full border ${
+                      reason === r
+                        ? isKod
+                          ? 'border-teal-300 bg-teal-400 text-black'
+                          : 'border-teal-500 bg-teal-500 text-white'
+                        : isKod
+                        ? 'border-white/20'
+                        : 'border-neutral-300'
+                    }`}
+                  >
+                    <span
+                      className={`h-2.5 w-2.5 rounded-full ${
+                        reason === r ? 'bg-current' : 'bg-transparent'
+                      }`}
+                    />
+                  </span>
+                  <span className="text-base font-medium">{r}</span>
+                </label>
+              ))}
+            </div>
           </div>
           {reason === 'Item out of stock' && (
-            <div className="space-y-2 bg-gray-50 p-3 rounded">
-              <p className="font-medium">Mark items out of stock</p>
-              <ul className="space-y-1">
+            <div className="space-y-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-400">
+                Mark items out of stock
+              </p>
+              <div
+                className={`space-y-4 rounded-2xl border p-4 ${
+                  isKod ? 'border-white/10 bg-white/5' : 'border-neutral-200 bg-neutral-50'
+                }`}
+              >
                 {order.order_items.map((it) => (
-                  <li key={it.id} className="ml-2 space-y-1">
-                    <label className="flex items-center space-x-2">
+                  <div key={it.id} className="space-y-2">
+                    <label className="flex cursor-pointer items-center gap-3">
                       <input
                         type="checkbox"
                         checked={itemIds.has(it.item_id)}
                         onChange={() => toggleItem(it.item_id)}
+                        className="sr-only"
                       />
-                      <span className="font-medium">{it.name}</span>
+                      <span
+                        className={`flex h-5 w-5 items-center justify-center rounded border ${
+                          itemIds.has(it.item_id)
+                            ? isKod
+                              ? 'border-teal-300 bg-teal-400 text-black'
+                              : 'border-teal-500 bg-teal-500 text-white'
+                            : isKod
+                            ? 'border-white/20'
+                            : 'border-neutral-300'
+                        }`}
+                      >
+                        <span
+                          className={`h-2.5 w-2.5 rounded-sm ${
+                            itemIds.has(it.item_id) ? 'bg-current' : 'bg-transparent'
+                          }`}
+                        />
+                      </span>
+                      <div className="flex-1">
+                        <p className="text-base font-semibold">{it.name}</p>
+                        <p className="text-xs text-neutral-400">Qty {it.quantity}</p>
+                      </div>
                     </label>
                     {it.order_addons.length > 0 && (
-                      <ul className="ml-6 space-y-1">
+                      <div
+                        className={`grid gap-2 rounded-xl border border-dashed p-3 sm:grid-cols-2 ${
+                          isKod ? 'border-white/10' : 'border-neutral-200'
+                        }`}
+                      >
                         {it.order_addons.map((ad) => (
-                          <li key={ad.id}>
-                            <label className="flex items-center space-x-2">
-                              <input
-                                type="checkbox"
-                                checked={addonIds.has(ad.option_id)}
-                                onChange={() => toggleAddon(ad.option_id)}
+                          <label
+                            key={ad.id}
+                            className="flex cursor-pointer items-center gap-2"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={addonIds.has(ad.option_id)}
+                              onChange={() => toggleAddon(ad.option_id)}
+                              className="sr-only"
+                            />
+                            <span
+                              className={`flex h-4 w-4 items-center justify-center rounded border ${
+                                addonIds.has(ad.option_id)
+                                  ? isKod
+                                    ? 'border-amber-300 bg-amber-300 text-black'
+                                    : 'border-amber-500 bg-amber-500 text-white'
+                                  : isKod
+                                  ? 'border-white/20'
+                                  : 'border-neutral-300'
+                              }`}
+                            >
+                              <span
+                                className={`h-2 w-2 rounded-sm ${
+                                  addonIds.has(ad.option_id) ? 'bg-current' : 'bg-transparent'
+                                }`}
                               />
-                              <span>{ad.name}</span>
-                            </label>
-                          </li>
+                            </span>
+                            <span className="text-sm">{ad.name}</span>
+                          </label>
                         ))}
-                      </ul>
+                      </div>
                     )}
-                  </li>
+                  </div>
                 ))}
-              </ul>
+              </div>
             </div>
           )}
-          <div className="space-y-1">
-            <label className="block text-sm font-medium mb-1">Custom message (optional)</label>
+          <div className="space-y-2">
+            <label className="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-400">
+              Customer message (optional)
+            </label>
             <textarea
-              className="w-full border rounded-md p-2 min-h-[6rem]"
+              className={`min-h-[7rem] w-full rounded-xl border px-3 py-2 text-sm outline-none transition ${
+                isKod
+                  ? 'border-white/10 bg-black/60 text-white placeholder:text-neutral-500 focus:border-teal-400/60'
+                  : 'border-neutral-200 bg-white text-neutral-900 focus:border-teal-500'
+              }`}
               rows={4}
               value={message}
               onChange={(e) => setMessage(e.target.value)}
+              placeholder="Add a note for the customer..."
             />
           </div>
-          <div className="flex flex-col sm:flex-row justify-end gap-2 pt-2 relative">
+          <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
             <button
               type="button"
               onClick={onClose}
-              className="px-4 py-2 border border-red-600 text-red-600 rounded hover:bg-red-50 w-full sm:w-auto"
+              className={`px-4 py-2 text-sm font-semibold rounded-xl transition ${
+                isKod
+                  ? 'border border-white/10 bg-white/5 text-white hover:bg-white/10'
+                  : 'border border-neutral-300 text-neutral-700 hover:bg-neutral-100'
+              }`}
             >
               Cancel
             </button>
             <button
               type="button"
               onClick={handleConfirm}
-              className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 w-full sm:w-auto"
+              className={`px-4 py-2 text-sm font-semibold rounded-xl transition ${
+                isKod
+                  ? 'bg-rose-500 text-white hover:bg-rose-400'
+                  : 'bg-red-600 text-white hover:bg-red-700'
+              }`}
               disabled={saving}
             >
               {saving

--- a/hooks/useRestaurantAvailability.ts
+++ b/hooks/useRestaurantAvailability.ts
@@ -1,0 +1,121 @@
+import { useCallback, useEffect, useState } from 'react';
+import { supabase } from '@/lib/supabaseClient';
+
+export function useRestaurantAvailability(restaurantId?: string | null) {
+  const [isOpen, setIsOpen] = useState<boolean | null>(null);
+  const [breakUntil, setBreakUntil] = useState<string | null>(null);
+  const [showBreakModal, setShowBreakModal] = useState(false);
+
+  useEffect(() => {
+    if (!restaurantId) return;
+    const load = async () => {
+      const { data, error } = await supabase
+        .from('restaurants')
+        .select('is_open, break_until')
+        .eq('id', restaurantId)
+        .single();
+      if (!error && data) {
+        setIsOpen(data.is_open);
+        setBreakUntil(data.break_until);
+      }
+    };
+    load();
+  }, [restaurantId]);
+
+  const endBreak = useCallback(async () => {
+    if (!restaurantId) return;
+    const { error } = await supabase
+      .from('restaurants')
+      .update({ is_open: true, break_until: null })
+      .eq('id', restaurantId);
+    if (!error) {
+      setIsOpen(true);
+      setBreakUntil(null);
+    }
+  }, [restaurantId]);
+
+  const startBreak = useCallback(
+    async (mins: number) => {
+      if (!restaurantId) return;
+      const until = new Date(Date.now() + mins * 60000).toISOString();
+      const { error } = await supabase
+        .from('restaurants')
+        .update({ is_open: false, break_until: until })
+        .eq('id', restaurantId);
+      if (!error) {
+        setIsOpen(false);
+        setBreakUntil(until);
+      }
+    },
+    [restaurantId]
+  );
+
+  const toggleOpen = useCallback(async () => {
+    if (!restaurantId || isOpen === null) return;
+    if (!isOpen && breakUntil && new Date(breakUntil).getTime() > Date.now()) {
+      await endBreak();
+      return;
+    }
+    const newState = !isOpen;
+    const { error } = await supabase
+      .from('restaurants')
+      .update({ is_open: newState })
+      .eq('id', restaurantId);
+    if (!error) {
+      setIsOpen(newState);
+    }
+  }, [breakUntil, endBreak, isOpen, restaurantId]);
+
+  useEffect(() => {
+    if (!breakUntil) return;
+    if (new Date(breakUntil).getTime() <= Date.now()) {
+      void endBreak();
+      return;
+    }
+    const timer = setInterval(() => {
+      if (breakUntil && new Date(breakUntil).getTime() <= Date.now()) {
+        void endBreak();
+      }
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [breakUntil, endBreak]);
+
+  useEffect(() => {
+    if (!restaurantId) return;
+    const channel = supabase
+      .channel('restaurant-' + restaurantId)
+      .on(
+        'postgres_changes',
+        {
+          event: 'UPDATE',
+          schema: 'public',
+          table: 'restaurants',
+          filter: `id=eq.${restaurantId}`,
+        },
+        (payload) => {
+          const newRow = payload.new as { is_open?: boolean | null; break_until?: string | null };
+          if (typeof newRow.is_open === 'boolean') {
+            setIsOpen(newRow.is_open);
+          }
+          if (typeof newRow.break_until !== 'undefined') {
+            setBreakUntil(newRow.break_until ?? null);
+          }
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [restaurantId]);
+
+  return {
+    isOpen,
+    breakUntil,
+    showBreakModal,
+    setShowBreakModal,
+    toggleOpen,
+    startBreak,
+    endBreak,
+  };
+}


### PR DESCRIPTION
### Motivation
- Reuse the existing Live Orders reject flow, double-tap behavior and break/open controls inside the Kitchen Display (KOD) to keep behavior and side-effects identical. 
- Restore the regression that prevented opening/viewing an order from the Live Orders list by ensuring orders are hydrated before showing details. 

### Description
- Introduced `useRestaurantAvailability` hook and wired it into Live Orders and KOD so `Open/Close` and `Take a Break` controls (and the break modal/countdown) reuse the same logic and realtime updates. 
- Added a small `OrderRejectButton` component that reproduces the Live Orders double-tap/tooltip behavior and used it in `OrderDetailsModal` and KOD tickets to trigger the shared `RejectOrderModal`. 
- Reused `RejectOrderModal` in KOD (new `tone` prop) and restyled the modal and break controls for a KOD-consistent visual tone while preserving the exact reject flow (reasons, mark out-of-stock logic, custom message, cancel). 
- Fixed the Live Orders open-order regression by adding `handleOpenOrder` which hydrates an order via `hydrateOrder` before calling `setSelectedOrder`, and replaced direct `setSelectedOrder` calls with the new handler. 
- Kept all original status values and server interactions unchanged (no new status strings or checkout/POS logic changes). 

### Testing
- Launched the dev server with `npm run dev` and observed the Next.js server compile successfully with client and server builds. (succeeded) 
- Ran a Playwright script to load the KOD page and capture a screenshot of the header controls and reject action, producing `artifacts/.../kod-controls.png`. (succeeded) 
- No unit test suites were executed in this rollout; no automated test failures were observed during the manual validation steps above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69837941b4608325ab0b765a42aebd18)