### PR TITLE
fix(kiosk-payments): require Stripe 'succeeded' for kiosk finalization; rename Android app to OFtaptest

### DIFF
--- a/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
+++ b/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
@@ -496,11 +496,18 @@ public class OrderfastTapToPayPlugin extends Plugin {
                                     activePaymentIntent = intent;
                                     clearOperationTimeout();
 
-                                    if (intent.getStatus() == PaymentIntentStatus.SUCCEEDED || intent.getStatus() == PaymentIntentStatus.PROCESSING || intent.getStatus() == PaymentIntentStatus.REQUIRES_CAPTURE) {
+                                    if (intent.getStatus() == PaymentIntentStatus.SUCCEEDED) {
                                         status = "succeeded";
                                         postSessionState("processing", "native_process_succeeded");
                                         JSObject payload = result("succeeded", null, "Tap to Pay payment processed by Stripe Terminal SDK.");
-                                        payload.put("detail", detail("native_process_result", "succeeded", null));
+                                        payload.put("detail", detail("native_process_result", "succeeded", intent.getStatus().name()));
+                                        logStartupStage("native_process_result", payload);
+                                        resolveOnce(resolveGate, call, payload);
+                                    } else if (intent.getStatus() == PaymentIntentStatus.PROCESSING || intent.getStatus() == PaymentIntentStatus.REQUIRES_CAPTURE) {
+                                        status = "processing";
+                                        postSessionState("needs_reconciliation", "native_process_pending");
+                                        JSObject payload = result("processing", null, "Stripe Terminal returned a pending PaymentIntent state.");
+                                        payload.put("detail", detail("native_process_result", "pending", intent.getStatus().name()));
                                         logStartupStage("native_process_result", payload);
                                         resolveOnce(resolveGate, call, payload);
                                     } else {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
-    <string name="app_name">Orderfast</string>
-    <string name="title_activity_main">Orderfast</string>
+    <string name="app_name">OFtaptest</string>
+    <string name="title_activity_main">OFtaptest</string>
     <string name="package_name">com.orderfast.app</string>
     <string name="custom_url_scheme">com.orderfast.app</string>
 </resources>

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -2,7 +2,7 @@ import type { CapacitorConfig } from '@capacitor/cli';
 
 const config: CapacitorConfig = {
   appId: 'com.orderfast.app',
-  appName: 'Orderfast',
+  appName: 'OFtaptest',
   webDir: 'www',
   server: {
     url: 'https://orderfast.vercel.app/dashboard/launcher',

--- a/lib/server/payments/kioskCardPresentService.ts
+++ b/lib/server/payments/kioskCardPresentService.ts
@@ -20,12 +20,7 @@ export type KioskSessionPaymentVerification = {
   reason: string;
 };
 
-const hasSimulatedCompletionMarker = (session: KioskCardPresentSession) =>
-  Boolean(
-    session.metadata &&
-      typeof session.metadata === 'object' &&
-      (session.metadata as Record<string, unknown>).simulated_completion === true
-  );
+const isStripePaymentIntentCompleted = (status: Stripe.PaymentIntent.Status) => status === 'succeeded';
 
 const toSession = (row: SessionRow): KioskCardPresentSession => ({
   ...row,
@@ -309,12 +304,22 @@ export const cancelKioskPaymentSession = async (input: { sessionId: string; rest
         stripeAccount: session.stripe_connected_account_id,
       });
 
-      if (paymentIntent.status === 'succeeded' || paymentIntent.status === 'processing' || paymentIntent.status === 'requires_capture') {
+      if (isStripePaymentIntentCompleted(paymentIntent.status)) {
         const finalized = await finalizeSuccessfulKioskPaymentSession({
           sessionId: session.id,
           restaurantId: session.restaurant_id,
         });
         return finalized.session;
+      }
+
+      if (paymentIntent.status === 'processing' || paymentIntent.status === 'requires_capture') {
+        return markKioskPaymentSessionState({
+          sessionId: session.id,
+          restaurantId: session.restaurant_id,
+          nextState: 'needs_reconciliation',
+          eventType: 'cancel_requested_while_payment_pending',
+          eventPayload: { payment_intent_status: paymentIntent.status },
+        });
       }
 
       if (paymentIntent.status !== 'canceled') {
@@ -355,7 +360,7 @@ export const finalizeSuccessfulKioskPaymentSession = async (input: { sessionId: 
     stripeAccount: session.stripe_connected_account_id,
   });
 
-  if (paymentIntent.status === 'succeeded') {
+  if (isStripePaymentIntentCompleted(paymentIntent.status)) {
     const succeeded =
       session.state === 'succeeded'
         ? session
@@ -386,7 +391,10 @@ export const finalizeSuccessfulKioskPaymentSession = async (input: { sessionId: 
       restaurantId: session.restaurant_id,
       nextState: 'needs_reconciliation',
       eventType: 'payment_needs_reconciliation',
-      eventPayload: { payment_intent_status: paymentIntent.status },
+      eventPayload: {
+        payment_intent_status: paymentIntent.status,
+        completion_rule: paymentIntent.status === 'requires_capture' ? 'authorized_only_not_completed' : 'awaiting_terminal_stripe_completion',
+      },
     });
 
     return { session: needsReconciliation, paymentIntentStatus: paymentIntent.status };
@@ -434,43 +442,19 @@ export const completeSimulatedKioskPaymentSession = async (input: { sessionId: s
 
   if (error || !data) throw error || new Error('Failed to mark simulated completion metadata');
 
-  const succeeded = await markKioskPaymentSessionState({
+  const finalized = await finalizeSuccessfulKioskPaymentSession({
     sessionId: session.id,
     restaurantId: session.restaurant_id,
-    nextState: 'succeeded',
-    eventType: 'simulated_payment_confirmed',
   });
+  const verification = await verifyKioskSessionPaymentCompletion(finalized.session);
 
-  const finalized = await markKioskPaymentSessionState({
-    sessionId: succeeded.id,
-    restaurantId: succeeded.restaurant_id,
-    nextState: 'finalized',
-    eventType: 'simulated_session_finalized',
-  });
-
-  return {
-    session: finalized,
-    verification: {
-      mode,
-      verifiedPaid: true,
-      paymentIntentStatus: 'succeeded' as Stripe.PaymentIntent.Status,
-      reason: 'Simulated terminal completion accepted for kiosk testing',
-    } satisfies KioskSessionPaymentVerification,
-  };
+  return { session: finalized.session, verification };
 };
 
 export const verifyKioskSessionPaymentCompletion = async (
   session: KioskCardPresentSession
 ): Promise<KioskSessionPaymentVerification> => {
   const mode = await resolveRestaurantTerminalMode(session.restaurant_id);
-  if (mode === 'simulated_terminal' && session.state === 'finalized' && hasSimulatedCompletionMarker(session)) {
-    return {
-      mode,
-      verifiedPaid: true,
-      paymentIntentStatus: 'succeeded',
-      reason: 'Simulated terminal completion accepted for kiosk testing',
-    };
-  }
 
   if (!session.stripe_connected_account_id || !session.stripe_payment_intent_id) {
     return {
@@ -486,12 +470,15 @@ export const verifyKioskSessionPaymentCompletion = async (
     stripeAccount: session.stripe_connected_account_id,
   });
 
-  if (paymentIntent.status !== 'succeeded') {
+  if (!isStripePaymentIntentCompleted(paymentIntent.status)) {
     return {
       mode,
       verifiedPaid: false,
       paymentIntentStatus: paymentIntent.status,
-      reason: `Stripe PaymentIntent is not completed (status: ${paymentIntent.status})`,
+      reason:
+        paymentIntent.status === 'requires_capture'
+          ? 'Stripe PaymentIntent is only authorized (requires_capture) and is not treated as a completed payment.'
+          : `Stripe PaymentIntent is not completed (status: ${paymentIntent.status})`,
     };
   }
 

--- a/pages/api/kiosk/payments/card-present/session-state.ts
+++ b/pages/api/kiosk/payments/card-present/session-state.ts
@@ -9,6 +9,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     if (!session_id || !next_state || !isKioskSessionState(String(next_state))) {
       return res.status(400).json({ error: 'session_id and valid next_state are required' });
     }
+    if (next_state === 'finalized' || next_state === 'succeeded') {
+      return res.status(400).json({
+        error: 'finalized/succeeded cannot be set directly; use Stripe-verified finalize flow',
+      });
+    }
 
     const session = await markKioskPaymentSessionState({
       sessionId: String(session_id),

--- a/pages/kiosk/[restaurantId]/payment-entry.tsx
+++ b/pages/kiosk/[restaurantId]/payment-entry.tsx
@@ -772,12 +772,13 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
       setContactlessDebug('native_collect_process');
       setTapStartupTrace((prev) => ({ ...prev, native_start: { status: 'pending', detail: 'Starting native collection flow.' } }));
       const started = await tapToPayBridge.startTapToPayPayment({ restaurantId, sessionId, backendBaseUrl, terminalLocationId });
+      const isNativeSuccessOrPending = started.status === 'succeeded' || started.status === 'processing';
       logTapStageResult(
-        started.status === 'succeeded' ? 'native_process_result' : 'native_collect_result',
-        started.status === 'succeeded' ? 'ok' : 'failed',
+        isNativeSuccessOrPending ? 'native_process_result' : 'native_collect_result',
+        isNativeSuccessOrPending ? 'ok' : 'failed',
         started
       );
-      if (started.status !== 'succeeded') {
+      if (!isNativeSuccessOrPending) {
         setContactlessStatus(started.status === 'canceled' ? 'canceled' : 'failed');
         setContactlessError(
           started.status === 'canceled'


### PR DESCRIPTION
### Motivation
- Prevent kiosk payments and orders being marked completed before Stripe reports a true terminal completion, and make simulated-mode follow the same verification path rather than force-local success.  
- Make the Android build/show the correct visible app name for kiosk test installs by updating the app label and Capacitor config.  

### Description
- Hardened server-side finalization in `lib/server/payments/kioskCardPresentService.ts` by adding a strict completion predicate (`isStripePaymentIntentCompleted`) and only treating `PaymentIntent.status === 'succeeded'` as a completed payment, while mapping `processing` / `requires_capture` to `needs_reconciliation`.  
- Changed simulated completion to reuse the real `finalizeSuccessfulKioskPaymentSession` + `verifyKioskSessionPaymentCompletion` path instead of force-marking `succeeded`/`finalized`, removing the local-only simulated success shortcut.  
- Blocked direct client/server writes of terminal success by rejecting attempts to set `succeeded`/`finalized` via `pages/api/kiosk/payments/card-present/session-state.ts`.  
- Tightened native handling in `android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java` so only `PaymentIntentStatus.SUCCEEDED` is treated as terminal success; `PROCESSING`/`REQUIRES_CAPTURE` now return pending and post `needs_reconciliation` server state.  
- Updated kiosk UI startup/result handling in `pages/kiosk/[restaurantId]/payment-entry.tsx` to treat native `processing` as a pending result (continue backend finalize/reconcile checks) and avoid showing success unless backend verification confirms Stripe `succeeded`.  
- Renamed visible Android app label to `OFtaptest` and aligned Capacitor config by updating `android/app/src/main/res/values/strings.xml` and `capacitor.config.ts`.  
- Did not add any customer-visible debug UI; existing hidden operator diagnostics remain unchanged and still require the hidden unlock.  

### Testing
- Ran `npm run test:ci -- --runInBand` (Jest) and observed failures unrelated to these patches caused by the local Jest/TSX transform configuration and missing server env, so the repo test-suite did not pass here.  
- Ran `npm run build`; compilation succeeded but Next page-data collection failed in this environment due to a missing `SUPABASE_URL` server env, so site build could not fully complete here.  
- `npm run typecheck` is not present in the repo scripts, so no separate typecheck run was available.  
- Summary: changes compiled and unit/integration runs could not be fully exercised in this environment due to repo test/build environment constraints (Jest transform and missing `SUPABASE_URL`), but runtime-critical payment logic paths were adjusted and native plugin behavior updated as described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cea6a5ae90832595497810b5609dea)