### PR TITLE
fix(tap-to-pay): stop forced destroy-time cancel and add native flow tracing

### DIFF
--- a/android/app/src/main/java/com/orderfast/app/MainActivity.java
+++ b/android/app/src/main/java/com/orderfast/app/MainActivity.java
@@ -8,18 +8,38 @@ import android.view.WindowManager;
 import android.view.WindowInsets;
 import android.view.WindowInsetsController;
 import android.webkit.WebBackForwardList;
+import android.content.res.Configuration;
+import android.util.Log;
 
 import com.getcapacitor.BridgeActivity;
 import android.webkit.WebView;
 
 public class MainActivity extends BridgeActivity {
+    private static final String TAG = "OrderfastMainActivity";
+    private static int activityInstanceCounter = 0;
     private final Handler immersiveHandler = new Handler(Looper.getMainLooper());
     private final Runnable immersiveRunnable = this::applyImmersiveMode;
+    private int activityInstanceId = 0;
+
+    private void logLifecycle(String event, Bundle savedInstanceState) {
+        Log.i(
+            TAG,
+            "[kiosk][activity_lifecycle] event=" + event
+                + " instanceId=" + activityInstanceId
+                + " instanceHash=" + System.identityHashCode(this)
+                + " hasBridge=" + (bridge != null)
+                + " hasSavedState=" + (savedInstanceState != null)
+                + " isChangingConfigurations=" + isChangingConfigurations()
+                + " tsMs=" + System.currentTimeMillis()
+        );
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        activityInstanceId = ++activityInstanceCounter;
         registerPlugin(OrderfastTapToPayPlugin.class);
         super.onCreate(savedInstanceState);
+        logLifecycle("onCreate", savedInstanceState);
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
         applyImmersiveMode();
         configureWebViewPresentation();
@@ -47,7 +67,39 @@ public class MainActivity extends BridgeActivity {
     @Override
     public void onResume() {
         super.onResume();
+        logLifecycle("onResume", null);
         immersiveHandler.postDelayed(immersiveRunnable, 120);
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        logLifecycle("onStart", null);
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        logLifecycle("onStop", null);
+    }
+
+    @Override
+    protected void onDestroy() {
+        logLifecycle("onDestroy", null);
+        super.onDestroy();
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        Log.i(
+            TAG,
+            "[kiosk][activity_lifecycle] event=onConfigurationChanged"
+                + " instanceId=" + activityInstanceId
+                + " orientation=" + newConfig.orientation
+                + " uiMode=" + newConfig.uiMode
+                + " tsMs=" + System.currentTimeMillis()
+        );
     }
 
     @Override

--- a/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
+++ b/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
@@ -99,6 +99,17 @@ public class OrderfastTapToPayPlugin extends Plugin {
     private volatile long lastStopAtMs = 0L;
     private volatile long lastResumeAtMs = 0L;
 
+    private void logFlowEvent(String stage, JSObject payload) {
+        payload.put("timestampMs", System.currentTimeMillis());
+        logStartupStage(stage, payload);
+    }
+
+    private void logCancelSource(String source) {
+        JSObject payload = lifecyclePayload("cancel_invoked");
+        payload.put("source", source);
+        logFlowEvent("native_cancel_invoked", payload);
+    }
+
     private void clearActivePaymentState() {
         clearOperationTimeout();
         activePaymentIntent = null;
@@ -185,9 +196,9 @@ public class OrderfastTapToPayPlugin extends Plugin {
     private final TapToPayReaderListener tapToPayReaderListener = new TapToPayReaderListener() {
         @Override
         public void onDisconnect(DisconnectReason reason) {
-            if (isDebugBuild()) {
-                Log.d(TAG, "Reader disconnected: " + reason);
-            }
+            JSObject disconnectPayload = lifecyclePayload("reader_disconnect");
+            disconnectPayload.put("disconnectReason", reason == null ? "UNKNOWN" : reason.name());
+            logFlowEvent("native_disconnect_invoked", disconnectPayload);
             connectedReader = null;
             if (!"canceled".equals(status)) {
                 status = "failed";
@@ -548,6 +559,9 @@ public class OrderfastTapToPayPlugin extends Plugin {
                         logStartupStage("native_collect_start", collectStartPayload);
                         postSessionState("collecting", "native_collect_start");
                         status = "collecting";
+                        JSObject collectInvokedPayload = lifecyclePayload("collect_payment_method_invoked");
+                        collectInvokedPayload.put("paymentIntentId", paymentIntent.getId());
+                        logFlowEvent("native_collect_invoked", collectInvokedPayload);
 
                         Terminal.getInstance().collectPaymentMethod(
                             paymentIntent,
@@ -572,6 +586,9 @@ public class OrderfastTapToPayPlugin extends Plugin {
                                     logStartupStage("native_process_start", processStartPayload);
                                     postSessionState("processing", "native_process_start");
                                     status = "processing";
+                                    JSObject processInvokedPayload = lifecyclePayload("process_payment_intent_invoked");
+                                    processInvokedPayload.put("paymentIntentId", collectedIntent.getId());
+                                    logFlowEvent("native_process_invoked", processInvokedPayload);
                                     processCancelable = Terminal.getInstance().processPaymentIntent(
                                         collectedIntent,
                                         new CollectPaymentIntentConfiguration.Builder().build(),
@@ -626,6 +643,8 @@ public class OrderfastTapToPayPlugin extends Plugin {
                                                 payload.put("interruptionSource", confirmedBackgroundInterruption ? "app_or_device_backgrounded" : (lifecyclePausedDuringActiveFlow ? "transient_lifecycle_change" : "none_detected"));
                                                 payload.put("backgroundInterruptionCandidate", backgroundInterruptionCandidate);
                                                 payload.put("backgroundInterruptionMs", backgroundInterruptionCandidateAtMs > 0 ? (System.currentTimeMillis() - backgroundInterruptionCandidateAtMs) : 0L);
+                                                payload.put("cancelRequestedByApp", cancelRequestedByApp);
+                                                payload.put("isProcessCancelableActive", processCancelable != null && !processCancelable.isCompleted());
                                                 logStartupStage("native_process_result", payload);
                                                 clearActivePaymentState();
                                                 resetStatusForNextAttempt();
@@ -689,10 +708,12 @@ public class OrderfastTapToPayPlugin extends Plugin {
     public void cancelTapToPayPayment(PluginCall call) {
         clearOperationTimeout();
         cancelRequestedByApp = true;
+        logCancelSource("plugin_method:cancelTapToPayPayment");
         logStartupStage("native_cancel_result", detail("native_cancel_result", "entered", null));
         mainHandler.post(() -> {
             try {
                 if (processCancelable != null && !processCancelable.isCompleted()) {
+                    logCancelSource("plugin_method:processCancelable.cancel");
                     processCancelable.cancel(new Callback() {
                         @Override
                         public void onSuccess() {
@@ -721,6 +742,7 @@ public class OrderfastTapToPayPlugin extends Plugin {
                 }
 
                 if (activePaymentIntent != null && Terminal.isInitialized()) {
+                    logCancelSource("plugin_method:cancelPaymentIntent");
                     Terminal.getInstance().cancelPaymentIntent(activePaymentIntent, new PaymentIntentCallback() {
                         @Override
                         public void onSuccess(PaymentIntent paymentIntent) {
@@ -910,12 +932,9 @@ public class OrderfastTapToPayPlugin extends Plugin {
             });
         }
         if (processCancelable != null && !processCancelable.isCompleted()) {
-            processCancelable.cancel(new Callback() {
-                @Override
-                public void onSuccess() {}
-                @Override
-                public void onFailure(TerminalException e) {}
-            });
+            JSObject payload = lifecyclePayload("handleOnDestroy_processCancelable_active");
+            payload.put("action", "left_active_to_avoid_forced_cancel");
+            logFlowEvent("native_cancel_suppressed", payload);
         }
         discoverCancelable = null;
         processCancelable = null;
@@ -1023,6 +1042,7 @@ public class OrderfastTapToPayPlugin extends Plugin {
                 status = "failed";
                 postSessionState("needs_reconciliation", "native_timeout");
                 if (processCancelable != null && !processCancelable.isCompleted()) {
+                    logCancelSource("operation_timeout");
                     processCancelable.cancel(new Callback() {
                         @Override
                         public void onSuccess() {}


### PR DESCRIPTION
### Motivation
- Users observed live Tap to Pay flows ending with `terminalCode = CANCELED` during/after Stripe takeover, so the change targets the single app-owned branch that could inject that cancel during native teardown. 
- Add minimal, focused instrumentation to definitively attribute future `CANCELED` events to an exact source instead of broad lifecycle speculation.

### Description
- Remove forced process cancellation at plugin teardown by stopping the `processCancelable.cancel(...)` call in `handleOnDestroy()` and replace it with a `native_cancel_suppressed` lifecycle log so destroy-time teardown no longer triggers Stripe cancels (file: `android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java`).
- Add flow-level instrumentation for exact tracing: `native_collect_invoked` when `collectPaymentMethod(...)` is called, `native_process_invoked` when `processPaymentIntent(...)` is called, `native_cancel_invoked` with explicit source labels (e.g. `plugin_method:cancelTapToPayPayment`, `plugin_method:processCancelable.cancel`, `operation_timeout`), and `native_disconnect_invoked` with disconnect reason (file: `android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java`).
- Surface more debug fields in process failure payloads (`cancelRequestedByApp`, `isProcessCancelableActive`) so the exact presence/state of app-side cancellation is recorded with `native_process_result` (file: `android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java`).
- Add Activity lifecycle and configuration instrumentation to detect activity/bridge recreation (structured logs from `onCreate`, `onStart`, `onResume`, `onStop`, `onDestroy`, `onConfigurationChanged`) and include instance id/hash and timestamps for correlation (file: `android/app/src/main/java/com/orderfast/app/MainActivity.java`).

### Testing
- Attempted Android Java compile check using `./gradlew :app:compileDebugJavaWithJavac` but the run failed due to no Android SDK configured in the environment (`ANDROID_HOME`/`local.properties` missing), so binary compile could not be validated in this CI container. 
- No unit/integration tests were modified or added in this change; runtime validation should be done on-device to confirm `native_process_result` no longer shows app-initiated `CANCELED` caused by destroy-time teardown and that new logs produce the expected flow events.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d695871ca88325a343731b68d25c90)