### PR TITLE
fix(android): restore fallback APK signing path when keystore secret is absent

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -101,21 +101,27 @@ jobs:
             echo "has_release_keystore=true" >> "$GITHUB_ENV"
             echo "Loaded release keystore from ANDROID_KEYSTORE_BASE64 secret"
           else
-            echo "ANDROID_KEYSTORE_BASE64 is not set; refusing to build a release APK with a non-release signing key."
-            exit 1
+            echo "has_release_keystore=false" >> "$GITHUB_ENV"
+            echo "ANDROID_KEYSTORE_BASE64 is not set; using debug signing key for release testing APK"
           fi
 
       - name: Build release APK
         run: |
           cd android
           BUILD_VERSION_NAME="kiosk-${GITHUB_RUN_NUMBER}-${GITHUB_SHA::7}"
-          ./gradlew assembleRelease \
-            -PORDERFAST_VERSION_CODE="$GITHUB_RUN_NUMBER" \
-            -PORDERFAST_VERSION_NAME="$BUILD_VERSION_NAME" \
-            -PORDERFAST_UPLOAD_STORE_FILE="$GITHUB_WORKSPACE/$ANDROID_KEYSTORE_PATH" \
-            -PORDERFAST_UPLOAD_KEY_ALIAS="$ANDROID_KEY_ALIAS" \
-            -PORDERFAST_UPLOAD_STORE_PASSWORD="$ANDROID_KEYSTORE_PASSWORD" \
-            -PORDERFAST_UPLOAD_KEY_PASSWORD="$ANDROID_KEY_PASSWORD"
+          if [ "$has_release_keystore" = "true" ]; then
+            ./gradlew assembleRelease \
+              -PORDERFAST_VERSION_CODE="$GITHUB_RUN_NUMBER" \
+              -PORDERFAST_VERSION_NAME="$BUILD_VERSION_NAME" \
+              -PORDERFAST_UPLOAD_STORE_FILE="$GITHUB_WORKSPACE/$ANDROID_KEYSTORE_PATH" \
+              -PORDERFAST_UPLOAD_KEY_ALIAS="$ANDROID_KEY_ALIAS" \
+              -PORDERFAST_UPLOAD_STORE_PASSWORD="$ANDROID_KEYSTORE_PASSWORD" \
+              -PORDERFAST_UPLOAD_KEY_PASSWORD="$ANDROID_KEY_PASSWORD"
+          else
+            ./gradlew assembleRelease \
+              -PORDERFAST_VERSION_CODE="$GITHUB_RUN_NUMBER" \
+              -PORDERFAST_VERSION_NAME="$BUILD_VERSION_NAME"
+          fi
 
       - name: Verify release manifest is non-debuggable
         run: |


### PR DESCRIPTION
### Motivation
- A recent workflow change started exiting when `ANDROID_KEYSTORE_BASE64` was not set, which blocked CI from producing installable test APKs.
- The intent is to restore the previous behavior where CI can still build an installable testing APK when release keystore secrets are absent while keeping proper release signing when secrets are present.

### Description
- Updated `.github/workflows/android-apk.yml` to only modify the release signing gate and Gradle invocation; no other workflow logic (including Tap to Pay steps) was changed.
- In the `Prepare release signing` step the script now writes `has_release_keystore=false` to the environment and logs a fallback message instead of `exit 1` when `ANDROID_KEYSTORE_BASE64` is missing.
- In the `Build release APK` step the workflow now conditionally passes the release keystore Gradle properties only when `has_release_keystore=true`, and otherwise runs `./gradlew assembleRelease` without release signing properties to produce a test APK.
- All Tap to Pay artifact upload steps and release tagging remain unchanged.

### Testing
- Located and inspected the workflow and regression using `rg` and `git show` to find the change that introduced the hard fail, and these checks completed successfully.
- Applied the patch and validated the local diff with `git diff` and `git commit`, and those commands succeeded.
- No CI run was executed as part of this PR, but the change is a minimal workflow-file modification intended to restore installable testing APK output when signing secrets are absent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b582c5b48325a2360c2ae78cd3e8)