### PR TITLE
feat(settlement): add shared internal settlement module foundation

### DIFF
--- a/components/payments/InternalSettlementModule.tsx
+++ b/components/payments/InternalSettlementModule.tsx
@@ -1,0 +1,370 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { tapToPayBridge } from '@/lib/kiosk/tapToPayBridge';
+import { formatPrice } from '@/lib/orderDisplay';
+
+type SettlementMode = 'order_payment' | 'quick_charge';
+type CollectionState = 'idle' | 'preparing' | 'collecting' | 'processing' | 'succeeded' | 'failed' | 'canceled' | 'unavailable';
+
+type UnpaidOrder = {
+  id: string;
+  short_order_number: number | null;
+  customer_name: string | null;
+  order_type: string | null;
+  status: string;
+  total_price: number | null;
+  created_at: string;
+};
+
+const toCurrencyCode = (value?: string | null) => (value || 'GBP').toUpperCase();
+
+const makeIdempotencyKey = (prefix: string) => `${prefix}:${Date.now()}:${Math.random().toString(36).slice(2, 10)}`;
+
+export default function InternalSettlementModule() {
+  const [mode, setMode] = useState<SettlementMode>('order_payment');
+  const [orders, setOrders] = useState<UnpaidOrder[]>([]);
+  const [loadingOrders, setLoadingOrders] = useState(true);
+  const [selectedOrderId, setSelectedOrderId] = useState<string>('');
+
+  const [quickAmount, setQuickAmount] = useState('0.00');
+  const [quickNote, setQuickNote] = useState('');
+  const [quickReference, setQuickReference] = useState('');
+
+  const [busy, setBusy] = useState(false);
+  const [state, setState] = useState<CollectionState>('idle');
+  const [message, setMessage] = useState('Ready to collect payment.');
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+  const [activeTerminalLocationId, setActiveTerminalLocationId] = useState<string | null>(null);
+
+  const selectedOrder = useMemo(() => orders.find((order) => order.id === selectedOrderId) || null, [orders, selectedOrderId]);
+
+  const amountCents = useMemo(() => {
+    if (mode === 'order_payment') return Number(selectedOrder?.total_price || 0);
+    const numeric = Number(quickAmount);
+    if (!Number.isFinite(numeric) || numeric <= 0) return 0;
+    return Math.round(numeric * 100);
+  }, [mode, quickAmount, selectedOrder?.total_price]);
+
+  const amountLabel = useMemo(() => formatPrice(amountCents / 100), [amountCents]);
+
+  const loadOrders = useCallback(async () => {
+    setLoadingOrders(true);
+    try {
+      const response = await fetch('/api/dashboard/internal-settlement/unpaid-orders');
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(payload?.message || `HTTP ${response.status}`);
+      const nextOrders = Array.isArray(payload?.orders) ? (payload.orders as UnpaidOrder[]) : [];
+      setOrders(nextOrders);
+      if (nextOrders.length > 0 && !nextOrders.some((order) => order.id === selectedOrderId)) {
+        setSelectedOrderId(nextOrders[0].id);
+      }
+    } catch (error: any) {
+      setMessage(error?.message || 'Failed to load unpaid orders.');
+      setState('failed');
+    } finally {
+      setLoadingOrders(false);
+    }
+  }, [selectedOrderId]);
+
+  useEffect(() => {
+    void loadOrders();
+  }, [loadOrders]);
+
+  const isUnsupportedDeviceError = (code?: string) => code === 'unsupported' || code === 'unsupported_device';
+
+  const handleCollectContactless = useCallback(async () => {
+    if (busy) return;
+    if (mode === 'order_payment' && !selectedOrderId) {
+      setState('failed');
+      setMessage('Select an unpaid order first.');
+      return;
+    }
+    if (amountCents <= 0) {
+      setState('failed');
+      setMessage('Amount must be greater than zero.');
+      return;
+    }
+
+    setBusy(true);
+    setState('preparing');
+    setMessage('Checking Tap to Pay readiness…');
+
+    let sessionIdForCleanup: string | null = null;
+    try {
+      const readinessRes = await fetch('/api/dashboard/internal-settlement/tap-to-pay-availability');
+      const readinessPayload = await readinessRes.json().catch(() => ({}));
+      if (!readinessRes.ok || !readinessPayload?.tap_to_pay_available) {
+        setState('unavailable');
+        setMessage(readinessPayload?.reason || 'Tap to Pay is not available for this restaurant.');
+        return;
+      }
+
+      const createRes = await fetch('/api/dashboard/internal-settlement/create-session', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          mode,
+          idempotency_key: makeIdempotencyKey('internal_settlement'),
+          order_id: mode === 'order_payment' ? selectedOrderId : null,
+          amount_cents: mode === 'quick_charge' ? amountCents : undefined,
+          currency: 'gbp',
+          note: mode === 'quick_charge' ? quickNote : undefined,
+          reference: mode === 'quick_charge' ? quickReference : undefined,
+        }),
+      });
+      const createPayload = await createRes.json().catch(() => ({}));
+      if (!createRes.ok) throw new Error(createPayload?.message || `Failed to create payment session (${createRes.status})`);
+
+      const sessionId = createPayload?.session?.id ? String(createPayload.session.id) : '';
+      const terminalLocationId = createPayload?.session?.stripe_terminal_location_id
+        ? String(createPayload.session.stripe_terminal_location_id)
+        : '';
+
+      if (!sessionId || !terminalLocationId) throw new Error('Missing payment session context.');
+      sessionIdForCleanup = sessionId;
+      setActiveSessionId(sessionId);
+      setActiveTerminalLocationId(terminalLocationId);
+
+      await fetch('/api/dashboard/internal-settlement/payment-intent', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ session_id: sessionId }),
+      });
+
+      const support = await tapToPayBridge.isTapToPaySupported();
+      if (!support.supported) {
+        setState('unavailable');
+        setMessage(support.reason || 'This device cannot run Tap to Pay.');
+        await fetch('/api/dashboard/internal-settlement/cancel', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ session_id: sessionId }),
+        });
+        return;
+      }
+
+      const setup = await tapToPayBridge.ensureTapToPaySetup({ promptIfNeeded: true });
+      if (!setup.ready) {
+        setState('unavailable');
+        setMessage(setup.reason || 'Tap to Pay setup is incomplete on this device.');
+        await fetch('/api/dashboard/internal-settlement/cancel', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ session_id: sessionId }),
+        });
+        return;
+      }
+
+      setState('collecting');
+      setMessage('Present card/phone to collect payment…');
+
+      const nativeResult = await tapToPayBridge.startTapToPayPayment({
+        restaurantId: 'internal-settlement',
+        sessionId,
+        backendBaseUrl: window.location.origin,
+        terminalLocationId,
+      });
+
+      if (nativeResult.status === 'canceled') {
+        setState('canceled');
+        setMessage(nativeResult.message || 'Payment canceled.');
+        await fetch('/api/dashboard/internal-settlement/cancel', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ session_id: sessionId }),
+        });
+        return;
+      }
+
+      if (nativeResult.status !== 'succeeded') {
+        setState(isUnsupportedDeviceError(nativeResult.code) ? 'unavailable' : 'failed');
+        setMessage(nativeResult.message || 'Payment failed.');
+        await fetch('/api/dashboard/internal-settlement/cancel', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ session_id: sessionId }),
+        });
+        return;
+      }
+
+      setState('processing');
+      setMessage('Finalizing settlement…');
+
+      const finalizeRes = await fetch('/api/dashboard/internal-settlement/finalize', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ session_id: sessionId }),
+      });
+      const finalizePayload = await finalizeRes.json().catch(() => ({}));
+      if (!finalizeRes.ok) throw new Error(finalizePayload?.message || `Failed to finalize settlement (${finalizeRes.status})`);
+
+      setState('succeeded');
+      setMessage(mode === 'order_payment' ? 'Order payment collected successfully.' : 'Quick charge collected successfully.');
+
+      if (mode === 'quick_charge') {
+        setQuickAmount('0.00');
+        setQuickNote('');
+        setQuickReference('');
+      }
+
+      await loadOrders();
+    } catch (error: any) {
+      setState('failed');
+      setMessage(error?.message || 'Payment failed.');
+      if (sessionIdForCleanup) {
+        await fetch('/api/dashboard/internal-settlement/cancel', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ session_id: sessionIdForCleanup }),
+        }).catch(() => undefined);
+      }
+    } finally {
+      setBusy(false);
+    }
+  }, [amountCents, busy, loadOrders, mode, quickNote, quickReference, selectedOrderId]);
+
+  const handleCancel = useCallback(async () => {
+    if (!activeSessionId) return;
+    setBusy(true);
+    try {
+      await fetch('/api/dashboard/internal-settlement/cancel', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ session_id: activeSessionId }),
+      });
+      setState('canceled');
+      setMessage('Payment canceled.');
+      setActiveSessionId(null);
+      setActiveTerminalLocationId(null);
+      await loadOrders();
+    } finally {
+      setBusy(false);
+    }
+  }, [activeSessionId, loadOrders]);
+
+  return (
+    <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Internal settlement module</p>
+      <h1 className="mt-2 text-2xl font-semibold tracking-tight text-slate-900 sm:text-3xl">Internal collection</h1>
+
+      <div className="mt-6 flex flex-wrap gap-2 rounded-2xl bg-slate-100 p-1">
+        <button
+          type="button"
+          onClick={() => setMode('order_payment')}
+          className={`rounded-xl px-4 py-2 text-sm font-semibold transition ${
+            mode === 'order_payment' ? 'bg-white text-slate-900 shadow-sm' : 'text-slate-600'
+          }`}
+        >
+          Order payment
+        </button>
+        <button
+          type="button"
+          onClick={() => setMode('quick_charge')}
+          className={`rounded-xl px-4 py-2 text-sm font-semibold transition ${
+            mode === 'quick_charge' ? 'bg-white text-slate-900 shadow-sm' : 'text-slate-600'
+          }`}
+        >
+          Quick charge
+        </button>
+      </div>
+
+      <div className="mt-6 grid gap-6 lg:grid-cols-2">
+        <div className="space-y-4 rounded-2xl border border-slate-200 p-4">
+          <h2 className="text-sm font-semibold text-slate-900">Amount</h2>
+          {mode === 'order_payment' ? (
+            <>
+              <label className="block text-xs font-medium uppercase tracking-[0.12em] text-slate-500">Unpaid order</label>
+              <select
+                value={selectedOrderId}
+                onChange={(event) => setSelectedOrderId(event.target.value)}
+                disabled={loadingOrders || busy}
+                className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm"
+              >
+                {orders.length === 0 ? <option value="">No unpaid orders</option> : null}
+                {orders.map((order) => (
+                  <option key={order.id} value={order.id}>
+                    #{order.short_order_number ?? '—'} · {order.customer_name || 'Guest'} · {formatPrice(Number(order.total_price || 0) / 100)}
+                  </option>
+                ))}
+              </select>
+            </>
+          ) : (
+            <>
+              <label className="block text-xs font-medium uppercase tracking-[0.12em] text-slate-500">Custom amount ({toCurrencyCode('gbp')})</label>
+              <input
+                type="number"
+                min="0"
+                step="0.01"
+                value={quickAmount}
+                onChange={(event) => setQuickAmount(event.target.value)}
+                disabled={busy}
+                className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm"
+              />
+              <input
+                type="text"
+                value={quickReference}
+                onChange={(event) => setQuickReference(event.target.value)}
+                disabled={busy}
+                placeholder="Reference (optional)"
+                className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm"
+              />
+              <textarea
+                value={quickNote}
+                onChange={(event) => setQuickNote(event.target.value)}
+                disabled={busy}
+                placeholder="Note (optional)"
+                className="min-h-[84px] w-full rounded-xl border border-slate-200 px-3 py-2 text-sm"
+              />
+            </>
+          )}
+          <div className="rounded-2xl bg-slate-50 px-4 py-3">
+            <p className="text-xs uppercase tracking-[0.12em] text-slate-500">Amount to collect</p>
+            <p className="mt-1 text-2xl font-semibold text-slate-900">{amountLabel}</p>
+          </div>
+        </div>
+
+        <div className="space-y-4 rounded-2xl border border-slate-200 p-4">
+          <h2 className="text-sm font-semibold text-slate-900">Payment method</h2>
+          <p className="text-sm text-slate-600">Contactless card-present via Tap to Pay</p>
+
+          <div
+            className={`rounded-2xl border px-4 py-3 text-sm ${
+              state === 'succeeded'
+                ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+                : state === 'failed' || state === 'canceled'
+                  ? 'border-rose-200 bg-rose-50 text-rose-700'
+                  : state === 'unavailable'
+                    ? 'border-amber-200 bg-amber-50 text-amber-700'
+                    : 'border-slate-200 bg-slate-50 text-slate-700'
+            }`}
+          >
+            <p className="font-semibold">Collection state: {state.replace('_', ' ')}</p>
+            <p className="mt-1 text-xs">{message}</p>
+            {activeSessionId ? <p className="mt-2 text-[11px] text-slate-500">Session: {activeSessionId}</p> : null}
+            {activeTerminalLocationId ? (
+              <p className="mt-1 text-[11px] text-slate-500">Terminal location: {activeTerminalLocationId}</p>
+            ) : null}
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            <button
+              type="button"
+              disabled={busy || amountCents <= 0 || (mode === 'order_payment' && !selectedOrderId)}
+              onClick={handleCollectContactless}
+              className="rounded-full bg-slate-900 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-300"
+            >
+              {busy ? 'Collecting…' : 'Collect contactless'}
+            </button>
+            <button
+              type="button"
+              disabled={busy || !activeSessionId}
+              onClick={handleCancel}
+              className="rounded-full border border-slate-200 bg-white px-5 py-2.5 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              Cancel session
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/lib/server/payments/internalSettlementService.ts
+++ b/lib/server/payments/internalSettlementService.ts
@@ -1,0 +1,252 @@
+import { requestPrintJobCreation } from '@/lib/print-jobs/request';
+import { supaServer } from '@/lib/supaServer';
+import {
+  cancelKioskPaymentSession,
+  createKioskCardPresentSession,
+  createOrRetrieveCardPresentPaymentIntentForSession,
+  finalizeSuccessfulKioskPaymentSession,
+  markKioskPaymentSessionState,
+  verifyKioskSessionPaymentCompletion,
+} from '@/lib/server/payments/kioskCardPresentService';
+
+export type InternalSettlementMode = 'order_payment' | 'quick_charge';
+
+export type UnpaidOrderSummary = {
+  id: string;
+  short_order_number: number | null;
+  customer_name: string | null;
+  order_type: string | null;
+  status: string;
+  total_price: number | null;
+  created_at: string;
+};
+
+const isOrderPaymentUnpaid = (value: unknown) => {
+  if (typeof value !== 'string') return true;
+  return value === '' || value === 'unpaid' || value === 'failed';
+};
+
+const isCollectionOperationalType = (orderType: string | null | undefined) => {
+  if (!orderType) return true;
+  return orderType !== 'delivery';
+};
+
+const maybeAutoCompletePreparedOrder = async (input: { orderId: string; orderStatus: string; orderType: string | null }) => {
+  if (!isCollectionOperationalType(input.orderType)) return;
+  if (input.orderStatus !== 'prepared') return;
+
+  const { error } = await supaServer
+    .from('orders')
+    .update({ status: 'completed' })
+    .eq('id', input.orderId)
+    .eq('status', 'prepared');
+
+  if (error) {
+    console.error('[internal-settlement] failed to auto-complete prepared order', {
+      order_id: input.orderId,
+      error: error.message,
+    });
+  }
+};
+
+export const listUnpaidOrdersForSettlement = async (restaurantId: string, limit = 80): Promise<UnpaidOrderSummary[]> => {
+  const { data, error } = await supaServer
+    .from('orders')
+    .select('id,short_order_number,customer_name,order_type,status,total_price,created_at,payment_status')
+    .eq('restaurant_id', restaurantId)
+    .in('status', ['pending', 'accepted', 'prepared'])
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (error) throw error;
+
+  return (data || [])
+    .filter((row: any) => isOrderPaymentUnpaid(row.payment_status) && Number(row.total_price || 0) > 0)
+    .map((row: any) => ({
+      id: String(row.id),
+      short_order_number: row.short_order_number == null ? null : Number(row.short_order_number),
+      customer_name: row.customer_name ? String(row.customer_name) : null,
+      order_type: row.order_type ? String(row.order_type) : null,
+      status: String(row.status || 'pending'),
+      total_price: row.total_price == null ? null : Number(row.total_price),
+      created_at: String(row.created_at),
+    }));
+};
+
+export const createInternalSettlementSession = async (input: {
+  restaurantId: string;
+  mode: InternalSettlementMode;
+  idempotencyKey: string;
+  currency?: string;
+  orderId?: string | null;
+  amountCents?: number | null;
+  note?: string | null;
+  reference?: string | null;
+}) => {
+  const mode = input.mode;
+  const currency = (input.currency || 'gbp').toLowerCase();
+
+  if (mode === 'order_payment') {
+    if (!input.orderId) throw new Error('order_id is required for order payment');
+
+    const { data: order, error } = await supaServer
+      .from('orders')
+      .select('id,restaurant_id,total_price,status,order_type,payment_status')
+      .eq('id', input.orderId)
+      .eq('restaurant_id', input.restaurantId)
+      .maybeSingle();
+
+    if (error) throw error;
+    if (!order) throw new Error('Order not found');
+    if (!isOrderPaymentUnpaid(order.payment_status)) throw new Error('Order is already settled');
+
+    const orderAmount = Math.max(1, Number(order.total_price || 0));
+    if (orderAmount <= 0) throw new Error('Order has no outstanding amount');
+
+    const { error: pendingError } = await supaServer
+      .from('orders')
+      .update({
+        payment_status: 'pending',
+        payment_method: 'card_present',
+        paid_at: null,
+      })
+      .eq('id', order.id)
+      .eq('restaurant_id', input.restaurantId);
+
+    if (pendingError) throw pendingError;
+
+    const session = await createKioskCardPresentSession({
+      restaurantId: input.restaurantId,
+      orderId: String(order.id),
+      amountCents: orderAmount,
+      currency,
+      idempotencyKey: input.idempotencyKey,
+      metadata: {
+        settlement_module: 'internal',
+        settlement_mode: mode,
+      },
+    });
+
+    return { session, amountCents: orderAmount, currency };
+  }
+
+  const customAmount = Math.max(1, Math.floor(Number(input.amountCents || 0)));
+  if (!customAmount) throw new Error('amount_cents is required for quick charge');
+
+  const session = await createKioskCardPresentSession({
+    restaurantId: input.restaurantId,
+    amountCents: customAmount,
+    currency,
+    idempotencyKey: input.idempotencyKey,
+    metadata: {
+      settlement_module: 'internal',
+      settlement_mode: mode,
+      quick_charge_note: input.note?.trim() || null,
+      quick_charge_reference: input.reference?.trim() || null,
+    },
+  });
+
+  return { session, amountCents: customAmount, currency };
+};
+
+export const createInternalSettlementPaymentIntent = async (input: { sessionId: string; restaurantId: string }) => {
+  return createOrRetrieveCardPresentPaymentIntentForSession({
+    sessionId: input.sessionId,
+    restaurantId: input.restaurantId,
+  });
+};
+
+export const finalizeInternalSettlement = async (input: { sessionId: string; restaurantId: string }) => {
+  const finalized = await finalizeSuccessfulKioskPaymentSession({
+    sessionId: input.sessionId,
+    restaurantId: input.restaurantId,
+  });
+
+  const verification = await verifyKioskSessionPaymentCompletion(finalized.session);
+  if (!verification.verifiedPaid) {
+    await markKioskPaymentSessionState({
+      sessionId: finalized.session.id,
+      restaurantId: input.restaurantId,
+      nextState: 'failed',
+      failureCode: 'verification_failed',
+      failureMessage: verification.reason,
+      eventType: 'internal_settlement_verification_failed',
+      eventPayload: { payment_intent_status: verification.paymentIntentStatus },
+    });
+    throw new Error(`Payment verification failed: ${verification.reason}`);
+  }
+
+  if (finalized.session.order_id) {
+    const paidAt = new Date().toISOString();
+    const { data: updatedOrder, error } = await supaServer
+      .from('orders')
+      .update({
+        payment_status: 'paid',
+        payment_method: 'card_present',
+        paid_at: paidAt,
+        payment_reference: finalized.session.stripe_payment_intent_id,
+      })
+      .eq('id', finalized.session.order_id)
+      .eq('restaurant_id', input.restaurantId)
+      .select('id,status,order_type,restaurant_id')
+      .maybeSingle();
+
+    if (error) throw error;
+
+    if (updatedOrder) {
+      await maybeAutoCompletePreparedOrder({
+        orderId: String(updatedOrder.id),
+        orderStatus: String(updatedOrder.status || ''),
+        orderType: updatedOrder.order_type ? String(updatedOrder.order_type) : null,
+      });
+
+      try {
+        await requestPrintJobCreation({
+          restaurantId: String(updatedOrder.restaurant_id),
+          orderId: String(updatedOrder.id),
+          ticketType: 'invoice',
+          source: 'auto',
+          triggerEvent: 'payment_succeeded',
+          dedupeToken: `payment_succeeded:${updatedOrder.id}`,
+        });
+      } catch (printError) {
+        console.warn('[internal-settlement] payment settled but print job creation failed', {
+          order_id: updatedOrder.id,
+          error: printError,
+        });
+      }
+    }
+  }
+
+  return {
+    session: finalized.session,
+    verification,
+  };
+};
+
+export const cancelInternalSettlement = async (input: { sessionId: string; restaurantId: string }) => {
+  const canceled = await cancelKioskPaymentSession({
+    sessionId: input.sessionId,
+    restaurantId: input.restaurantId,
+  });
+
+  if (canceled.order_id) {
+    const { error } = await supaServer
+      .from('orders')
+      .update({
+        payment_status: 'failed',
+      })
+      .eq('id', canceled.order_id)
+      .eq('restaurant_id', input.restaurantId)
+      .neq('payment_status', 'paid');
+
+    if (error) {
+      console.error('[internal-settlement] failed to mark order payment failed after cancellation', {
+        order_id: canceled.order_id,
+        error: error.message,
+      });
+    }
+  }
+
+  return { session: canceled };
+};

--- a/pages/api/dashboard/internal-settlement/cancel.ts
+++ b/pages/api/dashboard/internal-settlement/cancel.ts
@@ -1,0 +1,23 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { resolveRestaurantIdFromSession } from '@/lib/server/payments/stripeConnectService';
+import { cancelInternalSettlement } from '@/lib/server/payments/internalSettlementService';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  const restaurantId = await resolveRestaurantIdFromSession(req, res);
+  if (!restaurantId) return res.status(401).json({ message: 'Unauthorized' });
+
+  try {
+    const sessionId = String(req.body?.session_id || '');
+    if (!sessionId) return res.status(400).json({ message: 'session_id is required' });
+
+    const result = await cancelInternalSettlement({ sessionId, restaurantId });
+    return res.status(200).json(result);
+  } catch (error: any) {
+    return res.status(400).json({ message: error?.message || 'Failed to cancel settlement session' });
+  }
+}

