### PR TITLE
fix(android): add missing imports for TapToPay plugin compile

### DIFF
--- a/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
+++ b/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
@@ -58,6 +58,8 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.ArrayDeque;
 import java.util.Deque;


### PR DESCRIPTION
### Motivation
- Resolve compilation failures in `OrderfastTapToPayPlugin.java` due to missing symbols for `ArrayList` and `Method` while leaving all runtime logic and behavior unchanged.

### Description
- Added the minimal imports `java.util.ArrayList` and `java.lang.reflect.Method` to `android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java` and made no other code or behavioral changes.

### Testing
- Attempted a narrow compile with `./gradlew :app:compileDebugJavaWithJavac --console=plain`, but the run could not complete because the environment lacks Android SDK configuration (`ANDROID_HOME` / `sdk.dir`), so full compile confirmation is blocked; a static inspection confirms the previously missing symbols are now imported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc21364f08325b34bdbef4b6f3831)