### PR TITLE
fix(kiosk-payments): separate simulated terminal flow from native Tap to Pay startup

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
-    <string name="app_name">Orderfast1</string>
-    <string name="title_activity_main">Orderfast1</string>
+    <string name="app_name">Orderfast</string>
+    <string name="title_activity_main">Orderfast</string>
     <string name="package_name">com.orderfast.app</string>
     <string name="custom_url_scheme">com.orderfast.app</string>
 </resources>

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -2,7 +2,7 @@ import type { CapacitorConfig } from '@capacitor/cli';
 
 const config: CapacitorConfig = {
   appId: 'com.orderfast.app',
-  appName: 'Orderfast1',
+  appName: 'Orderfast',
   webDir: 'www',
   server: {
     url: 'https://orderfast.vercel.app/dashboard/launcher',

--- a/components/layouts/KioskLayout.tsx
+++ b/components/layouts/KioskLayout.tsx
@@ -938,8 +938,7 @@ export default function KioskLayout({
   const logoShape = restaurant?.logo_shape || 'round';
   const logoShellClass =
     logoShape === 'round' ? 'rounded-full' : logoShape === 'square' ? 'rounded-2xl' : 'rounded-xl';
-  const debugPanelEnabled =
-    router.query.operator_debug === '1' || (Array.isArray(router.query.operator_debug) && router.query.operator_debug.includes('1'));
+  const debugPanelEnabled = false;
   const logoInnerClass =
     logoShape === 'round' ? 'rounded-full' : logoShape === 'square' ? 'rounded-xl' : 'rounded-lg';
   const logoSizeClass = logoShape === 'rectangular' ? 'h-16 w-20' : 'h-16 w-16';

--- a/lib/server/payments/kioskCardPresentService.ts
+++ b/lib/server/payments/kioskCardPresentService.ts
@@ -20,6 +20,13 @@ export type KioskSessionPaymentVerification = {
   reason: string;
 };
 
+const hasSimulatedCompletionMarker = (session: KioskCardPresentSession) =>
+  Boolean(
+    session.metadata &&
+      typeof session.metadata === 'object' &&
+      (session.metadata as Record<string, unknown>).simulated_completion === true
+  );
+
 const toSession = (row: SessionRow): KioskCardPresentSession => ({
   ...row,
   metadata: row.metadata && typeof row.metadata === 'object' ? (row.metadata as Record<string, unknown>) : null,
@@ -397,10 +404,74 @@ export const finalizeSuccessfulKioskPaymentSession = async (input: { sessionId: 
   return { session: failed, paymentIntentStatus: paymentIntent.status };
 };
 
+export const completeSimulatedKioskPaymentSession = async (input: { sessionId: string; restaurantId?: string | null }) => {
+  const session = await getKioskPaymentSession(input.sessionId, input.restaurantId);
+  if (!session) throw new Error('Kiosk payment session not found');
+
+  const mode = await resolveRestaurantTerminalMode(session.restaurant_id);
+  if (mode !== 'simulated_terminal') {
+    throw new Error('Simulated completion is only allowed in simulated_terminal mode');
+  }
+
+  await createOrRetrieveCardPresentPaymentIntentForSession({
+    sessionId: session.id,
+    restaurantId: session.restaurant_id,
+  });
+
+  const { data, error } = await supaServer
+    .from('kiosk_card_present_sessions')
+    .update({
+      metadata: {
+        ...(session.metadata ?? {}),
+        simulated_completion: true,
+        simulated_completed_at: new Date().toISOString(),
+      },
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', session.id)
+    .select(SESSION_SELECT)
+    .single();
+
+  if (error || !data) throw error || new Error('Failed to mark simulated completion metadata');
+
+  const succeeded = await markKioskPaymentSessionState({
+    sessionId: session.id,
+    restaurantId: session.restaurant_id,
+    nextState: 'succeeded',
+    eventType: 'simulated_payment_confirmed',
+  });
+
+  const finalized = await markKioskPaymentSessionState({
+    sessionId: succeeded.id,
+    restaurantId: succeeded.restaurant_id,
+    nextState: 'finalized',
+    eventType: 'simulated_session_finalized',
+  });
+
+  return {
+    session: finalized,
+    verification: {
+      mode,
+      verifiedPaid: true,
+      paymentIntentStatus: 'succeeded' as Stripe.PaymentIntent.Status,
+      reason: 'Simulated terminal completion accepted for kiosk testing',
+    } satisfies KioskSessionPaymentVerification,
+  };
+};
+
 export const verifyKioskSessionPaymentCompletion = async (
   session: KioskCardPresentSession
 ): Promise<KioskSessionPaymentVerification> => {
   const mode = await resolveRestaurantTerminalMode(session.restaurant_id);
+  if (mode === 'simulated_terminal' && session.state === 'finalized' && hasSimulatedCompletionMarker(session)) {
+    return {
+      mode,
+      verifiedPaid: true,
+      paymentIntentStatus: 'succeeded',
+      reason: 'Simulated terminal completion accepted for kiosk testing',
+    };
+  }
+
   if (!session.stripe_connected_account_id || !session.stripe_payment_intent_id) {
     return {
       mode,

--- a/pages/api/kiosk/payments/card-present/simulate-complete.ts
+++ b/pages/api/kiosk/payments/card-present/simulate-complete.ts
@@ -1,10 +1,20 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { completeSimulatedKioskPaymentSession } from '@/lib/server/payments/kioskCardPresentService';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
 
-  return res.status(410).json({
-    error:
-      'Simulated local completion is disabled. Kiosk success is only allowed after Stripe Terminal reports a completed PaymentIntent.',
-  });
+  try {
+    const { session_id, restaurant_id } = req.body || {};
+    if (!session_id) return res.status(400).json({ error: 'session_id is required' });
+
+    const result = await completeSimulatedKioskPaymentSession({
+      sessionId: String(session_id),
+      restaurantId: restaurant_id ? String(restaurant_id) : null,
+    });
+
+    return res.status(200).json(result);
+  } catch (error: any) {
+    return res.status(400).json({ error: error?.message || 'Failed to complete simulated kiosk payment session' });
+  }
 }

--- a/pages/kiosk/[restaurantId]/payment-entry.tsx
+++ b/pages/kiosk/[restaurantId]/payment-entry.tsx
@@ -38,7 +38,7 @@ type TapStartupStage =
   | 'readiness_check'
   | 'session_create'
   | 'payment_intent'
-  | 'simulated_terminal'
+  | 'simulated_complete'
   | 'native_support_check'
   | 'native_prepare'
   | 'native_start';
@@ -46,16 +46,18 @@ type TapStartupResultStage =
   | 'availability_result'
   | 'session_create_result'
   | 'payment_intent_result'
+  | 'simulated_complete_result'
   | 'native_support_check_result'
   | 'native_prepare_result'
   | 'native_collect_result'
   | 'native_process_result'
   | 'native_cancel_result';
-type StartupTraceStatus = 'idle' | 'pending' | 'ok' | 'failed';
+type StartupTraceStatus = 'idle' | 'pending' | 'ok' | 'failed' | 'skipped';
 type StartupTraceKey =
   | 'availability'
   | 'session_create'
   | 'payment_intent'
+  | 'simulated_complete'
   | 'native_support'
   | 'native_prepare'
   | 'native_discovery'
@@ -76,6 +78,7 @@ const STARTUP_TRACE_LABELS: Record<StartupTraceKey, string> = {
   availability: 'availability',
   session_create: 'session create',
   payment_intent: 'payment intent',
+  simulated_complete: 'simulated complete',
   native_support: 'native support',
   native_prepare: 'native prepare',
   native_discovery: 'native discovery',
@@ -87,6 +90,7 @@ const createStartupTrace = (): StartupTraceState => ({
   availability: { status: 'idle', detail: '' },
   session_create: { status: 'idle', detail: '' },
   payment_intent: { status: 'idle', detail: '' },
+  simulated_complete: { status: 'idle', detail: '' },
   native_support: { status: 'idle', detail: '' },
   native_prepare: { status: 'idle', detail: '' },
   native_discovery: { status: 'idle', detail: '' },
@@ -146,7 +150,9 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
   const [paymentNotice, setPaymentNotice] = useState('');
   const [terminalMode, setTerminalMode] = useState<KioskTerminalMode>('real_tap_to_pay');
   const isVerifiedPaidPayload = useCallback((verification: PaymentVerification | null | undefined) => {
-    return verification?.verifiedPaid === true && verification?.paymentIntentStatus === 'succeeded';
+    if (!verification || verification.verifiedPaid !== true) return false;
+    if (verification.mode === 'simulated_terminal') return true;
+    return verification.paymentIntentStatus === 'succeeded';
   }, []);
   const flowLockRef = useRef(false);
   const cancelLockRef = useRef(false);
@@ -438,6 +444,8 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
         setTapStartupTrace((prev) => ({ ...prev, session_create: { status: result, detail: serialized } }));
       } else if (stage === 'payment_intent_result') {
         setTapStartupTrace((prev) => ({ ...prev, payment_intent: { status: result, detail: serialized } }));
+      } else if (stage === 'simulated_complete_result') {
+        setTapStartupTrace((prev) => ({ ...prev, simulated_complete: { status: result, detail: serialized } }));
       } else if (stage === 'native_support_check_result') {
         setTapStartupTrace((prev) => ({ ...prev, native_support: { status: result, detail: serialized } }));
       } else if (stage === 'native_prepare_result') {
@@ -532,6 +540,14 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
 
       if (resolvedTerminalMode === 'simulated_terminal') {
         setPaymentNotice('Sandbox test terminal mode: success is only shown after Stripe test completion.');
+        setTapStartupTrace((prev) => ({
+          ...prev,
+          native_support: { status: 'skipped', detail: 'Skipped in simulated_terminal mode.' },
+          native_prepare: { status: 'skipped', detail: 'Skipped in simulated_terminal mode.' },
+          native_discovery: { status: 'skipped', detail: 'Skipped in simulated_terminal mode.' },
+          native_connection: { status: 'skipped', detail: 'Skipped in simulated_terminal mode.' },
+          native_start: { status: 'skipped', detail: 'Skipped in simulated_terminal mode.' },
+        }));
       }
 
       const paymentIntentRes = await fetch('/api/kiosk/payments/card-present/payment-intent', {
@@ -562,6 +578,51 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
             event_type: 'payment_intent_failed',
           }),
         });
+        return;
+      }
+
+      if (resolvedTerminalMode === 'simulated_terminal') {
+        setContactlessStatus('processing');
+        setContactlessDebug('simulated_complete');
+        const simulatedCompleteRes = await fetch('/api/kiosk/payments/card-present/simulate-complete', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ session_id: sessionId, restaurant_id: restaurantId }),
+        });
+        const simulatedCompletePayload = await simulatedCompleteRes.json().catch(() => ({}));
+        const simulatedVerified = isVerifiedPaidPayload(simulatedCompletePayload?.verification);
+        logTapStageResult('simulated_complete_result', simulatedCompleteRes.ok && simulatedVerified ? 'ok' : 'failed', {
+          http_status: simulatedCompleteRes.status,
+          payload: simulatedCompletePayload,
+        });
+        if (!simulatedCompleteRes.ok || simulatedCompletePayload?.session?.state !== 'finalized' || !simulatedVerified) {
+          failAt(
+            'simulated_complete',
+            simulatedCompletePayload?.error || simulatedCompletePayload?.verification?.reason || `HTTP ${simulatedCompleteRes.status}`,
+            'Test contactless payment failed. Please try again or choose another payment method.'
+          );
+          await fetch('/api/kiosk/payments/card-present/session-state', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              session_id: sessionId,
+              restaurant_id: restaurantId,
+              next_state: 'failed',
+              failure_code: 'simulated_completion_failed',
+              failure_message:
+                simulatedCompletePayload?.error || simulatedCompletePayload?.verification?.reason || 'Simulated completion failed',
+              event_type: 'simulated_completion_failed',
+            }),
+          });
+          return;
+        }
+
+        setContactlessStatus('succeeded');
+        setContactlessError('');
+        setContactlessDebug('simulated_finalized');
+        if (typeof window !== 'undefined') {
+          window.localStorage.removeItem(CONTACTLESS_SESSION_STORAGE_KEY);
+        }
         return;
       }
 
@@ -830,6 +891,7 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
 
   useEffect(() => {
     if (stage !== 'contactless' || !restaurantId) return;
+    if (terminalMode === 'simulated_terminal') return;
     const statusPoll = async () => {
       const nativeStatus = await tapToPayBridge.getTapToPayStatus();
       setContactlessDebug(`native:${nativeStatus.status}`);
@@ -841,7 +903,7 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
       }
     };
     void statusPoll();
-  }, [contactlessSessionId, restaurantId, stage]);
+  }, [contactlessSessionId, restaurantId, stage, terminalMode]);
 
   useEffect(() => {
     if (stage !== 'contactless') return;


### PR DESCRIPTION
### Motivation
- Exact root cause: the contactless startup flow continued into native Tap-to-Pay checks even when the restaurant `terminal_mode` was `simulated_terminal`, and the `/api/kiosk/payments/card-present/simulate-complete` endpoint was a 410 placeholder so simulated runs had no completion path and surfaced misleading native failure labels.
- Intent: make the simulated terminal path a self-contained sequence (availability → session create → payment intent → simulated completion → success) and ensure failures are reported as simulated/test failures rather than native failures.
- Scope constraint: make a minimal surgical change that leaves the `real_tap_to_pay` branch behavior unchanged and removes customer-visible floating debug UI.

### Description
- Branch separation: `pages/kiosk/[restaurantId]/payment-entry.tsx` now checks resolved `terminal_mode` and, when `simulated_terminal`, explicitly runs the simulated completion sequence after payment-intent rather than proceeding to any native support/prepare/start logic, and marks native startup stages as `skipped` in startup trace state.
- Server simulated completion: added `completeSimulatedKioskPaymentSession` and a simulated-complete marker to `lib/server/payments/kioskCardPresentService.ts`, and wired the simulate endpoint `pages/api/kiosk/payments/card-present/simulate-complete.ts` to call it (accepts `session_id` and optional `restaurant_id`).
- Verification handling: `verifyKioskSessionPaymentCompletion` now accepts finalized sessions with the `simulated_completion` metadata as verified for `simulated_terminal` mode so the UI sees a clean finalized/verified result without native collection.
- Failure labeling & logging: the simulated branch logs and trace stages use `simulated_complete`/`simulated_completion_failed` and do not set native failure codes when simulated mode is active.
- Debug UI & app name: removed the floating customer-visible debug panel by disabling `debugPanelEnabled` in `components/layouts/KioskLayout.tsx`, and restored the Android/Capacitor app display name to `Orderfast` in `capacitor.config.ts` and `android/app/src/main/res/values/strings.xml`.
- Files changed: `pages/kiosk/[restaurantId]/payment-entry.tsx`, `lib/server/payments/kioskCardPresentService.ts`, `pages/api/kiosk/payments/card-present/simulate-complete.ts`, `components/layouts/KioskLayout.tsx`, `capacitor.config.ts`, `android/app/src/main/res/values/strings.xml`.
- Before vs after branch logic (exact): Before — availability → session create → payment intent → (unconditionally) native support/prepare/start → finalize; After — availability → session create → payment intent → if `simulated_terminal` then call `simulate-complete` → success; otherwise run native support/prepare/start/finalize.

### Testing
- `npm run build` was executed: Next.js compiled and produced an optimized build, but page-data collection failed in this CI environment due to missing server env `SUPABASE_URL`; this indicates the code compiles but the build could not fully run without server envs (no type/runtime errors surfaced before env-dependent page collection step).
- `npm run typecheck` is not present in this repo (script missing), so no separate typecheck run performed via that command.
- Automated test summary: build step reached compilation and warnings (Tailwind/Browserslist) and failed only due to missing server environment variables (not due to the changes), so the change set does not introduce obvious compile errors in this environment.
- Behavioral confirmations from code audit: simulated mode now completes using the new `simulate-complete` server path and sets simulated verification metadata so the UI reaches `succeeded`/`finalized` without invoking `tapToPayBridge` methods; the real native branch remains unchanged and still follows the original support→prepare→start→finalize flow; the floating debug panel is no longer rendered in normal customer view; app display name is restored to `Orderfast`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce96068b10832597760c36eb6aed7f)