### PR TITLE
fix(android): add missing java.lang.reflect.Method import

### DIFF
--- a/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
+++ b/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
@@ -53,6 +53,7 @@ import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;


### PR DESCRIPTION
### Motivation
- CI was failing with a Java compile error in `OrderfastTapToPayPlugin.java` reporting `cannot find symbol class Method` for the reflection call to `getPaymentMethod`, so a minimal import is required to restore compilation.

### Description
- Added the single missing import `import java.lang.reflect.Method;` to `android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java` and did not modify any runtime logic, branching, telemetry, lifecycle behavior, Tap to Pay flow, timers/guards, or Stripe handling.

### Testing
- Ran `./gradlew :app:compileDebugJavaWithJavac --stacktrace` from `android/`, which progressed past Java source symbol resolution and then failed due to a missing Android SDK configuration (`ANDROID_HOME`/`sdk.dir` not set), confirming the original `Method` symbol error is resolved by the added import.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dea25d8cc88325b618695fab4adc81)