### PR TITLE
fix(kiosk): gate real contactless order submit on payment success

### DIFF
--- a/pages/kiosk/[restaurantId]/payment-entry.tsx
+++ b/pages/kiosk/[restaurantId]/payment-entry.tsx
@@ -166,7 +166,7 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
   const [restaurantLoading, setRestaurantLoading] = useState(true);
   const [settingsLoading, setSettingsLoading] = useState(true);
   const [enabledMethods, setEnabledMethods] = useState<KioskPaymentMethod[]>(['pay_at_counter']);
-  const [stage, setStage] = useState<PaymentStage>('pay_at_counter');
+  const [stage, setStage] = useState<PaymentStage>('method_picker');
   const [contactlessStatus, setContactlessStatus] = useState<TapToPayStatus>('idle');
   const [contactlessBusy, setContactlessBusy] = useState(false);
   const [contactlessError, setContactlessError] = useState('');
@@ -834,13 +834,13 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
       setContactlessDebug('native_collect_process');
       setTapStartupTrace((prev) => ({ ...prev, native_start: { status: 'pending', detail: 'Starting native collection flow.' } }));
       const started = await tapToPayBridge.startTapToPayPayment({ restaurantId, sessionId, backendBaseUrl, terminalLocationId });
-      const isNativeSuccessOrPending = started.status === 'succeeded' || started.status === 'processing';
+      const isNativeSuccessOrProcessing = started.status === 'succeeded' || started.status === 'processing';
       logTapStageResult(
-        isNativeSuccessOrPending ? 'native_process_result' : 'native_collect_result',
-        isNativeSuccessOrPending ? 'ok' : 'failed',
+        isNativeSuccessOrProcessing ? 'native_process_result' : 'native_collect_result',
+        isNativeSuccessOrProcessing ? 'ok' : 'failed',
         started
       );
-      if (!isNativeSuccessOrPending) {
+      if (!isNativeSuccessOrProcessing) {
         setContactlessStatus(started.status === 'canceled' ? 'canceled' : 'failed');
         setContactlessError(
           started.status === 'canceled'
@@ -855,6 +855,37 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
         );
         await reconcileSession(sessionId, 'native_start_failed');
         return;
+      }
+
+      if (started.status === 'processing') {
+        const nativePollDeadline = Date.now() + 180000;
+        let nativeResolvedStatus: TapToPayStatus = 'processing';
+
+        while (Date.now() < nativePollDeadline) {
+          await new Promise<void>((resolve) => {
+            window.setTimeout(() => resolve(), 700);
+          });
+          const polledStatus = await tapToPayBridge.getTapToPayStatus();
+          if (polledStatus.sessionId && polledStatus.sessionId !== sessionId) {
+            continue;
+          }
+          setContactlessDebug(`native_poll:${polledStatus.status}`);
+          if (polledStatus.status === 'succeeded' || polledStatus.status === 'failed' || polledStatus.status === 'canceled') {
+            nativeResolvedStatus = polledStatus.status;
+            logTapStageResult(polledStatus.status === 'succeeded' ? 'native_process_result' : 'native_collect_result', polledStatus.status === 'succeeded' ? 'ok' : 'failed', polledStatus);
+            break;
+          }
+        }
+
+        if (nativeResolvedStatus !== 'succeeded') {
+          await reconcileSession(sessionId, nativeResolvedStatus === 'processing' ? 'native_poll_timeout' : `native_poll_${nativeResolvedStatus}`);
+          if (nativeResolvedStatus === 'processing') {
+            setContactlessStatus('failed');
+            setContactlessError('Payment did not complete. Please try again or choose another payment method.');
+            setContactlessDebug('native_poll_timeout');
+          }
+          return;
+        }
       }
 
       setContactlessStatus('processing');
@@ -1107,6 +1138,7 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
   }, [contactlessBusy, contactlessError, contactlessStatus, returnToFallback, stage]);
 
   useEffect(() => {
+    if (settingsLoading) return;
     if (orderSubmitting) return;
     if (stage === 'cash' && autoSubmitAttemptedMethod !== 'cash') {
       setAutoSubmitAttemptedMethod('cash');
@@ -1115,7 +1147,7 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
       setAutoSubmitAttemptedMethod('pay_at_counter');
       void submitOrderAndRedirect('pay_at_counter');
     }
-  }, [autoSubmitAttemptedMethod, orderSubmitting, stage, submitOrderAndRedirect]);
+  }, [autoSubmitAttemptedMethod, orderSubmitting, settingsLoading, stage, submitOrderAndRedirect]);
 
   useEffect(() => {
     if (contactlessStatus !== 'succeeded' || orderSubmitting || autoSubmitAttemptedMethod === 'contactless') return;


### PR DESCRIPTION
### Motivation
- Exact root cause: the payment entry page could auto-submit an order before real Tap to Pay finished because the screen initialized to `pay_at_counter` (allowing an early auto-submit while settings were still loading) and the real native `startTapToPayPayment()` return value of `processing` was treated as sufficient to proceed to backend finalize/submit, creating a race between native collection and order submission. 

### Description
- Files changed: only `pages/kiosk/[restaurantId]/payment-entry.tsx` was modified to keep the fix narrowly scoped. 
- Before vs after contactless flow: before, selection of contactless or an early auto-submit could lead to order creation/confirm navigation while the native Tap to Pay flow was still `processing`; after, contactless now waits for the native side to reach a terminal success and for backend finalize verification before any order submit or confirm redirect occurs. 
- Key technical changes: initial `stage` now starts at `method_picker` (prevents premature pay-at-counter auto-submit), the cash/pay-at-counter auto-submit effect is gated on `settingsLoading === false`, and the real `tapToPayBridge.startTapToPayPayment()` result of `processing` is now actively polled via `tapToPayBridge.getTapToPayStatus()` (with timeout/reconcile) so the code only proceeds to finalization when native status becomes `succeeded`; failures/cancels/timeouts reconcile and exit without order submission. 
- Confirmations: contactless submission is gated until `contactlessStatus === 'succeeded'` which now requires native success + backend finalize verification; cash and pay‑at‑counter immediate-submit behavior is preserved but deferred until settings load completes; the app cannot reset/redirect to home (via the confirm/submit path) before contactless payment actually completes. 

### Testing
- Ran TypeScript typecheck with `npx tsc --noEmit` and it passed (no type errors reported). 
- No automated unit or integration tests were changed or required for this focused timing fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cedc8a2d7c8325833f8b75327f3987)