### PR TITLE
fix(capacitor): align webDir with Next.js build output

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -3,7 +3,7 @@ import type { CapacitorConfig } from '@capacitor/cli';
 const config: CapacitorConfig = {
   appId: 'com.orderfast.app',
   appName: 'Orderfast',
-  webDir: 'out',
+  webDir: '.next',
 };
 
 export default config;


### PR DESCRIPTION
### Motivation
- The project uses `next build` which produces the `.next` build artifacts rather than a static `out` export, so `webDir: 'out'` pointed at a folder this repo does not produce and could cause Capacitor sync/build mismatches.

### Description
- Changed `webDir` in `capacitor.config.ts` from `'out'` to `'.next'` to match the actual Next.js build output and kept the change minimal without touching app or business logic.

### Testing
- Ran `npm run build` to validate the setup; the build failed on a pre-existing type-resolution error for `@capacitor/cli` during Next type checking, which is unrelated to the `webDir` change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca7eebf6188325bdc73b452a3a93d8)