### PR TITLE
fix(android-taptopay): align processPaymentIntent call to Stripe Terminal 5.3.0 signature

### DIFF
--- a/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
+++ b/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
@@ -535,6 +535,7 @@ public class OrderfastTapToPayPlugin extends Plugin {
                                     status = "processing";
                                     processCancelable = Terminal.getInstance().processPaymentIntent(
                                         collectedIntent,
+                                        new CollectPaymentIntentConfiguration.Builder().build(),
                                         new ConfirmPaymentIntentConfiguration.Builder().build(),
                                         new PaymentIntentCallback() {
                                             @Override


### PR DESCRIPTION
### Motivation
- The Android native build failed due to a method signature mismatch when calling `Terminal.getInstance().processPaymentIntent(...)`, so the plugin needs to call the SDK API with the exact parameter order and types required by the installed Stripe Terminal SDK.

### Description
- Confirmed Gradle resolves Stripe Terminal Android SDK at `com.stripe:stripeterminal:5.3.0` (also `stripeterminal-taptopay:5.3.0`).
- Updated the `processPaymentIntent(...)` invocation to the exact 4-argument shape required by the installed SDK: `PaymentIntent`, `CollectPaymentIntentConfiguration`, `ConfirmPaymentIntentConfiguration`, `PaymentIntentCallback` (call now: `processPaymentIntent(collectedIntent, new CollectPaymentIntentConfiguration.Builder().build(), new ConfirmPaymentIntentConfiguration.Builder().build(), new PaymentIntentCallback() { ... })`).
- File changed: `android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java`.
- The previous fix was still wrong because it omitted the `CollectPaymentIntentConfiguration` argument (and/or passed `ConfirmPaymentIntentConfiguration` in the wrong position), which caused Java to attempt to convert a `CollectPaymentIntentConfiguration` into a `PaymentIntentCallback` and otherwise mis-match overload parameter positions.
- This change keeps runtime logic intact and only fixes the compile-time argument order/type to match the installed SDK exactly.

### Testing
- Ran `./gradlew :app:dependencies --configuration debugCompileClasspath` to verify `stripeterminal` and `stripeterminal-taptopay` resolve to `5.3.0`, which succeeded.
- Attempted `./gradlew :app:compileDebugJavaWithJavac` in the environment, but the run was blocked by missing Android SDK configuration (`sdk.dir`/`ANDROID_HOME`), so a full native compile could not be executed here; this prevented final local verification in the CI environment.
- Given the exact signature alignment to Stripe Terminal `5.3.0`, the original `processPaymentIntent` argument order/type mismatch error should be resolved when the project is built in an Android SDK-configured environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3bebc7ce08325b3e143b1a546d9c8)