### PR TITLE
fix(android-tap-to-pay): relax lifecycle gate after Stripe takeover

### DIFF
--- a/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
+++ b/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
@@ -2202,13 +2202,19 @@ public class OrderfastTapToPayPlugin extends Plugin {
         int hostIdentity = MainActivity.getHostActivityIdentityHash();
         int pluginIdentity = pluginActivity == null ? -1 : System.identityHashCode(pluginActivity);
         int bridgeIdentity = bridgeActivity == null ? -1 : System.identityHashCode(bridgeActivity);
+        boolean appInBackground = isAppInBackground();
+        boolean pluginHasWindowFocus = pluginActivity != null && pluginActivity.hasWindowFocus();
+        boolean bridgeHasWindowFocus = bridgeActivity != null && bridgeActivity.hasWindowFocus();
         ArrayList<String> blockedReasons = new ArrayList<>();
         boolean hostIdentityConsistent = hostIdentity != -1
             && pluginIdentity != -1
             && bridgeIdentity != -1
             && hostIdentity == pluginIdentity
             && hostIdentity == bridgeIdentity;
-        if (!hostIdentityConsistent) {
+        // During Stripe's Tap to Pay takeover Android can briefly report stale/mismatched Activity identities
+        // even when the app is still foregrounded and safe to continue processPaymentIntent.
+        // Keep this as diagnostic context, but do not hard-block process start on identity mismatch alone.
+        if (!hostIdentityConsistent && appInBackground) {
             blockedReasons.add("host_identity_mismatch");
         }
         if (pluginActivity == null || bridgeActivity == null) {
@@ -2218,11 +2224,13 @@ public class OrderfastTapToPayPlugin extends Plugin {
             && (pluginActivity.isFinishing() || pluginActivity.isDestroyed() || bridgeActivity.isFinishing() || bridgeActivity.isDestroyed())) {
             blockedReasons.add("activity_finishing_or_destroyed");
         }
-        if (isAppInBackground()) {
+        if (appInBackground) {
             blockedReasons.add("app_in_background");
         }
         long takeoverBoundaryAtMs = Math.max(lastPauseAtMs, lastStopAtMs);
-        if (takeoverBoundaryAtMs > 0L && MainActivity.getHostActivityLastResumedAtMs() < takeoverBoundaryAtMs) {
+        if (takeoverBoundaryAtMs > 0L
+            && MainActivity.getHostActivityLastResumedAtMs() < takeoverBoundaryAtMs
+            && (appInBackground || (!pluginHasWindowFocus && !bridgeHasWindowFocus))) {
             blockedReasons.add("host_not_resumed_after_takeover_boundary");
         }
         boolean safe = blockedReasons.isEmpty();


### PR DESCRIPTION
### Motivation
- Prevent Tap to Pay "first tap cancels / second tap works" loops caused by the host lifecycle safety gate treating transient post‑takeover activity identity/resume timing as unsafe. 
- Preserve real safety blockers (backgrounded app, destroyed activities) while avoiding false negatives that defer or block `processPaymentIntent` unnecessarily.

### Description
- Relaxed `evaluateHostLifecycleSafety()` in `android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java` to compute and use explicit foreground/focus signals (`appInBackground`, `pluginHasWindowFocus`, `bridgeHasWindowFocus`).
- `host_identity_mismatch` is now treated as a diagnostic/blocked reason only when the app is actually backgrounded rather than blocking on transient identity mismatch alone.
- Tightened the takeover‑boundary resume rule so `host_not_resumed_after_takeover_boundary` only blocks when the app is backgrounded or when both plugin and bridge activities lack window focus.
- Added explanatory comments describing the Stripe Tap to Pay takeover edge case to make intent clear.

### Testing
- Attempted an Android Java compile with `./gradlew :app:compileDebugJavaWithJavac`, which could not complete in this environment due to missing Android SDK configuration (`ANDROID_HOME`/`android/local.properties`), so build failure was environmental and not due to the code change.
- No other automated tests were run in this environment; change is narrowly scoped to lifecycle gating logic to minimize regression risk.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb9d64d80832589e4cb97aeaa3ffa)