### PR TITLE
fix(payments): harden quick charge process-stage lifecycle handling

### DIFF
--- a/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
+++ b/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
@@ -137,6 +137,10 @@ public class OrderfastTapToPayPlugin extends Plugin {
         return inFlight && ("collecting".equals(status) || "processing".equals(status));
     }
 
+    private boolean isProcessStageActive() {
+        return inFlight && "processing".equals(status);
+    }
+
     private JSObject paymentRunGuardPayload(String path, String reason) {
         JSObject payload = lifecyclePayload("payment_run_guard");
         payload.put("path", path);
@@ -1255,6 +1259,14 @@ public class OrderfastTapToPayPlugin extends Plugin {
         traceTimeline("plugin_handleOnStop", null);
         if (inFlight && ("collecting".equals(status) || "processing".equals(status))) {
             stripeTakeoverObserved = true;
+            if ("processing".equals(status)) {
+                lifecyclePausedDuringActiveFlow = false;
+                confirmedBackgroundInterruption = false;
+                backgroundInterruptionCandidate = false;
+                backgroundInterruptionCandidateAtMs = 0L;
+                logStartupStage("native_lifecycle", detail("native_lifecycle", "transient_stop_during_process_takeover", status));
+                return;
+            }
             if (appInBackground && !changingConfigurations) {
                 lifecyclePausedDuringActiveFlow = true;
                 backgroundInterruptionCandidate = true;
@@ -1561,6 +1573,9 @@ public class OrderfastTapToPayPlugin extends Plugin {
     }
 
     private boolean isConfirmedLifecycleInterruption() {
+        if (isProcessStageActive() && stripeTakeoverObserved) {
+            return false;
+        }
         if (confirmedBackgroundInterruption && isAppInBackground()) {
             return true;
         }

--- a/components/payments/InternalSettlementModule.tsx
+++ b/components/payments/InternalSettlementModule.tsx
@@ -754,10 +754,12 @@ export default function InternalSettlementModule({
     } catch (error: any) {
       logCollectionEvent('collection_exception', { message: error?.message || 'unknown_exception' });
       let nativeRunStillActive = false;
+      let nativeRunStatus: string | null = null;
       if (sessionIdForCleanup) {
         try {
           const nativeState = await tapToPayBridge.getActivePaymentRunState();
           nativeRunStillActive = nativeState.activeRun === true || nativeState.inFlight === true;
+          nativeRunStatus = typeof nativeState.status === 'string' ? nativeState.status : null;
           logCollectionEvent('collection_exception_native_state_check', {
             sessionId: sessionIdForCleanup,
             activeRun: nativeState.activeRun,
@@ -770,8 +772,13 @@ export default function InternalSettlementModule({
       }
       if (nativeRunStillActive) {
         keepFlowActiveAfterError = true;
-        setState('collecting');
-        setMessage('Tap to Pay remains active on device. Waiting for native completion callback…');
+        const processingInFlight = nativeRunStatus === 'processing';
+        setState(processingInFlight ? 'processing' : 'collecting');
+        setMessage(
+          processingInFlight
+            ? 'Tap to Pay is still processing on device. Waiting for native process callback…'
+            : 'Tap to Pay remains active on device. Waiting for native completion callback…'
+        );
         return;
       }
       setState('failed');
@@ -833,18 +840,24 @@ export default function InternalSettlementModule({
         return;
       }
       if (nativeState.activeRun && activeRun?.sessionId) {
+        const processingInFlight = nativeState.status === 'processing';
         logCollectionEvent('app_resume_rehydrated_active_run', {
           source,
           sessionId: activeRun.sessionId,
           nativeStatus: nativeState.status,
           nativeFlowRunId: nativeState.flowRunId || null,
+          processStageInFlight: processingInFlight,
         });
         setBusy(true);
         flowActiveRef.current = true;
         setActiveSessionId(activeRun.sessionId);
         setActiveTerminalLocationId(activeRun.terminalLocationId);
-        setState('collecting');
-        setMessage('Rehydrated active Tap to Pay run after resume.');
+        setState(processingInFlight ? 'processing' : 'collecting');
+        setMessage(
+          processingInFlight
+            ? 'Rehydrated active Tap to Pay run while processPaymentIntent is in progress.'
+            : 'Rehydrated active Tap to Pay run after resume.'
+        );
       }
       const cached = (nativeState.cachedFinalResult as Record<string, unknown> | undefined) || null;
       if (cached && activeRun?.sessionId) {


### PR DESCRIPTION
### Motivation
- Quick-charge failures showed the flow succeeds through collect but then the `processPaymentIntent` callback was classified as `lifecycle_interrupted` due to transient activity pause/stop churn during the Stripe SDK takeover. The goal is to stop transient pause/stop/focus churn from being treated as a destructive lifecycle interruption during the process window for launcher -> Take Payment -> Quick charge.

### Description
- Treat the process stage as a special-case by adding `isProcessStageActive()` and short-circuiting `handleOnStop()` when `status == "processing"` so transient stops during active processing clear interruption-candidate flags instead of confirming interruption; change made in `android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java`.
- Prevent `isConfirmedLifecycleInterruption()` from returning true when a process-stage takeover is active so a canceled `processPaymentIntent` callback is not misclassified as `lifecycle_interrupted`; change made in `OrderfastTapToPayPlugin.java`.
- On the JS side, keep the UI/flow in `processing` (rather than prematurely downgrading to collecting/failed) when `getActivePaymentRunState()` reports `status === 'processing'`, both in the exception path and resume rehydration, so the frontend waits for the native process callback; change made in `components/payments/InternalSettlementModule.tsx`.
- No changes were made to kiosk checkout, PWA-only logic, Stripe PaymentIntent creation paths, or `MainActivity` behavior beyond relying on the new process-stage guard.

### Testing
- Typecheck: ran `npx tsc --noEmit` and it completed successfully without type errors.
- Static/local validation: verified modified Java and TSX files compile/parse in-tree and the quick-charge flow code paths touched are limited to the native Tap to Pay plugin and the Internal Settlement UI, with no other surfaces modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7cb0616bc832580504f1bdcd143bc)