--- a/pages/api/dashboard/internal-settlement/create-session.ts
+++ b/pages/api/dashboard/internal-settlement/create-session.ts
@@ -1,0 +1,31 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { resolveRestaurantIdFromSession } from '@/lib/server/payments/stripeConnectService';
+import { createInternalSettlementSession, type InternalSettlementMode } from '@/lib/server/payments/internalSettlementService';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  const restaurantId = await resolveRestaurantIdFromSession(req, res);
+  if (!restaurantId) return res.status(401).json({ message: 'Unauthorized' });
+
+  try {
+    const mode = (req.body?.mode || 'order_payment') as InternalSettlementMode;
+    const result = await createInternalSettlementSession({
+      restaurantId,
+      mode,
+      idempotencyKey: String(req.body?.idempotency_key || ''),
+      orderId: req.body?.order_id ? String(req.body.order_id) : null,
+      amountCents: req.body?.amount_cents == null ? null : Number(req.body.amount_cents),
+      currency: req.body?.currency ? String(req.body.currency) : 'gbp',
+      note: req.body?.note ? String(req.body.note) : null,
+      reference: req.body?.reference ? String(req.body.reference) : null,
+    });
+
+    return res.status(200).json(result);
+  } catch (error: any) {
+    return res.status(400).json({ message: error?.message || 'Failed to create settlement session' });
+  }
+}

