### PR TITLE
fix(order-flow): restore POS stock blocking and KOD pending intake

### DIFF
--- a/components/MenuItemCard.tsx
+++ b/components/MenuItemCard.tsx
@@ -6,6 +6,7 @@ import { useBrand } from '@/components/branding/BrandProvider';
 import { formatPrice, normalizePriceValue } from '@/lib/orderDisplay';
 import ItemModal from '@/components/modals/ItemModal';
 import { toast } from '@/components/ui/toast';
+import { isOutOfStockEntity } from '@/lib/stockAvailability';
 import {
   FALLBACK_PLACEHOLDER_SRC,
   getItemPlaceholder,
@@ -131,10 +132,7 @@ export default function MenuItemCard({
     return addonGroups.some((group) => group?.required);
   }, [addonGroups]);
 
-  const isOutOfStock =
-    item?.stock_status !== 'in_stock' ||
-    item?.available === false ||
-    item?.out_of_stock === true;
+  const isOutOfStock = isOutOfStockEntity(item);
 
   const handleClick = () => {
     onInteraction?.();

--- a/components/modals/ItemModal.tsx
+++ b/components/modals/ItemModal.tsx
@@ -10,6 +10,7 @@ import { formatPrice, normalizePriceValue } from '@/lib/orderDisplay';
 import { getAddonsForItem } from '@/utils/getAddonsForItem';
 import type { AddonGroup } from '@/utils/types';
 import { toast } from '@/components/ui/toast';
+import { isInStockAddonOption } from '@/lib/stockAvailability';
 
 function contrast(c?: string) {
   try {
@@ -141,7 +142,7 @@ export default function ItemModal({ item, restaurantId, onAddToCart, isOutOfStoc
       .map((group) => {
         const options = Array.isArray(group.addon_options)
           ? group.addon_options.filter(
-              (option) => option?.available !== false && option?.stock_status === 'in_stock'
+              (option) => isInStockAddonOption(option)
             )
           : [];
         return { ...group, addon_options: options };

--- a/lib/stockAvailability.ts
+++ b/lib/stockAvailability.ts
@@ -1,0 +1,24 @@
+export type StockComparable = {
+  stock_status?: string | null;
+  available?: boolean | null;
+  out_of_stock?: boolean | null;
+};
+
+export type AddonStockComparable = {
+  stock_status?: string | null;
+  available?: boolean | null;
+};
+
+export const isOutOfStockEntity = (entity: StockComparable | null | undefined): boolean => {
+  if (!entity) return true;
+  return (
+    entity.stock_status !== 'in_stock' ||
+    entity.available === false ||
+    entity.out_of_stock === true
+  );
+};
+
+export const isInStockAddonOption = (option: AddonStockComparable | null | undefined): boolean => {
+  if (!option) return false;
+  return option.stock_status === 'in_stock' && option.available !== false;
+};

--- a/pages/kod/[restaurantId]/index.tsx
+++ b/pages/kod/[restaurantId]/index.tsx
@@ -354,7 +354,7 @@ export default function KitchenDisplayPage() {
       `
       )
       .eq('restaurant_id', restaurantId)
-      .eq('status', 'accepted')
+      .in('status', ACTIVE_STATUSES)
       .is('kod_done_at', null)
       .order('created_at', { ascending: true });
 
@@ -556,6 +556,27 @@ export default function KitchenDisplayPage() {
     if (!restaurantId) return;
     fetchPreparedOrders();
   }, [fetchPreparedOrders, restaurantId]);
+
+  useEffect(() => {
+    if (!restaurantId) return;
+    const channel = supabase
+      .channel(`kod-orders-${restaurantId}`)
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'orders', filter: `restaurant_id=eq.${restaurantId}` },
+        () => { void refreshCurrentView(); }
+      )
+      .on(
+        'postgres_changes',
+        { event: 'UPDATE', schema: 'public', table: 'orders', filter: `restaurant_id=eq.${restaurantId}` },
+        () => { void refreshCurrentView(); }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [refreshCurrentView, restaurantId]);
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
@@ -819,6 +840,13 @@ export default function KitchenDisplayPage() {
       if (isPreparedView) {
         if (order.status === 'completed') return;
         await updateOrderStatus(order, 'completed', ['accepted', 'preparing', 'ready_to_collect', 'delivering']);
+        await fetchPreparedOrders();
+        return;
+      }
+
+      if (order.status === 'pending') {
+        await updateOrderStatus(order, 'accepted', ['pending']);
+        await fetchOrders();
         await fetchPreparedOrders();
         return;
       }
@@ -1289,11 +1317,11 @@ export default function KitchenDisplayPage() {
                           disabled={
                             (isPreparedView
                               ? segment.order.status === 'completed'
-                              : !['accepted', 'preparing', 'ready_to_collect', 'delivering'].includes(segment.order.status)) || cooldowns[`${segment.order.id}-primary`]
+                              : !['pending', 'accepted', 'preparing', 'ready_to_collect', 'delivering'].includes(segment.order.status)) || cooldowns[`${segment.order.id}-primary`]
                           }
                           className="flex-1 rounded-full bg-teal-500 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-black transition hover:bg-teal-400 disabled:cursor-not-allowed disabled:opacity-40"
                         >
-                          {isPreparedView ? (segment.order.status === 'completed' ? 'VIEW' : 'COMPLETE') : 'DONE'}
+                          {isPreparedView ? (segment.order.status === 'completed' ? 'VIEW' : 'COMPLETE') : segment.order.status === 'pending' ? 'ACCEPT' : 'DONE'}
                         </button>
                         {isPreparedView && segment.order.status !== 'completed' ? (
                           <button

--- a/pages/pos/[restaurantId]/index.tsx
+++ b/pages/pos/[restaurantId]/index.tsx
@@ -15,6 +15,7 @@ import ConfirmModal from '@/components/ConfirmModal';
 import { supabase } from '@/lib/supabaseClient';
 import { ITEM_ADDON_LINK_WITH_GROUPS_SELECT } from '@/lib/queries/addons';
 import { calculateCartTotals, formatPrice } from '@/lib/orderDisplay';
+import { isInStockAddonOption, isOutOfStockEntity } from '@/lib/stockAvailability';
 import Toast from '@/components/Toast';
 
 type OrderType = 'walk-in' | 'collection' | 'delivery';
@@ -63,6 +64,7 @@ type Item = {
   is_18_plus: boolean | null;
   stock_status: 'in_stock' | 'scheduled' | 'out' | null;
   available?: boolean | null;
+  out_of_stock?: boolean | null;
   category_id?: number | null;
   addon_groups?: any[];
 };
@@ -113,6 +115,7 @@ export default function PosHomePage() {
   const [toastMessage, setToastMessage] = useState('');
   const [saveError, setSaveError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+  const [menuRefreshKey, setMenuRefreshKey] = useState(0);
 
   useEffect(() => {
     if (!storageKey || typeof window === 'undefined') return;
@@ -168,7 +171,7 @@ export default function PosHomePage() {
         const itemsPromise = supabase
           .from('menu_items')
           .select(
-            'id,name,description,price,image_url,is_vegetarian,is_vegan,is_18_plus,stock_status,category_id,available'
+            'id,name,description,price,image_url,is_vegetarian,is_vegan,is_18_plus,stock_status,category_id,available,out_of_stock'
           )
           .eq('restaurant_id', restaurantId)
           .is('archived_at', null)
@@ -182,8 +185,8 @@ export default function PosHomePage() {
         if (catRes.error) console.error('[pos] failed to fetch categories', catRes.error);
         if (itemRes.error) console.error('[pos] failed to fetch items', itemRes.error);
 
-        const liveItems = (itemRes.data || []).filter((it: any) => it?.available !== false);
-        const liveItemIds = liveItems.map((row) => row.id);
+        const liveItems = itemRes.data || [];
+        const liveItemIds = liveItems.map((row: any) => row.id);
         let linkRows: ItemLink[] = [];
         let addonRows: any[] = [];
 
@@ -219,7 +222,7 @@ export default function PosHomePage() {
                 {
                   ...row.addon_groups,
                   addon_options: row.addon_groups.addon_options
-                    .filter((opt: any) => opt?.archived_at == null && opt?.available !== false)
+                    .filter((opt: any) => opt?.archived_at == null && isInStockAddonOption(opt))
                     .sort(sortByOrder),
                 },
               ]
@@ -228,7 +231,7 @@ export default function PosHomePage() {
                 {
                   ...row.addon_groups,
                   addon_options: (row.addon_groups.addon_options || [])
-                    .filter((opt: any) => opt?.archived_at == null && opt?.available !== false)
+                    .filter((opt: any) => opt?.archived_at == null && isInStockAddonOption(opt))
                     .sort(sortByOrder),
                 },
               ]
@@ -257,6 +260,45 @@ export default function PosHomePage() {
 
     return () => {
       active = false;
+    };
+  }, [menuRefreshKey, restaurantId]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const handleFocus = () => {
+      setMenuRefreshKey((prev) => prev + 1);
+    };
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        setMenuRefreshKey((prev) => prev + 1);
+      }
+    };
+    window.addEventListener('focus', handleFocus);
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => {
+      window.removeEventListener('focus', handleFocus);
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!restaurantId) return;
+    const channel = supabase
+      .channel(`pos-stock-${restaurantId}`)
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'menu_items', filter: `restaurant_id=eq.${restaurantId}` },
+        () => setMenuRefreshKey((prev) => prev + 1)
+      )
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'addon_options' },
+        () => setMenuRefreshKey((prev) => prev + 1)
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
     };
   }, [restaurantId]);
 
@@ -295,6 +337,8 @@ export default function PosHomePage() {
 
   const totals = useMemo(() => calculateCartTotals(cartItems), [cartItems]);
 
+  const isItemUnavailable = useCallback((item: Item | null | undefined) => isOutOfStockEntity(item), []);
+
   const buildAddonKey = (addons?: PosAddon[]) => {
     if (!addons || addons.length === 0) return '';
     return addons
@@ -306,6 +350,10 @@ export default function PosHomePage() {
   const addLineItem = useCallback(
     (item: Item, quantity: number, addons?: PosAddon[]) => {
       if (!restaurantId) return;
+      if (isItemUnavailable(item)) {
+        setToastMessage('This item is out of stock.');
+        return;
+      }
       const addonKey = buildAddonKey(addons);
       setCartItems((prev) => {
         const existing = prev.find(
@@ -341,8 +389,13 @@ export default function PosHomePage() {
 
   const handleItemTap = (item: Item) => {
     if (!restaurantId) return;
+    if (isItemUnavailable(item)) {
+      setToastMessage('This item is out of stock.');
+      return;
+    }
     const groups = Array.isArray(item.addon_groups) ? item.addon_groups : [];
     if (groups.length > 0) {
+      setMenuRefreshKey((prev) => prev + 1);
       setActiveModalItem(item);
       return;
     }
@@ -863,13 +916,22 @@ export default function PosHomePage() {
                     </button>
                   ))}
                   </div>
-                  <button
-                    type="button"
-                    onClick={() => setShowOrderDrawer(true)}
-                    className="rounded-full border border-gray-200 px-4 py-2 text-xs font-semibold text-gray-700 md:hidden"
-                  >
-                    View Order ({cartItems.reduce((sum, line) => sum + line.quantity, 0)})
-                  </button>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => setMenuRefreshKey((prev) => prev + 1)}
+                      className="rounded-full border border-gray-200 px-4 py-2 text-xs font-semibold text-gray-700"
+                    >
+                      Refresh menu
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setShowOrderDrawer(true)}
+                      className="rounded-full border border-gray-200 px-4 py-2 text-xs font-semibold text-gray-700 md:hidden"
+                    >
+                      View Order ({cartItems.reduce((sum, line) => sum + line.quantity, 0)})
+                    </button>
+                  </div>
                 </div>
               </div>
               <div className="flex-1 overflow-y-auto px-6 py-6">
@@ -877,12 +939,16 @@ export default function PosHomePage() {
                   <div className="text-sm text-gray-500">Loading menu…</div>
                 ) : (
                   <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
-                    {visibleItems.map((item) => (
+                    {visibleItems.map((item) => {
+                      const isUnavailable = isItemUnavailable(item);
+                      return (
                       <button
                         key={item.id}
                         type="button"
                         onClick={() => handleItemTap(item)}
-                        className="flex flex-col rounded-2xl border border-gray-200 bg-white px-4 py-3 text-left shadow-sm transition hover:border-gray-300"
+                        disabled={isUnavailable}
+                        aria-disabled={isUnavailable}
+                        className={`flex flex-col rounded-2xl border px-4 py-3 text-left shadow-sm transition ${isUnavailable ? 'cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400 opacity-70' : 'border-gray-200 bg-white hover:border-gray-300'}`}
                       >
                         <div className="flex items-start justify-between gap-3">
                           <div className="min-w-0 flex-1">
@@ -894,8 +960,12 @@ export default function PosHomePage() {
                             {formatPrice(item.price)}
                           </span>
                         </div>
+                        {isUnavailable ? (
+                          <span className="mt-2 text-xs font-semibold uppercase tracking-[0.12em] text-gray-500">Out of stock</span>
+                        ) : null}
                       </button>
-                    ))}
+                      );
+                    })}
                   </div>
                 )}
               </div>
@@ -1143,9 +1213,14 @@ export default function PosHomePage() {
           item={{ ...activeModalItem, __onClose: () => setActiveModalItem(null) }}
           restaurantId={String(restaurantId ?? '')}
           onAddToCart={(item, qty, addons) => {
+            if (isItemUnavailable(activeModalItem)) {
+              setToastMessage('This item is out of stock.');
+              return;
+            }
             addLineItem(activeModalItem, qty, addons as PosAddon[]);
             setActiveModalItem(null);
           }}
+          isOutOfStock={isItemUnavailable(activeModalItem)}
         />
       ) : null}
 


### PR DESCRIPTION
### Motivation
- Two regressions were introduced: the Till/POS was allowing out‑of‑stock items/add‑ons to be ordered, and KOD stopped showing new incoming (pre‑acceptance) orders immediately.\n
### Description
- Added a shared stock helper `lib/stockAvailability.ts` with `isOutOfStockEntity` and `isInStockAddonOption` so customer/kiosk/pos evaluate stock consistently.\n- POS/Till: changed menu load to include `stock_status`, `available`, and `out_of_stock`, reused the shared helpers to filter add‑on options, greyed out and disabled unavailable item cards, added hard guards in `addLineItem` and modal handlers that show `This item is out of stock.` and block adds, and passed `isOutOfStock` to `ItemModal`.\n- POS live refresh: added focus/visibility handlers, a manual `Refresh menu` button and Supabase realtime listeners for `menu_items` / `addon_options` to refresh stock state without heavy polling.\n- KOD (Kitchen Display): widened the live `fetchOrders` query to include active statuses (including `pending`) instead of only `accepted`, added a realtime `INSERT`/`UPDATE` subscription for `orders`, and restored an in‑ticket `ACCEPT` action that reuses the existing accept/update path so pending orders can be accepted from KOD; preserved `kod_done_at`, prepared/done, and completed semantics.\n
### Testing
- Typecheck: ran `npx tsc --noEmit` and it succeeded.\n- Unit tests: ran `npm run test:ci -- --runInBand` and many Jest suites failed due to repository Jest/TSX transform and missing server env issues (unrelated to the stock/KOD changes).\n- Build: ran `npm run build` which failed in this environment because server page data collection requires `SUPABASE_URL` (environment missing), so page collection failed but the changes themselves typechecked.\n- Manual / runtime smoke: started dev server and captured screenshots via a Playwright script to validate UI behavior: `artifacts/pos-stock-guard.png` (POS shows greyed out / blocked items) and `artifacts/kod-pending-visible.png` (KOD displays pending orders and shows Accept action).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aafc8107e4832585d3de8255778910)