### PR TITLE
fix(android): allow fallback signing for test release APK builds

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -48,7 +48,8 @@ android {
             if (hasReleaseStoreFile) {
                 signingConfig signingConfigs.release
             } else {
-                throw new GradleException("Release signing is required: provide ORDERFAST_UPLOAD_STORE_FILE/ALIAS/PASSWORD properties with a valid keystore file.")
+                signingConfig signingConfigs.debug
+                logger.lifecycle("ORDERFAST release signing properties not found; using debug signing config for test APK generation.")
             }
         }
     }


### PR DESCRIPTION
### Motivation
- CI testing must be able to produce an installable Release APK when release keystore secrets are not present so the workflow fallback can validate APK output. 
- Gradle currently hard-fails in `buildTypes.release` if `ORDERFAST` keystore properties are absent, blocking test builds despite the workflow fallback being restored.

### Description
- Changed `android/app/build.gradle` to remove the hard failure and fall back to debug signing for `release` when `ORDERFAST_UPLOAD_*` properties or keystore file are missing, while preserving release signing when the properties and file are present. 
- Exact file changed: `android/app/build.gradle`. 
- Exact Gradle signing gate removed/narrowed: the `throw new GradleException("Release signing is required: provide ORDERFAST_UPLOAD_STORE_FILE/ALIAS/PASSWORD properties with a valid keystore file.")` path was removed and replaced with `signingConfig signingConfigs.debug` plus a lifecycle log when `hasReleaseStoreFile` is false. 
- Behavior before vs after: before, `assembleRelease` would hard-fail whenever `ORDERFAST_UPLOAD_*` props/file were missing; after, if the `ORDERFAST_UPLOAD_*` props and keystore file are present the build uses `signingConfigs.release` as before, and if they are absent the build uses `signingConfigs.debug` so test/fallback Release APK generation can proceed.
- This change is scoped to Android signing/build config only and does not modify any Tap to Pay or payment logic.

### Testing
- Ran `cd android && ./gradlew :app:assembleRelease -x lint -x test` and observed Gradle configuration progress and the lifecycle message `ORDERFAST release signing properties not found; using debug signing config for test APK generation.`, demonstrating the signing gate no longer hard-fails. 
- The build then failed due to an unrelated environment issue (`SDK location not found`), confirming the signing fix took effect and the remaining failure is not related to signing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8c4315d848325abf4e61f2cd0bb36)