### PR TITLE
fix(taptopay): stabilize native quick charge collect/process handoff

### DIFF
--- a/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
+++ b/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
@@ -78,8 +78,6 @@ public class OrderfastTapToPayPlugin extends Plugin {
     private static final String TAG = "OrderfastTapToPay";
     private static final long OPERATION_TIMEOUT_MS = 120_000L;
     private static final long BACKGROUND_INTERRUPTION_MIN_MS = 4_000L;
-    private static final long PROCESS_FOREGROUND_WAIT_TIMEOUT_MS = 2_500L;
-    private static final long PROCESS_FOREGROUND_WAIT_POLL_MS = 100L;
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
     private final Handler mainHandler = new Handler(Looper.getMainLooper());
     private final Handler timeoutHandler = new Handler(Looper.getMainLooper());
@@ -153,19 +151,6 @@ public class OrderfastTapToPayPlugin extends Plugin {
 
     private boolean isProcessStageActive() {
         return inFlight && "processing".equals(status);
-    }
-
-    private boolean isHostForegroundAndFocusedForProcess() {
-        boolean appInBackground = isAppInBackground();
-        boolean activityHasFocus = getActivity() != null && getActivity().hasWindowFocus();
-        Boolean hostFocus = MainActivity.getHostActivityWindowFocus();
-        boolean resolvedFocus = hostFocus != null ? hostFocus : activityHasFocus;
-        // During Stripe Tap to Pay takeover the host Activity can temporarily lose window focus
-        // even while the app is still foregrounded and collect already succeeded.
-        // Treat that transient focus loss as safe for process handoff so we don't defer process
-        // long enough to require card re-presentment.
-        boolean transientTakeoverFocusLoss = stripeTakeoverObserved && !appInBackground;
-        return !appInBackground && (resolvedFocus || transientTakeoverFocusLoss);
     }
 
     private JSObject paymentRunGuardPayload(String path, String reason) {
@@ -1007,91 +992,55 @@ public class OrderfastTapToPayPlugin extends Plugin {
                                     );
                                     };
 
-                                    if (isHostForegroundAndFocusedForProcess()) {
-                                        invokeProcessPaymentIntent.run();
+                                    if (isAppInBackground()) {
+                                        backgroundInterruptionCandidate = true;
+                                        lifecyclePausedDuringActiveFlow = true;
+                                        if (backgroundInterruptionCandidateAtMs <= 0L) {
+                                            backgroundInterruptionCandidateAtMs = System.currentTimeMillis();
+                                        }
+                                        confirmedBackgroundInterruption = true;
+                                        String reasonCategory = "lifecycle_interrupted";
+                                        String mappedSessionState = mapSessionStateForFailureCategory(reasonCategory);
+                                        String mappedPluginStatus = mapPluginStatusForFailureCategory(reasonCategory);
+                                        status = mappedPluginStatus;
+
+                                        quickChargeTraceSnapshot.put("processInvoked", false);
+                                        quickChargeTraceSnapshot.put("processCallbackStatus", "not_invoked_backgrounded_before_process");
+                                        quickChargeTraceSnapshot.put("processFailureCode", "canceled");
+                                        quickChargeTraceSnapshot.put("processFailureMessage", "Tap to Pay was backgrounded before processPaymentIntent could start.");
+                                        quickChargeTraceSnapshot.put("processFailureExceptionClass", "backgrounded_before_process");
+                                        quickChargeTraceSnapshot.put("processFailureReasonCategory", reasonCategory);
+                                        quickChargeTraceSnapshot.put("nativeFailurePoint", "process_not_started_due_to_background_loss");
+                                        quickChargeTraceSnapshot.put("finalFailureReason", "App/background loss detected after collect success and before process invocation.");
+
+                                        JSObject backgroundedPayload = lifecyclePayload("process_not_started_backgrounded_before_process");
+                                        backgroundedPayload.put("paymentIntentId", collectedIntent.getId());
+                                        logFlowEvent("native_process_skipped_backgrounded", backgroundedPayload);
+                                        traceTimeline("process_not_started_backgrounded", backgroundedPayload);
+
+                                        postSessionState(mappedSessionState, "native_process_not_started_backgrounded");
+                                        JSObject payload = result(mappedPluginStatus, "canceled", "Tap to Pay was interrupted before processing could start.");
+                                        payload.put("reasonCategory", reasonCategory);
+                                        payload.put("mappedSessionState", mappedSessionState);
+                                        payload.put("interruptionReasonCode", "background_loss_confirmed");
+                                        payload.put("interruptionSource", "app_or_device_backgrounded");
+                                        payload.put("backgroundInterruptionCandidate", true);
+                                        payload.put("backgroundInterruptionMs", backgroundInterruptionCandidateAtMs > 0 ? (System.currentTimeMillis() - backgroundInterruptionCandidateAtMs) : 0L);
+                                        payload.put("appResumedDuringProcessInFlight", appResumedDuringProcessInFlight);
+                                        payload.put("processDeferredForForegroundFocus", false);
+                                        payload.put("detail", detail("native_process_result", "backgrounded_before_process_invocation", null));
+                                        attachPaymentIntentSnapshot(payload, activePaymentIntent, "process_not_started_backgrounded");
+                                        payload.put("quickChargeTraceSnapshot", quickChargeTraceSnapshot);
+                                        logStartupStage("native_process_result", payload);
+                                        cacheFinalResult(payload, "process_not_started_backgrounded");
+                                        clearActivePaymentState();
+                                        resetStatusForNextAttempt();
+                                        resolveOnce(resolveGate, call, payload);
                                         return;
                                     }
 
-                                    quickChargeTraceSnapshot.put("processDeferredForForegroundFocus", true);
-                                    JSObject deferredPayload = lifecyclePayload("process_deferred_waiting_for_foreground_focus");
-                                    deferredPayload.put("paymentIntentId", collectedIntent.getId());
-                                    deferredPayload.put("waitTimeoutMs", PROCESS_FOREGROUND_WAIT_TIMEOUT_MS);
-                                    logFlowEvent("native_process_deferred_wait", deferredPayload);
-                                    traceTimeline("process_deferred_wait_start", deferredPayload);
-
-                                    final long deferredWaitStartedAtMs = System.currentTimeMillis();
-                                    final Runnable[] waitForForegroundRunnableHolder = new Runnable[1];
-                                    waitForForegroundRunnableHolder[0] = new Runnable() {
-                                        @Override
-                                        public void run() {
-                                            if (resolveGate.get()) {
-                                                return;
-                                            }
-
-                                            if (isHostForegroundAndFocusedForProcess()) {
-                                                JSObject resumedPayload = lifecyclePayload("process_deferred_wait_ready");
-                                                resumedPayload.put("paymentIntentId", collectedIntent.getId());
-                                                resumedPayload.put("deferredMs", System.currentTimeMillis() - deferredWaitStartedAtMs);
-                                                logFlowEvent("native_process_deferred_wait_ready", resumedPayload);
-                                                traceTimeline("process_deferred_wait_ready", resumedPayload);
-                                                invokeProcessPaymentIntent.run();
-                                                return;
-                                            }
-
-                                            long elapsedMs = System.currentTimeMillis() - deferredWaitStartedAtMs;
-                                            if (elapsedMs >= PROCESS_FOREGROUND_WAIT_TIMEOUT_MS) {
-                                                backgroundInterruptionCandidate = true;
-                                                lifecyclePausedDuringActiveFlow = true;
-                                                if (backgroundInterruptionCandidateAtMs <= 0L) {
-                                                    backgroundInterruptionCandidateAtMs = deferredWaitStartedAtMs;
-                                                }
-                                                confirmedBackgroundInterruption = true;
-                                                String reasonCategory = "lifecycle_interrupted";
-                                                String mappedSessionState = mapSessionStateForFailureCategory(reasonCategory);
-                                                String mappedPluginStatus = mapPluginStatusForFailureCategory(reasonCategory);
-                                                status = mappedPluginStatus;
-
-                                                quickChargeTraceSnapshot.put("processInvoked", false);
-                                                quickChargeTraceSnapshot.put("processCallbackStatus", "not_invoked_background_timeout");
-                                                quickChargeTraceSnapshot.put("processFailureCode", "canceled");
-                                                quickChargeTraceSnapshot.put("processFailureMessage", "Host activity did not return to foreground before processPaymentIntent.");
-                                                quickChargeTraceSnapshot.put("processFailureExceptionClass", "foreground_wait_timeout");
-                                                quickChargeTraceSnapshot.put("processFailureReasonCategory", reasonCategory);
-                                                quickChargeTraceSnapshot.put("nativeFailurePoint", "process_deferred_wait_timeout_before_sdk_call");
-                                                quickChargeTraceSnapshot.put("finalFailureReason", "Foreground/focus was not restored before bounded process handoff wait expired.");
-                                                quickChargeTraceSnapshot.put("appResumedDuringProcessInFlight", appResumedDuringProcessInFlight);
-
-                                                JSObject timeoutPayload = lifecyclePayload("process_deferred_wait_timeout");
-                                                timeoutPayload.put("paymentIntentId", collectedIntent.getId());
-                                                timeoutPayload.put("deferredMs", elapsedMs);
-                                                traceTimeline("process_deferred_wait_timeout", timeoutPayload);
-
-                                                postSessionState(mappedSessionState, "native_process_deferred_wait_timeout");
-                                                JSObject payload = result(mappedPluginStatus, "canceled", "Tap to Pay was interrupted before processing could start.");
-                                                payload.put("reasonCategory", reasonCategory);
-                                                payload.put("mappedSessionState", mappedSessionState);
-                                                payload.put("interruptionReasonCode", "background_loss_confirmed");
-                                                payload.put("interruptionSource", "app_or_device_backgrounded");
-                                                payload.put("backgroundInterruptionCandidate", true);
-                                                payload.put("backgroundInterruptionMs", elapsedMs);
-                                                payload.put("appResumedDuringProcessInFlight", appResumedDuringProcessInFlight);
-                                                payload.put("processDeferredForForegroundFocus", true);
-                                                payload.put("detail", detail("native_process_result", "deferred_wait_timeout_before_process_invocation", null));
-                                                attachPaymentIntentSnapshot(payload, activePaymentIntent, "process_deferred_wait_timeout_active_intent");
-                                                payload.put("quickChargeTraceSnapshot", quickChargeTraceSnapshot);
-                                                logStartupStage("native_process_result", payload);
-                                                cacheFinalResult(payload, "process_deferred_wait_timeout");
-                                                clearActivePaymentState();
-                                                resetStatusForNextAttempt();
-                                                resolveOnce(resolveGate, call, payload);
-                                                return;
-                                            }
-
-                                            mainHandler.postDelayed(waitForForegroundRunnableHolder[0], PROCESS_FOREGROUND_WAIT_POLL_MS);
-                                        }
-                                    };
-
-                                    mainHandler.post(waitForForegroundRunnableHolder[0]);
+                                    quickChargeTraceSnapshot.put("processDeferredForForegroundFocus", false);
+                                    invokeProcessPaymentIntent.run();
                                 }
 
                                 @Override


### PR DESCRIPTION
### Motivation
- The native Tap to Pay quick-charge path sometimes required a second tap because the post-`collectPaymentMethod` handoff could be deferred by a foreground/focus polling window, producing a half-collected/half-processing state and glitchy UX.
- The change scope is intentionally narrow to the runtime handoff path for launcher -> Take Payment -> Quick charge and targets only the native collect->process state machine for Android.

### Description
- Changed `android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java` to remove the fragile foreground/focus deferred wait path and make the collect->process transition deterministic.
- Removed the deferred polling wait (the prior `PROCESS_FOREGROUND_WAIT_*` behavior and `isHostForegroundAndFocusedForProcess` gating) and replaced it with a single immediate branch that checks `isAppInBackground()` at handoff and then either fails fast or invokes `processPaymentIntent` immediately using the first collected `PaymentIntent`.
- Preserved existing diagnostics, session-state posts, `quickChargeTraceSnapshot` entries, final-result caching, and all other telemetry/logging around collect/process success or failure.
- Only `OrderfastTapToPayPlugin.java` was modified; no changes to kiosk, server/PaymentIntent creation, `InternalSettlementModule.tsx`, or `MainActivity` were made.

### Testing
- Attempted an Android Java compile via `./gradlew :app:compileDebugJavaWithJavac`, which failed in this environment due to missing Android SDK configuration (`ANDROID_HOME`/`android/local.properties`), so a built APK could not be produced here.
- Static verification performed (source searches and diffs) confirmed the change is limited to the targeted file and that the removed deferred-wait logic is no longer present; no automated runtime tests were executed in this container due to the missing SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8b9c73a883258974dc52cc2b649b)