--- a/pages/api/dashboard/internal-settlement/finalize.ts
+++ b/pages/api/dashboard/internal-settlement/finalize.ts
@@ -1,0 +1,23 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { resolveRestaurantIdFromSession } from '@/lib/server/payments/stripeConnectService';
+import { finalizeInternalSettlement } from '@/lib/server/payments/internalSettlementService';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  const restaurantId = await resolveRestaurantIdFromSession(req, res);
+  if (!restaurantId) return res.status(401).json({ message: 'Unauthorized' });
+
+  try {
+    const sessionId = String(req.body?.session_id || '');
+    if (!sessionId) return res.status(400).json({ message: 'session_id is required' });
+
+    const result = await finalizeInternalSettlement({ sessionId, restaurantId });
+    return res.status(200).json(result);
+  } catch (error: any) {
+    return res.status(400).json({ message: error?.message || 'Failed to finalize settlement' });
+  }
+}

--- a/pages/api/dashboard/internal-settlement/payment-intent.ts
+++ b/pages/api/dashboard/internal-settlement/payment-intent.ts
@@ -1,0 +1,23 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { resolveRestaurantIdFromSession } from '@/lib/server/payments/stripeConnectService';
+import { createInternalSettlementPaymentIntent } from '@/lib/server/payments/internalSettlementService';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  const restaurantId = await resolveRestaurantIdFromSession(req, res);
+  if (!restaurantId) return res.status(401).json({ message: 'Unauthorized' });
+
+  try {
+    const sessionId = String(req.body?.session_id || '');
+    if (!sessionId) return res.status(400).json({ message: 'session_id is required' });
+
+    const paymentIntent = await createInternalSettlementPaymentIntent({ sessionId, restaurantId });
+    return res.status(200).json(paymentIntent);
+  } catch (error: any) {
+    return res.status(400).json({ message: error?.message || 'Failed to create payment intent' });
+  }
+}

