### PR TITLE
fix(tap-to-pay): avoid process deferral on transient Stripe takeover focus loss

### DIFF
--- a/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
+++ b/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
@@ -160,7 +160,12 @@ public class OrderfastTapToPayPlugin extends Plugin {
         boolean activityHasFocus = getActivity() != null && getActivity().hasWindowFocus();
         Boolean hostFocus = MainActivity.getHostActivityWindowFocus();
         boolean resolvedFocus = hostFocus != null ? hostFocus : activityHasFocus;
-        return !appInBackground && resolvedFocus;
+        // During Stripe Tap to Pay takeover the host Activity can temporarily lose window focus
+        // even while the app is still foregrounded and collect already succeeded.
+        // Treat that transient focus loss as safe for process handoff so we don't defer process
+        // long enough to require card re-presentment.
+        boolean transientTakeoverFocusLoss = stripeTakeoverObserved && !appInBackground;
+        return !appInBackground && (resolvedFocus || transientTakeoverFocusLoss);
     }
 
     private JSObject paymentRunGuardPayload(String path, String reason) {


### PR DESCRIPTION
### Motivation
- Prevent unnecessary deferral of `processPaymentIntent` during quick-charge Tap to Pay when Stripe takeover can cause a transient host window focus loss that forces the card to be tapped twice.

### Description
- Relax `isHostForegroundAndFocusedForProcess()` in `OrderfastTapToPayPlugin.java` to allow process handoff when the app is foregrounded but window focus was transiently lost due to a Stripe takeover (`stripeTakeoverObserved && !appInBackground`), while preserving the existing app-background protection and diagnostics.

### Testing
- An attempted Android Java compile (`cd android && ./gradlew -q app:compileDebugJavaWithJavac`) failed due to the environment lacking an Android SDK (`ANDROID_HOME`/`local.properties`), so no build was produced; a code audit confirmed `collectPaymentMethod` is invoked once and the collected intent is passed directly into `processPaymentIntent`, and the change was committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d918c50ff48325ab582d90a6e1d8b4)