### PR TITLE
Add host activity/process telemetry and Tap-to-Pay process-awareness checks

### DIFF
--- a/android/app/src/main/java/com/orderfast/app/MainActivity.java
+++ b/android/app/src/main/java/com/orderfast/app/MainActivity.java
@@ -3,7 +3,9 @@ package com.orderfast.app;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.app.Application;
 import android.content.res.Configuration;
+import android.content.Intent;
 import android.view.View;
 import android.view.WindowManager;
 import android.view.WindowInsets;
@@ -25,6 +27,12 @@ public class MainActivity extends BridgeActivity {
     private static volatile boolean windowFocusChangedDuringPayment = false;
     private static volatile Boolean hostActivityWindowFocus = null;
     private static volatile String hostActivityCurrentOrientation = "unknown";
+    private static volatile String hostActivityClassName = "unknown";
+    private static volatile int hostActivityIdentityHash = -1;
+    private static volatile int hostActivityTaskId = -1;
+    private static volatile String hostActivityIntentAction = null;
+    private static volatile int hostActivityIntentFlags = 0;
+    private static volatile String hostProcessName = "unknown";
     private static volatile long lastHostLifecycleUpdateAtMs = 0L;
     private static volatile int lastKnownOrientationValue = Configuration.ORIENTATION_UNDEFINED;
 
@@ -37,6 +45,12 @@ public class MainActivity extends BridgeActivity {
     public static boolean getWindowFocusChangedDuringPayment() { return windowFocusChangedDuringPayment; }
     public static Boolean getHostActivityWindowFocus() { return hostActivityWindowFocus; }
     public static String getHostActivityCurrentOrientation() { return hostActivityCurrentOrientation; }
+    public static String getHostActivityClassName() { return hostActivityClassName; }
+    public static int getHostActivityIdentityHash() { return hostActivityIdentityHash; }
+    public static int getHostActivityTaskId() { return hostActivityTaskId; }
+    public static String getHostActivityIntentAction() { return hostActivityIntentAction; }
+    public static int getHostActivityIntentFlags() { return hostActivityIntentFlags; }
+    public static String getHostProcessName() { return hostProcessName; }
     public static long getLastHostLifecycleUpdateAtMs() { return lastHostLifecycleUpdateAtMs; }
 
     public static void resetPaymentHostTelemetry() {
@@ -48,6 +62,8 @@ public class MainActivity extends BridgeActivity {
         orientationChangedDuringPayment = false;
         windowFocusChangedDuringPayment = false;
         hostActivityWindowFocus = null;
+        hostActivityIntentAction = null;
+        hostActivityIntentFlags = 0;
         lastHostLifecycleUpdateAtMs = System.currentTimeMillis();
     }
 
@@ -66,6 +82,8 @@ public class MainActivity extends BridgeActivity {
     protected void onCreate(Bundle savedInstanceState) {
         registerPlugin(OrderfastTapToPayPlugin.class);
         super.onCreate(savedInstanceState);
+        updateHostIdentity();
+        updateHostIntentTelemetry(getIntent());
         hostActivityCurrentOrientation = orientationToName(getResources().getConfiguration().orientation);
         lastKnownOrientationValue = getResources().getConfiguration().orientation;
         lastHostLifecycleUpdateAtMs = System.currentTimeMillis();
@@ -96,12 +114,23 @@ public class MainActivity extends BridgeActivity {
     @Override
     public void onResume() {
         super.onResume();
+        updateHostIdentity();
+        updateHostIntentTelemetry(getIntent());
         hostActivityCurrentOrientation = orientationToName(getResources().getConfiguration().orientation);
         lastHostLifecycleUpdateAtMs = System.currentTimeMillis();
         if (shouldSuppressHostUiChurn()) {
             return;
         }
         immersiveHandler.postDelayed(immersiveRunnable, 120);
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        updateHostIdentity();
+        updateHostIntentTelemetry(intent);
+        lastHostLifecycleUpdateAtMs = System.currentTimeMillis();
     }
 
     @Override
@@ -261,5 +290,22 @@ public class MainActivity extends BridgeActivity {
 
         String historyUrl = history.getItemAtIndex(currentIndex).getUrl();
         return historyUrl != null && historyUrl.contains("/payment-entry");
+    }
+
+    private void updateHostIdentity() {
+        hostActivityClassName = getClass().getName();
+        hostActivityIdentityHash = System.identityHashCode(this);
+        hostActivityTaskId = getTaskId();
+        hostProcessName = getApplication() != null ? getApplication().getPackageName() : "unknown";
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+            hostProcessName = Application.getProcessName();
+        } else {
+            hostProcessName = getApplication() != null ? getApplication().getPackageName() : "unknown";
+        }
+    }
+
+    private void updateHostIntentTelemetry(Intent intent) {
+        hostActivityIntentAction = intent != null ? intent.getAction() : null;
+        hostActivityIntentFlags = intent != null ? intent.getFlags() : 0;
     }
 }

--- a/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
+++ b/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
@@ -23,6 +23,7 @@ import com.getcapacitor.annotation.Permission;
 import com.getcapacitor.annotation.PermissionCallback;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import com.stripe.stripeterminal.Terminal;
+import com.stripe.stripeterminal.TerminalApplicationDelegate;
 import com.stripe.stripeterminal.external.callable.Callback;
 import com.stripe.stripeterminal.external.callable.Cancelable;
 import com.stripe.stripeterminal.external.callable.ConnectionTokenCallback;
@@ -166,13 +167,16 @@ public class OrderfastTapToPayPlugin extends Plugin {
         boolean activityHasFocus = getActivity() != null && getActivity().hasWindowFocus();
         Boolean hostFocus = MainActivity.getHostActivityWindowFocus();
         boolean resolvedFocus = hostFocus != null ? hostFocus : activityHasFocus;
-        boolean definitelyBackgroundInterrupted = confirmedBackgroundInterruption || cancelRequestedByApp;
-        // During Stripe Tap to Pay takeover the host Activity can temporarily lose window focus
-        // and can briefly look backgrounded during handoff immediately after collect success.
-        // Treat takeover churn as safe for direct process handoff unless we have a confirmed
-        // real interruption/cancel signal.
-        boolean transientTakeoverLifecycleChurn = stripeTakeoverObserved && !definitelyBackgroundInterrupted;
-        return (!appInBackground && resolvedFocus) || transientTakeoverLifecycleChurn;
+        if (!appInBackground && resolvedFocus) {
+            return true;
+        }
+        JSObject processAwareness = resolveTapToPayProcessAwarenessPayload();
+        boolean processAwareConfirmed = processAwareness.optBoolean("supported", false)
+            && processAwareness.optBoolean("isTapToPayProcess", false);
+        // Stripe Tap to Pay may run in its dedicated process while host focus/background
+        // temporarily changes. Allow process handoff only when Stripe process-awareness
+        // explicitly confirms that process context.
+        return processAwareConfirmed && stripeTakeoverObserved && !cancelRequestedByApp;
     }
 
     private JSObject paymentRunGuardPayload(String path, String reason) {
@@ -1427,6 +1431,13 @@ public class OrderfastTapToPayPlugin extends Plugin {
         payload.put("activeRun", isCollectOrProcessActive());
         payload.put("stripeTakeoverActive", stripeTakeoverObserved);
         payload.put("appBackgrounded", isAppInBackground());
+        payload.put("tapToPayProcessAwareness", resolveTapToPayProcessAwarenessPayload());
+        payload.put("hostActivityClassName", MainActivity.getHostActivityClassName());
+        payload.put("hostActivityIdentityHash", MainActivity.getHostActivityIdentityHash());
+        payload.put("hostActivityTaskId", MainActivity.getHostActivityTaskId());
+        payload.put("hostActivityIntentAction", MainActivity.getHostActivityIntentAction());
+        payload.put("hostActivityIntentFlags", MainActivity.getHostActivityIntentFlags());
+        payload.put("hostProcessName", MainActivity.getHostProcessName());
         if (currentSessionId != null) payload.put("sessionId", currentSessionId);
         if (currentRestaurantId != null) payload.put("restaurantId", currentRestaurantId);
         if (currentTerminalLocationId != null) payload.put("terminalLocationId", currentTerminalLocationId);
@@ -1944,6 +1955,13 @@ public class OrderfastTapToPayPlugin extends Plugin {
         payload.put("collectOrProcessActive", isCollectOrProcessActive());
         payload.put("takeoverActive", stripeTakeoverObserved);
         payload.put("appResumedDuringProcessInFlight", appResumedDuringProcessInFlight);
+        payload.put("tapToPayProcessAwareness", resolveTapToPayProcessAwarenessPayload());
+        payload.put("hostActivityClassName", MainActivity.getHostActivityClassName());
+        payload.put("hostActivityIdentityHash", MainActivity.getHostActivityIdentityHash());
+        payload.put("hostActivityTaskId", MainActivity.getHostActivityTaskId());
+        payload.put("hostActivityIntentAction", MainActivity.getHostActivityIntentAction());
+        payload.put("hostActivityIntentFlags", MainActivity.getHostActivityIntentFlags());
+        payload.put("hostProcessName", MainActivity.getHostProcessName());
         return payload;
     }
 
@@ -2164,6 +2182,11 @@ public class OrderfastTapToPayPlugin extends Plugin {
         quickChargeTraceSnapshot.put("hostActivityRequestedOrientation", getActivityRequestedOrientationName());
         quickChargeTraceSnapshot.put("hostActivityCurrentOrientation", MainActivity.getHostActivityCurrentOrientation());
         quickChargeTraceSnapshot.put("hostActivityChangingConfigurations", getActivity() != null && getActivity().isChangingConfigurations());
+        quickChargeTraceSnapshot.put("hostActivityClassName", MainActivity.getHostActivityClassName());
+        quickChargeTraceSnapshot.put("hostActivityIdentityHash", MainActivity.getHostActivityIdentityHash());
+        quickChargeTraceSnapshot.put("hostActivityTaskId", MainActivity.getHostActivityTaskId());
+        quickChargeTraceSnapshot.put("hostActivityIntentAction", MainActivity.getHostActivityIntentAction());
+        quickChargeTraceSnapshot.put("hostActivityIntentFlags", MainActivity.getHostActivityIntentFlags());
         Boolean hasFocus = MainActivity.getHostActivityWindowFocus();
         quickChargeTraceSnapshot.put("hostActivityWindowFocus", hasFocus == null ? JSONObject.NULL : hasFocus);
         quickChargeTraceSnapshot.put("hostActivityWasPaused", MainActivity.getHostActivityWasPaused());
@@ -2174,8 +2197,47 @@ public class OrderfastTapToPayPlugin extends Plugin {
         quickChargeTraceSnapshot.put("immersiveReappliedDuringPayment", MainActivity.getImmersiveReappliedDuringPayment());
         quickChargeTraceSnapshot.put("orientationChangedDuringPayment", MainActivity.getOrientationChangedDuringPayment());
         quickChargeTraceSnapshot.put("windowFocusChangedDuringPayment", MainActivity.getWindowFocusChangedDuringPayment());
+        quickChargeTraceSnapshot.put("hostProcessName", MainActivity.getHostProcessName());
+        quickChargeTraceSnapshot.put("tapToPayProcessAwareness", resolveTapToPayProcessAwarenessPayload());
         quickChargeTraceSnapshot.put("timedEventTrail", quickChargeEventTrailPayload(quickChargeTraceSnapshot));
         quickChargeTraceSnapshot.put("processFailureReasonCategory", reasonCategory);
+    }
+
+    private JSObject resolveTapToPayProcessAwarenessPayload() {
+        JSObject payload = new JSObject();
+        payload.put("supported", false);
+        payload.put("isTapToPayProcess", JSONObject.NULL);
+        payload.put("sourceMethod", JSONObject.NULL);
+        payload.put("error", JSONObject.NULL);
+        try {
+            Class<?> delegateClass = TerminalApplicationDelegate.class;
+            String[] candidateMethods = new String[] {
+                "isInStripeProcess",
+                "isStripeProcess",
+                "isInTapToPayProcess",
+                "isTapToPayProcess"
+            };
+            for (String methodName : candidateMethods) {
+                try {
+                    Method method = delegateClass.getMethod(methodName);
+                    Object value = method.invoke(null);
+                    if (value instanceof Boolean) {
+                        payload.put("supported", true);
+                        payload.put("isTapToPayProcess", ((Boolean) value).booleanValue());
+                        payload.put("sourceMethod", methodName);
+                        payload.put("error", JSONObject.NULL);
+                        return payload;
+                    }
+                } catch (NoSuchMethodException ignored) {
+                    // Method name differs by SDK version; continue searching.
+                }
+            }
+            payload.put("error", "process_aware_method_not_found");
+            return payload;
+        } catch (Exception ex) {
+            payload.put("error", ex.getClass().getSimpleName() + ":" + (ex.getMessage() == null ? "unknown" : ex.getMessage()));
+            return payload;
+        }
     }
 
     private long monotonicRunDeltaMs() {


### PR DESCRIPTION
### Motivation
- Add richer host Activity identity and Intent telemetry to help diagnose Tap-to-Pay lifecycle and process handoff issues.
- Improve decisioning for handing off an active payment process to Stripe Tap-to-Pay by using SDK-provided process-awareness when host lifecycle/focus is ambiguous.

### Description
- Added new host telemetry fields to `MainActivity`: `hostActivityClassName`, `hostActivityIdentityHash`, `hostActivityTaskId`, `hostActivityIntentAction`, `hostActivityIntentFlags`, and `hostProcessName`, plus getters and `updateHostIdentity`/`updateHostIntentTelemetry` called from `onCreate`, `onResume`, and `onNewIntent`, and cleared in `resetPaymentHostTelemetry` where appropriate.
- Included the new host telemetry fields in plugin payloads by adding them to `getActivePaymentRunState`, `lifecyclePayload`, and quick-charge failure snapshots in `OrderfastTapToPayPlugin`.
- Added a reflective `resolveTapToPayProcessAwarenessPayload` helper that probes `TerminalApplicationDelegate` for common static methods (like `isInStripeProcess`/`isTapToPayProcess`) and exposes whether the current process is Stripe Tap-to-Pay aware; the result is attached to payloads for better diagnostics.
- Updated `isHostForegroundAndFocusedForProcess` logic to allow process handoff only when app/activity focus is satisfied or when explicit Tap-to-Pay process-awareness confirms the Stripe process context, tightening safety around background/focus churn.

### Testing
- Built the Android app with `./gradlew assembleDebug` to validate Java compilation and APK generation, and the build completed successfully.
- Executed unit tests with `./gradlew test` and they passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de88b85ba483258745d12be3cb7246)