### PR TITLE
fix(tap-to-pay): harden collect→process handoff and expose host/process telemetry

### DIFF
--- a/android/app/src/main/java/com/orderfast/app/MainActivity.java
+++ b/android/app/src/main/java/com/orderfast/app/MainActivity.java
@@ -3,7 +3,9 @@ package com.orderfast.app;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.app.Application;
 import android.content.res.Configuration;
+import android.content.Intent;
 import android.view.View;
 import android.view.WindowManager;
 import android.view.WindowInsets;
@@ -25,6 +27,12 @@ public class MainActivity extends BridgeActivity {
     private static volatile boolean windowFocusChangedDuringPayment = false;
     private static volatile Boolean hostActivityWindowFocus = null;
     private static volatile String hostActivityCurrentOrientation = "unknown";
+    private static volatile String hostActivityClassName = "unknown";
+    private static volatile int hostActivityIdentityHash = -1;
+    private static volatile int hostActivityTaskId = -1;
+    private static volatile String hostActivityIntentAction = null;
+    private static volatile int hostActivityIntentFlags = 0;
+    private static volatile String hostProcessName = "unknown";
     private static volatile long lastHostLifecycleUpdateAtMs = 0L;
     private static volatile int lastKnownOrientationValue = Configuration.ORIENTATION_UNDEFINED;
 
@@ -37,6 +45,12 @@ public class MainActivity extends BridgeActivity {
     public static boolean getWindowFocusChangedDuringPayment() { return windowFocusChangedDuringPayment; }
     public static Boolean getHostActivityWindowFocus() { return hostActivityWindowFocus; }
     public static String getHostActivityCurrentOrientation() { return hostActivityCurrentOrientation; }
+    public static String getHostActivityClassName() { return hostActivityClassName; }
+    public static int getHostActivityIdentityHash() { return hostActivityIdentityHash; }
+    public static int getHostActivityTaskId() { return hostActivityTaskId; }
+    public static String getHostActivityIntentAction() { return hostActivityIntentAction; }
+    public static int getHostActivityIntentFlags() { return hostActivityIntentFlags; }
+    public static String getHostProcessName() { return hostProcessName; }
     public static long getLastHostLifecycleUpdateAtMs() { return lastHostLifecycleUpdateAtMs; }
 
     public static void resetPaymentHostTelemetry() {
@@ -48,6 +62,8 @@ public class MainActivity extends BridgeActivity {
         orientationChangedDuringPayment = false;
         windowFocusChangedDuringPayment = false;
         hostActivityWindowFocus = null;
+        hostActivityIntentAction = null;
+        hostActivityIntentFlags = 0;
         lastHostLifecycleUpdateAtMs = System.currentTimeMillis();
     }
 
@@ -66,6 +82,8 @@ public class MainActivity extends BridgeActivity {
     protected void onCreate(Bundle savedInstanceState) {
         registerPlugin(OrderfastTapToPayPlugin.class);
         super.onCreate(savedInstanceState);
+        updateHostIdentity();
+        updateHostIntentTelemetry(getIntent());
         hostActivityCurrentOrientation = orientationToName(getResources().getConfiguration().orientation);
         lastKnownOrientationValue = getResources().getConfiguration().orientation;
         lastHostLifecycleUpdateAtMs = System.currentTimeMillis();
@@ -96,12 +114,23 @@ public class MainActivity extends BridgeActivity {
     @Override
     public void onResume() {
         super.onResume();
+        updateHostIdentity();
+        updateHostIntentTelemetry(getIntent());
         hostActivityCurrentOrientation = orientationToName(getResources().getConfiguration().orientation);
         lastHostLifecycleUpdateAtMs = System.currentTimeMillis();
         if (shouldSuppressHostUiChurn()) {
             return;
         }
         immersiveHandler.postDelayed(immersiveRunnable, 120);
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        updateHostIdentity();
+        updateHostIntentTelemetry(intent);
+        lastHostLifecycleUpdateAtMs = System.currentTimeMillis();
     }
 
     @Override
@@ -261,5 +290,22 @@ public class MainActivity extends BridgeActivity {
 
         String historyUrl = history.getItemAtIndex(currentIndex).getUrl();
         return historyUrl != null && historyUrl.contains("/payment-entry");
+    }
+
+    private void updateHostIdentity() {
+        hostActivityClassName = getClass().getName();
+        hostActivityIdentityHash = System.identityHashCode(this);
+        hostActivityTaskId = getTaskId();
+        hostProcessName = getApplication() != null ? getApplication().getPackageName() : "unknown";
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+            hostProcessName = Application.getProcessName();
+        } else {
+            hostProcessName = getApplication() != null ? getApplication().getPackageName() : "unknown";
+        }
+    }
+
+    private void updateHostIntentTelemetry(Intent intent) {
+        hostActivityIntentAction = intent != null ? intent.getAction() : null;
+        hostActivityIntentFlags = intent != null ? intent.getFlags() : 0;
     }
 }

--- a/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
+++ b/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
@@ -23,6 +23,7 @@ import com.getcapacitor.annotation.Permission;
 import com.getcapacitor.annotation.PermissionCallback;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import com.stripe.stripeterminal.Terminal;
+import com.stripe.stripeterminal.TerminalApplicationDelegate;
 import com.stripe.stripeterminal.external.callable.Callback;
 import com.stripe.stripeterminal.external.callable.Cancelable;
 import com.stripe.stripeterminal.external.callable.ConnectionTokenCallback;
@@ -166,13 +167,7 @@ public class OrderfastTapToPayPlugin extends Plugin {
         boolean activityHasFocus = getActivity() != null && getActivity().hasWindowFocus();
         Boolean hostFocus = MainActivity.getHostActivityWindowFocus();
         boolean resolvedFocus = hostFocus != null ? hostFocus : activityHasFocus;
-        boolean definitelyBackgroundInterrupted = confirmedBackgroundInterruption || cancelRequestedByApp;
-        // During Stripe Tap to Pay takeover the host Activity can temporarily lose window focus
-        // and can briefly look backgrounded during handoff immediately after collect success.
-        // Treat takeover churn as safe for direct process handoff unless we have a confirmed
-        // real interruption/cancel signal.
-        boolean transientTakeoverLifecycleChurn = stripeTakeoverObserved && !definitelyBackgroundInterrupted;
-        return (!appInBackground && resolvedFocus) || transientTakeoverLifecycleChurn;
+        return !appInBackground && resolvedFocus;
     }
 
     private JSObject paymentRunGuardPayload(String path, String reason) {
@@ -1427,6 +1422,13 @@ public class OrderfastTapToPayPlugin extends Plugin {
         payload.put("activeRun", isCollectOrProcessActive());
         payload.put("stripeTakeoverActive", stripeTakeoverObserved);
         payload.put("appBackgrounded", isAppInBackground());
+        payload.put("tapToPayProcessAwareness", resolveTapToPayProcessAwarenessPayload());
+        payload.put("hostActivityClassName", MainActivity.getHostActivityClassName());
+        payload.put("hostActivityIdentityHash", MainActivity.getHostActivityIdentityHash());
+        payload.put("hostActivityTaskId", MainActivity.getHostActivityTaskId());
+        payload.put("hostActivityIntentAction", MainActivity.getHostActivityIntentAction());
+        payload.put("hostActivityIntentFlags", MainActivity.getHostActivityIntentFlags());
+        payload.put("hostProcessName", MainActivity.getHostProcessName());
         if (currentSessionId != null) payload.put("sessionId", currentSessionId);
         if (currentRestaurantId != null) payload.put("restaurantId", currentRestaurantId);
         if (currentTerminalLocationId != null) payload.put("terminalLocationId", currentTerminalLocationId);
@@ -1944,6 +1946,13 @@ public class OrderfastTapToPayPlugin extends Plugin {
         payload.put("collectOrProcessActive", isCollectOrProcessActive());
         payload.put("takeoverActive", stripeTakeoverObserved);
         payload.put("appResumedDuringProcessInFlight", appResumedDuringProcessInFlight);
+        payload.put("tapToPayProcessAwareness", resolveTapToPayProcessAwarenessPayload());
+        payload.put("hostActivityClassName", MainActivity.getHostActivityClassName());
+        payload.put("hostActivityIdentityHash", MainActivity.getHostActivityIdentityHash());
+        payload.put("hostActivityTaskId", MainActivity.getHostActivityTaskId());
+        payload.put("hostActivityIntentAction", MainActivity.getHostActivityIntentAction());
+        payload.put("hostActivityIntentFlags", MainActivity.getHostActivityIntentFlags());
+        payload.put("hostProcessName", MainActivity.getHostProcessName());
         return payload;
     }
 
@@ -2164,6 +2173,11 @@ public class OrderfastTapToPayPlugin extends Plugin {
         quickChargeTraceSnapshot.put("hostActivityRequestedOrientation", getActivityRequestedOrientationName());
         quickChargeTraceSnapshot.put("hostActivityCurrentOrientation", MainActivity.getHostActivityCurrentOrientation());
         quickChargeTraceSnapshot.put("hostActivityChangingConfigurations", getActivity() != null && getActivity().isChangingConfigurations());
+        quickChargeTraceSnapshot.put("hostActivityClassName", MainActivity.getHostActivityClassName());
+        quickChargeTraceSnapshot.put("hostActivityIdentityHash", MainActivity.getHostActivityIdentityHash());
+        quickChargeTraceSnapshot.put("hostActivityTaskId", MainActivity.getHostActivityTaskId());
+        quickChargeTraceSnapshot.put("hostActivityIntentAction", MainActivity.getHostActivityIntentAction());
+        quickChargeTraceSnapshot.put("hostActivityIntentFlags", MainActivity.getHostActivityIntentFlags());
         Boolean hasFocus = MainActivity.getHostActivityWindowFocus();
         quickChargeTraceSnapshot.put("hostActivityWindowFocus", hasFocus == null ? JSONObject.NULL : hasFocus);
         quickChargeTraceSnapshot.put("hostActivityWasPaused", MainActivity.getHostActivityWasPaused());
@@ -2174,8 +2188,47 @@ public class OrderfastTapToPayPlugin extends Plugin {
         quickChargeTraceSnapshot.put("immersiveReappliedDuringPayment", MainActivity.getImmersiveReappliedDuringPayment());
         quickChargeTraceSnapshot.put("orientationChangedDuringPayment", MainActivity.getOrientationChangedDuringPayment());
         quickChargeTraceSnapshot.put("windowFocusChangedDuringPayment", MainActivity.getWindowFocusChangedDuringPayment());
+        quickChargeTraceSnapshot.put("hostProcessName", MainActivity.getHostProcessName());
+        quickChargeTraceSnapshot.put("tapToPayProcessAwareness", resolveTapToPayProcessAwarenessPayload());
         quickChargeTraceSnapshot.put("timedEventTrail", quickChargeEventTrailPayload(quickChargeTraceSnapshot));
         quickChargeTraceSnapshot.put("processFailureReasonCategory", reasonCategory);
+    }
+
+    private JSObject resolveTapToPayProcessAwarenessPayload() {
+        JSObject payload = new JSObject();
+        payload.put("supported", false);
+        payload.put("isTapToPayProcess", JSONObject.NULL);
+        payload.put("sourceMethod", JSONObject.NULL);
+        payload.put("error", JSONObject.NULL);
+        try {
+            Class<?> delegateClass = TerminalApplicationDelegate.class;
+            String[] candidateMethods = new String[] {
+                "isInStripeProcess",
+                "isStripeProcess",
+                "isInTapToPayProcess",
+                "isTapToPayProcess"
+            };
+            for (String methodName : candidateMethods) {
+                try {
+                    Method method = delegateClass.getMethod(methodName);
+                    Object value = method.invoke(null);
+                    if (value instanceof Boolean) {
+                        payload.put("supported", true);
+                        payload.put("isTapToPayProcess", ((Boolean) value).booleanValue());
+                        payload.put("sourceMethod", methodName);
+                        payload.put("error", JSONObject.NULL);
+                        return payload;
+                    }
+                } catch (NoSuchMethodException ignored) {
+                    // Method name differs by SDK version; continue searching.
+                }
+            }
+            payload.put("error", "process_aware_method_not_found");
+            return payload;
+        } catch (Exception ex) {
+            payload.put("error", ex.getClass().getSimpleName() + ":" + (ex.getMessage() == null ? "unknown" : ex.getMessage()));
+            return payload;
+        }
     }
 
     private long monotonicRunDeltaMs() {


### PR DESCRIPTION
### Motivation
- First-attempt Tap to Pay runs were often canceled at `processPaymentIntent` after a successful `collectPaymentMethod` due to host lifecycle/focus churn during Stripe takeover/return.  The change aims to eliminate the unsafe bypass that allowed `processPaymentIntent` to proceed while the host was not reliably foreground/focused.
- The codebase needed richer, raw native telemetry to prove whether callbacks and failures are tied to the expected activity/task/process and to identify stale/duplicate handlers without changing behavior elsewhere.

### Description
- Tightened the foreground/focus gate used before invoking `processPaymentIntent` by removing the takeover-bypass in `isHostForegroundAndFocusedForProcess()` so processing now requires the host app to be foregrounded and focused (in `OrderfastTapToPayPlugin.java`).
- Added process-awareness probing via reflective checks on `TerminalApplicationDelegate` and included the result in native payloads to show whether Stripe/Terminal considers the current process to be a Tap-to-Pay process (new `resolveTapToPayProcessAwarenessPayload()` in `OrderfastTapToPayPlugin.java`).
- Expanded host/activity/process telemetry surfaced from native to JS: included activity class name, identity hash, task id, intent action/flags, and host process name in `getActivePaymentRunState` and lifecycle/trace/failure snapshots (changes in `OrderfastTapToPayPlugin.java`).
- Captured/updating host telemetry (class/identity/task/intent/process) in `MainActivity` during `onCreate`, `onResume`, and `onNewIntent` with new static getters so native payloads can be correlated to the exact host context (`MainActivity.java`).
- Rollback note: the changes are conservative and mostly additive (additional telemetry and a stricter foreground gate). To rollback, revert the `isHostForegroundAndFocusedForProcess()` change and the telemetry additions in `OrderfastTapToPayPlugin.java` and `MainActivity.java`; each area can be reverted independently and will restore previous runtime behavior.

### Testing
- Static runtime audit: ran repository scans and inspected the active runtime path from `pages/pos/[restaurantId]/payment-entry.tsx` → `InternalSettlementModule` → `tapToPayBridge` → `OrderfastTapToPayPlugin` and confirmed no duplicate native plugin/classes or alternate native handlers for the POS quick-charge path (code grep/inspection completed successfully).
- Attempted an Android compile smoke check with `cd android && ./gradlew :app:compileDebugJavaWithJavac --no-daemon`, but it failed in this environment because the Android SDK location is not configured (`ANDROID_HOME`/`local.properties` missing), therefore no native compile or runtime device tests were executed.
- No JS unit/e2e tests were modified or added in this change; all instrumentation added is observable via existing native payloads and `getActivePaymentRunState` for follow-up verification on-device or in CI with an Android SDK present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de88b85ba483258745d12be3cb7246)