### PR TITLE
fix(android): enforce consistent release signing for installable APKs

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -101,27 +101,21 @@ jobs:
             echo "has_release_keystore=true" >> "$GITHUB_ENV"
             echo "Loaded release keystore from ANDROID_KEYSTORE_BASE64 secret"
           else
-            echo "has_release_keystore=false" >> "$GITHUB_ENV"
-            echo "ANDROID_KEYSTORE_BASE64 is not set; using debug signing key for release testing APK"
+            echo "ANDROID_KEYSTORE_BASE64 is not set; refusing to build a release APK with a non-release signing key."
+            exit 1
           fi
 
       - name: Build release APK
         run: |
           cd android
           BUILD_VERSION_NAME="kiosk-${GITHUB_RUN_NUMBER}-${GITHUB_SHA::7}"
-          if [ "$has_release_keystore" = "true" ]; then
-            ./gradlew assembleRelease \
-              -PORDERFAST_VERSION_CODE="$GITHUB_RUN_NUMBER" \
-              -PORDERFAST_VERSION_NAME="$BUILD_VERSION_NAME" \
-              -PORDERFAST_UPLOAD_STORE_FILE="$ANDROID_KEYSTORE_PATH" \
-              -PORDERFAST_UPLOAD_KEY_ALIAS="$ANDROID_KEY_ALIAS" \
-              -PORDERFAST_UPLOAD_STORE_PASSWORD="$ANDROID_KEYSTORE_PASSWORD" \
-              -PORDERFAST_UPLOAD_KEY_PASSWORD="$ANDROID_KEY_PASSWORD"
-          else
-            ./gradlew assembleRelease \
-              -PORDERFAST_VERSION_CODE="$GITHUB_RUN_NUMBER" \
-              -PORDERFAST_VERSION_NAME="$BUILD_VERSION_NAME"
-          fi
+          ./gradlew assembleRelease \
+            -PORDERFAST_VERSION_CODE="$GITHUB_RUN_NUMBER" \
+            -PORDERFAST_VERSION_NAME="$BUILD_VERSION_NAME" \
+            -PORDERFAST_UPLOAD_STORE_FILE="$GITHUB_WORKSPACE/$ANDROID_KEYSTORE_PATH" \
+            -PORDERFAST_UPLOAD_KEY_ALIAS="$ANDROID_KEY_ALIAS" \
+            -PORDERFAST_UPLOAD_STORE_PASSWORD="$ANDROID_KEYSTORE_PASSWORD" \
+            -PORDERFAST_UPLOAD_KEY_PASSWORD="$ANDROID_KEY_PASSWORD"
 
       - name: Verify release manifest is non-debuggable
         run: |

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -4,6 +4,7 @@ def hasReleaseSigningProps = project.hasProperty('ORDERFAST_UPLOAD_STORE_FILE') 
     project.hasProperty('ORDERFAST_UPLOAD_KEY_ALIAS') &&
     project.hasProperty('ORDERFAST_UPLOAD_STORE_PASSWORD') &&
     project.hasProperty('ORDERFAST_UPLOAD_KEY_PASSWORD')
+def hasReleaseStoreFile = hasReleaseSigningProps && file(project.property('ORDERFAST_UPLOAD_STORE_FILE')).exists()
 def orderfastVersionCode = (project.findProperty('ORDERFAST_VERSION_CODE') ?: "1").toInteger()
 def orderfastVersionName = project.findProperty('ORDERFAST_VERSION_NAME') ?: "1.0"
 
@@ -28,7 +29,7 @@ android {
     }
     signingConfigs {
         release {
-            if (hasReleaseSigningProps) {
+            if (hasReleaseStoreFile) {
                 storeFile file(project.property('ORDERFAST_UPLOAD_STORE_FILE'))
                 storePassword project.property('ORDERFAST_UPLOAD_STORE_PASSWORD')
                 keyAlias project.property('ORDERFAST_UPLOAD_KEY_ALIAS')
@@ -44,10 +45,10 @@ android {
             debuggable false
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            if (hasReleaseSigningProps) {
+            if (hasReleaseStoreFile) {
                 signingConfig signingConfigs.release
             } else {
-                signingConfig signingConfigs.debug
+                throw new GradleException("Release signing is required: provide ORDERFAST_UPLOAD_STORE_FILE/ALIAS/PASSWORD properties with a valid keystore file.")
             }
         }
     }


### PR DESCRIPTION
### Motivation
- Prevent CI from producing release APKs with inconsistent or missing release signing that can make the package fail to parse/install on Android 13+ devices. 
- Ensure the CI workflow and module Gradle signing config agree on a valid keystore path and fail early rather than publishing a non-installable artifact.

### Description
- Added a keystore existence gate `hasReleaseStoreFile` and removed the debug-key fallback so `release` builds require a valid keystore and now fail fast in `android/app/build.gradle`.
- Updated `.github/workflows/android-apk.yml` to require `ANDROID_KEYSTORE_BASE64` (fail the job if missing) and pass an absolute `$GITHUB_WORKSPACE/$ANDROID_KEYSTORE_PATH` into Gradle to avoid module-relative keystore resolution issues.
- The change only touches build/signing and CI workflow files and does not modify any Tap-to-Pay or payment flow logic.

### Testing
- Attempted `./gradlew :app:assembleRelease -PORDERFAST_VERSION_CODE=123 -PORDERFAST_VERSION_NAME=test-build` which could not complete in this environment because the Android SDK is not configured (`ANDROID_HOME` / `local.properties`), so the build step could not be fully executed (automated build attempt failed due to environment, not code).
- Ran static checks and repository inspections including manifest and AAR manifest probing for embedded Stripe components to confirm no manifest provider collision and to validate the scope of changes, which completed successfully.
- Validated diffs and workflow syntax sanity checks locally, receiving a here-document warning from the ephemeral check but no blocking syntax errors for the edited job steps.
- Verified that CI will now fail fast when keystore secrets are not provided, preventing creation of unsigned/incorrectly-signed release APK artifacts (behaviour enforced by the updated workflow and Gradle guards).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d81534945c8325aa30f6c1fd8dbc97)