--- a/pages/api/dashboard/internal-settlement/tap-to-pay-availability.ts
+++ b/pages/api/dashboard/internal-settlement/tap-to-pay-availability.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { resolveRestaurantIdFromSession } from '@/lib/server/payments/stripeConnectService';
+import { getRestaurantStripeContext } from '@/lib/server/payments/restaurantStripeContext';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  const restaurantId = await resolveRestaurantIdFromSession(req, res);
+  if (!restaurantId) return res.status(401).json({ message: 'Unauthorized' });
+
+  try {
+    const context = await getRestaurantStripeContext(restaurantId);
+    return res.status(200).json({
+      tap_to_pay_available: !!context?.tapToPayAvailable,
+      terminal_location_id: context?.terminalLocationId ?? null,
+      reason: context?.paymentReadinessReason ?? null,
+    });
+  } catch (error: any) {
+    return res.status(500).json({ message: error?.message || 'Failed to resolve Tap to Pay availability' });
+  }
+}

--- a/pages/api/dashboard/internal-settlement/unpaid-orders.ts
+++ b/pages/api/dashboard/internal-settlement/unpaid-orders.ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { resolveRestaurantIdFromSession } from '@/lib/server/payments/stripeConnectService';
+import { listUnpaidOrdersForSettlement } from '@/lib/server/payments/internalSettlementService';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  const restaurantId = await resolveRestaurantIdFromSession(req, res);
+  if (!restaurantId) return res.status(401).json({ message: 'Unauthorized' });
+
+  try {
+    const orders = await listUnpaidOrdersForSettlement(restaurantId);
+    return res.status(200).json({ restaurant_id: restaurantId, orders });
+  } catch (error: any) {
+    return res.status(500).json({ message: error?.message || 'Failed to load unpaid orders' });
+  }
+}

--- a/pages/pos/[restaurantId]/payment-entry.tsx
+++ b/pages/pos/[restaurantId]/payment-entry.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/router';
 import FullscreenAppLayout from '@/components/layouts/FullscreenAppLayout';
+import InternalSettlementModule from '@/components/payments/InternalSettlementModule';
 
 export default function PosPaymentEntryPage() {
   const router = useRouter();
@@ -9,28 +10,22 @@ export default function PosPaymentEntryPage() {
   return (
     <FullscreenAppLayout
       promptTitle="Tap to enter fullscreen"
-      promptDescription="Keep POS payment entry immersive while this shell is being wired."
+      promptDescription="Keep POS payment entry immersive while internal settlement is in use."
     >
-      <div className="mx-auto w-full max-w-3xl px-4 py-6 sm:px-6">
-        <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">POS payment entry</p>
-          <h1 className="mt-2 text-2xl font-semibold tracking-tight text-slate-900 sm:text-3xl">POS payment shell ready</h1>
-          <p className="mt-3 text-sm leading-relaxed text-slate-600 sm:text-base">
-            This route is reserved for POS-only payment UI handoff. It intentionally contains no live payment integrations yet.
-          </p>
-          <div className="mt-6 flex flex-wrap gap-3">
-            <button
-              type="button"
-              onClick={() => {
-                if (!restaurantId) return;
-                router.push(`/pos/${restaurantId}`).catch(() => undefined);
-              }}
-              className="rounded-full bg-slate-900 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800"
-            >
-              Back to POS
-            </button>
-          </div>
-        </section>
+      <div className="mx-auto w-full max-w-5xl px-4 py-6 sm:px-6">
+        <InternalSettlementModule />
+        <div className="mt-4">
+          <button
+            type="button"
+            onClick={() => {
+              if (!restaurantId) return;
+              router.push(`/pos/${restaurantId}`).catch(() => undefined);
+            }}
+            className="rounded-full border border-slate-200 bg-white px-5 py-2.5 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50"
+          >
+            Back to POS
+          </button>
+        </div>
       </div>
     </FullscreenAppLayout>
   );

--- a/supabase/migrations/20260406110000_orders_payment_settlement_foundation.sql
+++ b/supabase/migrations/20260406110000_orders_payment_settlement_foundation.sql
@@ -1,0 +1,22 @@
+ALTER TABLE IF EXISTS public.orders
+  ADD COLUMN IF NOT EXISTS payment_status text NOT NULL DEFAULT 'unpaid',
+  ADD COLUMN IF NOT EXISTS payment_method text,
+  ADD COLUMN IF NOT EXISTS paid_at timestamptz,
+  ADD COLUMN IF NOT EXISTS payment_reference text;
+
+UPDATE public.orders
+SET payment_status = COALESCE(NULLIF(payment_status, ''), 'unpaid')
+WHERE payment_status IS NULL OR payment_status = '';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'orders_payment_status_check'
+  ) THEN
+    ALTER TABLE public.orders
+      ADD CONSTRAINT orders_payment_status_check
+      CHECK (payment_status IN ('unpaid', 'pending', 'paid', 'failed', 'refunded'));
+  END IF;
+END $$;


### PR DESCRIPTION
### Motivation
- Separate financial settlement from operational order flow by adding dedicated payment fields to `orders` so `orders.status` remains operational only.
- Provide a small, reusable internal settlement foundation that supports collecting payment for an existing unpaid order and taking quick custom charges without duplicating the kiosk Tap-to-Pay engine.
- Reuse the existing kiosk card-present infrastructure (`kiosk_card_present_sessions` and Stripe Terminal internals) so Till/POS and staff-device terminals can share the same backend payment flow.

### Description
- Schema: added a safe migration `supabase/migrations/20260406110000_orders_payment_settlement_foundation.sql` which adds `payment_status`, `payment_method`, `paid_at`, and `payment_reference` to `orders`, backfills blank/null values to `unpaid`, and enforces a check constraint limiting `payment_status` to `unpaid|pending|paid|failed|refunded`.
- Backend service & APIs: implemented `lib/server/payments/internalSettlementService.ts` and dashboard-authenticated endpoints under `pages/api/dashboard/internal-settlement/*` to list unpaid orders, create settlement sessions (reusing `createKioskCardPresentSession` which writes to `kiosk_card_present_sessions`), create/retrieve PaymentIntents, finalize settlements, cancel sessions, and check Tap-to-Pay availability.
- UI & integration: added a reusable `components/payments/InternalSettlementModule.tsx` providing `Order payment` and `Quick charge` modes (amount panel, unpaid-order selector, contactless collection state, unsupported-device state, success/failure/cancel states), and mounted it in the POS payment-entry route at `pages/pos/[restaurantId]/payment-entry.tsx` for Till/POS usage.
- Business rules & resilience: finalized payments update the new `orders` payment fields and auto-complete an order only when `status === 'prepared'` AND the order type is non-delivery (collection-style), print job enqueueing for invoices is attempted but wrapped in `try/catch` so print failures do not block payment or order settlement, and canceled sessions mark linked orders as `payment_status='failed'` (without changing operational `status`).

### Testing
- TypeScript compilation passed: `npx tsc --noEmit` completed successfully. 
- No additional automated unit tests were added in this pass and existing surfaces were kept untouched for kiosk customer flow and the Orders page; manual smoke and integration validation should follow when running the migration and exercising POS/Till flows against Stripe/test terminals.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3b474e75c832580401f89f6d49f78)