### PR TITLE
fix(payments): unify tap to pay full-funnel diagnostics payload

### DIFF
--- a/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
+++ b/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
@@ -150,6 +150,10 @@ public class OrderfastTapToPayPlugin extends Plugin {
     private volatile boolean appResumedDuringProcessInFlight = false;
     private final Deque<String> recentLifecycleEvents = new ArrayDeque<>();
     private final Object recentLifecycleEventsLock = new Object();
+    private final Object runEventHistoryLock = new Object();
+    private final ArrayList<JSObject> runEventHistory = new ArrayList<>();
+    private volatile int runEventSequence = 0;
+    private volatile long runTraceStartWallClockMs = 0L;
     private static final AtomicBoolean nativeTapToPayTakeoverActive = new AtomicBoolean(false);
     private static final AtomicBoolean nativeTapToPayProcessInFlight = new AtomicBoolean(false);
     private static volatile OrderfastTapToPayPlugin activePluginInstance = null;
@@ -844,6 +848,9 @@ public class OrderfastTapToPayPlugin extends Plugin {
                 quickChargeTraceSnapshot.put("currentActivityIdentityHash", JSONObject.NULL);
                 quickChargeTraceSnapshot.put("continuationReleaseConditionPassed", JSONObject.NULL);
                 quickChargeTraceSnapshot.put("timedEventTrail", new JSONArray());
+                quickChargeTraceSnapshot.put("attemptStartTimestampMs", runTraceStartWallClockMs > 0L ? runTraceStartWallClockMs : System.currentTimeMillis());
+                quickChargeTraceSnapshot.put("attemptEndTimestampMs", JSONObject.NULL);
+                quickChargeTraceSnapshot.put("eventHistory", runEventHistoryPayload());
                 quickChargeTraceSnapshot.put("paymentStatusChangeCountBeforeCollectSuccess", 0);
                 quickChargeTraceSnapshot.put("paymentStatusWaitingForInputCountBeforeCollectSuccess", 0);
                 quickChargeTraceSnapshot.put("paymentStatusProcessingCountBeforeCollectSuccess", 0);
@@ -1024,6 +1031,7 @@ public class OrderfastTapToPayPlugin extends Plugin {
                                             blockedPayload.put("cancelClassification", determineCancelClassification("canceled"));
                                             blockedPayload.put("detail", detail("native_process_result", processStartBlockedReason, null));
                                             attachDeferredAuditCounters(blockedPayload);
+                                            finalizeQuickChargeTraceSnapshot(quickChargeTraceSnapshot);
                                             blockedPayload.put("quickChargeTraceSnapshot", quickChargeTraceSnapshot);
                                             logStartupStage("native_process_result", blockedPayload);
                                             cacheFinalResult(blockedPayload, "process_not_invoked_after_collect");
@@ -1133,6 +1141,7 @@ public class OrderfastTapToPayPlugin extends Plugin {
                                                     attachDeferredAuditCounters(payload);
                                                     attachDeferredRunIdentity(payload);
                                                     attachPaymentIntentSnapshot(payload, intent, "process_success");
+                                                    finalizeQuickChargeTraceSnapshot(quickChargeTraceSnapshot);
                                                     payload.put("quickChargeTraceSnapshot", quickChargeTraceSnapshot);
                                                     logStartupStage("native_process_result", payload);
                                                     cacheFinalResult(payload, "process_success");
@@ -1150,6 +1159,7 @@ public class OrderfastTapToPayPlugin extends Plugin {
                                                     attachDeferredAuditCounters(payload);
                                                     attachDeferredRunIdentity(payload);
                                                     attachPaymentIntentSnapshot(payload, intent, "process_pending");
+                                                    finalizeQuickChargeTraceSnapshot(quickChargeTraceSnapshot);
                                                     payload.put("quickChargeTraceSnapshot", quickChargeTraceSnapshot);
                                                     logStartupStage("native_process_result", payload);
                                                     cacheFinalResult(payload, "process_pending");
@@ -1168,6 +1178,7 @@ public class OrderfastTapToPayPlugin extends Plugin {
                                                     attachPaymentIntentSnapshot(payload, intent, "process_unexpected_status");
                                                     quickChargeTraceSnapshot.put("nativeFailurePoint", "process_unexpected_status");
                                                     quickChargeTraceSnapshot.put("finalFailureReason", "Unexpected PaymentIntent status after process callback.");
+                                                    finalizeQuickChargeTraceSnapshot(quickChargeTraceSnapshot);
                                                     payload.put("quickChargeTraceSnapshot", quickChargeTraceSnapshot);
                                                     logStartupStage("native_process_result", payload);
                                                     cacheFinalResult(payload, "process_unexpected_status");
@@ -1229,6 +1240,7 @@ public class OrderfastTapToPayPlugin extends Plugin {
                                                 attachDeferredAuditCounters(payload);
                                                 attachDeferredRunIdentity(payload);
                                                 attachPaymentIntentSnapshot(payload, activePaymentIntent, "process_failure_active_intent");
+                                                finalizeQuickChargeTraceSnapshot(quickChargeTraceSnapshot);
                                                 payload.put("quickChargeTraceSnapshot", quickChargeTraceSnapshot);
                                                 JSObject quickChargeProcessCallbackPayload = new JSObject();
                                                 quickChargeProcessCallbackPayload.put("sessionId", currentSessionId);
@@ -1307,6 +1319,7 @@ public class OrderfastTapToPayPlugin extends Plugin {
                                     quickChargeCollectCallbackPayload.put("terminalCode", e.getErrorCode() == null ? "UNKNOWN" : e.getErrorCode().name());
                                     logFlowEvent("quick_charge_native_collect_callback", quickChargeCollectCallbackPayload);
                                     attachPaymentIntentSnapshot(payload, activePaymentIntent, "collect_failure_active_intent");
+                                    finalizeQuickChargeTraceSnapshot(quickChargeTraceSnapshot);
                                     payload.put("quickChargeTraceSnapshot", quickChargeTraceSnapshot);
                                     logStartupStage("native_collect_result", payload);
                                     cacheFinalResult(payload, "collect_failure");
@@ -1327,6 +1340,7 @@ public class OrderfastTapToPayPlugin extends Plugin {
                         quickChargeTraceSnapshot.put("finalFailureReason", buildErrorMessage(e));
                         JSObject payload = result("failed", normalizeErrorCode(e), buildErrorMessage(e));
                         payload.put("detail", terminalErrorDetail(e, "native_collect_result"));
+                        finalizeQuickChargeTraceSnapshot(quickChargeTraceSnapshot);
                         payload.put("quickChargeTraceSnapshot", quickChargeTraceSnapshot);
                         logStartupStage("native_collect_result", payload);
                         cacheFinalResult(payload, "retrieve_payment_intent_failure");
@@ -1354,6 +1368,7 @@ public class OrderfastTapToPayPlugin extends Plugin {
                 quickChargeTraceSnapshot.put("nativeFailurePoint", "start_exception");
                 quickChargeTraceSnapshot.put("finalFailureReason", ex.getMessage() == null ? "start_exception" : ex.getMessage());
                 quickChargeTraceSnapshot.put("hostActivityRequestedOrientation", getActivityRequestedOrientationName());
+                finalizeQuickChargeTraceSnapshot(quickChargeTraceSnapshot);
                 payload.put("quickChargeTraceSnapshot", quickChargeTraceSnapshot);
                 logStartupStage("native_collect_result", payload);
                 cacheFinalResult(payload, "start_exception");
@@ -2416,6 +2431,11 @@ public class OrderfastTapToPayPlugin extends Plugin {
     private void beginRunTrace(String source) {
         activeRunSequence += 1;
         activeRunMonotonicStartNs = SystemClock.elapsedRealtimeNanos();
+        runTraceStartWallClockMs = System.currentTimeMillis();
+        synchronized (runEventHistoryLock) {
+            runEventHistory.clear();
+            runEventSequence = 0;
+        }
         lastReaderDisconnectElapsedMs = 0L;
         lastReaderDisconnectReason = "none";
         resetRunVisibilityTrail();
@@ -2435,7 +2455,69 @@ public class OrderfastTapToPayPlugin extends Plugin {
                 payload.put(key, extra.opt(key));
             }
         }
+        recordRunEventHistory(event, payload, "native");
         logStartupStage("native_timeline", payload);
+    }
+
+    private void recordRunEventHistory(String event, JSObject payload, String processName) {
+        if (payload == null) return;
+        JSObject row = new JSObject();
+        long timestampMs = payload.has("timestampMs") ? payload.optLong("timestampMs", System.currentTimeMillis()) : System.currentTimeMillis();
+        int nextSequence;
+        synchronized (runEventHistoryLock) {
+            runEventSequence += 1;
+            nextSequence = runEventSequence;
+        }
+        long attemptStartMs = runTraceStartWallClockMs > 0L ? runTraceStartWallClockMs : timestampMs;
+        row.put("sequence", nextSequence);
+        row.put("absoluteTimestamp", new java.util.Date(timestampMs).toString());
+        row.put("timestampMs", timestampMs);
+        row.put("elapsedMsSinceAttemptStart", Math.max(0L, timestampMs - attemptStartMs));
+        row.put("eventName", "native." + event);
+        row.put("sessionId", isBlank(currentSessionId) ? JSONObject.NULL : currentSessionId);
+        row.put("flowRunId", isBlank(currentFlowRunId) ? JSONObject.NULL : currentFlowRunId);
+        row.put("paymentIntentId", activePaymentIntent != null ? activePaymentIntent.getId() : JSONObject.NULL);
+        row.put("processName", processName == null ? "native" : processName);
+        row.put("activityIdentityHash", MainActivity.getHostActivityIdentityHash());
+        JSObject context = new JSObject();
+        context.put("status", status);
+        context.put("inFlight", inFlight);
+        context.put("timelineEvent", event);
+        if (payload.has("paymentStatus")) {
+            context.put("paymentStatus", payload.opt("paymentStatus"));
+        }
+        if (payload.has("disconnectReason")) {
+            context.put("disconnectReason", payload.opt("disconnectReason"));
+        }
+        if (payload.has("trigger")) {
+            context.put("trigger", payload.opt("trigger"));
+        }
+        row.put("context", context);
+        synchronized (runEventHistoryLock) {
+            runEventHistory.add(row);
+            while (runEventHistory.size() > 500) {
+                runEventHistory.remove(0);
+            }
+        }
+    }
+
+    private JSONArray runEventHistoryPayload() {
+        JSONArray events = new JSONArray();
+        synchronized (runEventHistoryLock) {
+            for (JSObject event : runEventHistory) {
+                events.put(event);
+            }
+        }
+        return events;
+    }
+
+    private void finalizeQuickChargeTraceSnapshot(JSObject quickChargeTraceSnapshot) {
+        if (quickChargeTraceSnapshot == null) return;
+        if (!quickChargeTraceSnapshot.has("attemptStartTimestampMs")) {
+            quickChargeTraceSnapshot.put("attemptStartTimestampMs", runTraceStartWallClockMs > 0L ? runTraceStartWallClockMs : System.currentTimeMillis());
+        }
+        quickChargeTraceSnapshot.put("attemptEndTimestampMs", System.currentTimeMillis());
+        quickChargeTraceSnapshot.put("eventHistory", runEventHistoryPayload());
     }
 
     private void recordRecentLifecycleEvent(String event, JSObject payload) {
@@ -2515,6 +2597,9 @@ public class OrderfastTapToPayPlugin extends Plugin {
 
     private void enrichQuickChargeSuccessSnapshot(JSObject quickChargeTraceSnapshot) {
         if (quickChargeTraceSnapshot == null) return;
+        quickChargeTraceSnapshot.put("attemptStartTimestampMs", runTraceStartWallClockMs > 0L ? runTraceStartWallClockMs : JSONObject.NULL);
+        quickChargeTraceSnapshot.put("attemptEndTimestampMs", System.currentTimeMillis());
+        quickChargeTraceSnapshot.put("eventHistory", runEventHistoryPayload());
         quickChargeTraceSnapshot.put("lastLifecycleEvents", recentLifecycleEventsPayload());
         quickChargeTraceSnapshot.put("timedEventTrail", quickChargeEventTrailPayload(quickChargeTraceSnapshot));
         boolean repeatedCollectSignalDetected = quickChargeTraceSnapshot.optInt("collectSuccessCallbackCount", 0) > 1
@@ -2530,6 +2615,9 @@ public class OrderfastTapToPayPlugin extends Plugin {
 
     private void enrichQuickChargeFailureSnapshot(JSObject quickChargeTraceSnapshot, TerminalException failure, String normalizedCode, String reasonCategory) {
         if (quickChargeTraceSnapshot == null) return;
+        quickChargeTraceSnapshot.put("attemptStartTimestampMs", runTraceStartWallClockMs > 0L ? runTraceStartWallClockMs : JSONObject.NULL);
+        quickChargeTraceSnapshot.put("attemptEndTimestampMs", System.currentTimeMillis());
+        quickChargeTraceSnapshot.put("eventHistory", runEventHistoryPayload());
         JSObject failureDetail = terminalErrorDetail(failure, "native_process_result");
         quickChargeTraceSnapshot.put("rawProcessCallbackPayload", failureDetail);
         quickChargeTraceSnapshot.put("processFailureStackTop", failureDetail.optString("stackTop", "none"));

--- a/components/payments/InternalSettlementModule.tsx
+++ b/components/payments/InternalSettlementModule.tsx
@@ -4,6 +4,7 @@ import { formatPrice } from '@/lib/orderDisplay';
 import { resolveNativeTapToPayReadiness } from '@/lib/kiosk/tapToPayNativeReadiness';
 import { type AppFlowState } from '@/lib/app/launcherBootstrap';
 import { internalSettlementActiveRunStore } from '@/lib/payments/internalSettlementActiveRunStore';
+import { buildCombinedTapToPayDiagnosticsPayload } from '@/lib/payments/tapToPayDiagnostics';
 
 type SettlementMode = 'order_payment' | 'quick_charge';
 type CollectionState = AppFlowState | 'idle';
@@ -150,6 +151,11 @@ export default function InternalSettlementModule({
   const [activeTerminalLocationId, setActiveTerminalLocationId] = useState<string | null>(null);
   const flowActiveRef = useRef(false);
   const flowRunIdRef = useRef<string | null>(null);
+  const quickChargeAttemptStartMsRef = useRef<number | null>(null);
+  const quickChargeAttemptEndMsRef = useRef<number | null>(null);
+  const quickChargeEventSequenceRef = useRef(0);
+  const quickChargeUiEventHistoryRef = useRef<Record<string, unknown>[]>([]);
+  const quickChargePaymentIntentIdRef = useRef<string | null>(null);
 
   const selectedOrder = useMemo(() => orders.find((order) => order.id === selectedOrderId) || null, [orders, selectedOrderId]);
 
@@ -161,6 +167,10 @@ export default function InternalSettlementModule({
   }, [mode, quickAmount, selectedOrder?.total_price]);
 
   const amountLabel = useMemo(() => formatPrice(amountCents / 100), [amountCents]);
+  const nativeRestaurantId = useMemo(() => {
+    const value = restaurantId?.trim();
+    return value ? value : null;
+  }, [restaurantId]);
   const quickChargeAttemptDiagnosticsPayload = useMemo(() => {
     if (mode !== 'quick_charge') return null;
     const attemptSummary =
@@ -170,23 +180,30 @@ export default function InternalSettlementModule({
           ? quickChargeFailureSnapshot
           : null;
     if (!attemptSummary) return null;
-    return {
-      attemptSummary,
+    return buildCombinedTapToPayDiagnosticsPayload({
+      attemptSummary: attemptSummary as unknown as Record<string, unknown>,
       rawNativePayload: quickChargeRawNativePayload,
       rawServerVerificationPayload: quickChargeRawServerVerificationPayload,
+      uiEventHistory: quickChargeUiEventHistoryRef.current,
       uiContext: {
         collectionState: state,
         message,
-        activeSessionId,
-        activeTerminalLocationId,
+        sessionId: activeSessionId,
+        flowRunId: flowRunIdRef.current,
+        paymentIntentId: quickChargePaymentIntentIdRef.current,
+        terminalLocationId: activeTerminalLocationId,
+        restaurantId: nativeRestaurantId,
+        attemptStartTimestampMs: quickChargeAttemptStartMsRef.current,
+        attemptEndTimestampMs: quickChargeAttemptEndMsRef.current,
       },
-    };
+    });
   }, [
     mode,
     state,
     message,
     activeSessionId,
     activeTerminalLocationId,
+    nativeRestaurantId,
     quickChargeSuccessSnapshot,
     quickChargeFailureSnapshot,
     quickChargeRawNativePayload,
@@ -196,10 +213,6 @@ export default function InternalSettlementModule({
     () => (quickChargeAttemptDiagnosticsPayload ? JSON.stringify(quickChargeAttemptDiagnosticsPayload, null, 2) : null),
     [quickChargeAttemptDiagnosticsPayload]
   );
-  const nativeRestaurantId = useMemo(() => {
-    const value = restaurantId?.trim();
-    return value ? value : null;
-  }, [restaurantId]);
 
   const loadOrders = useCallback(async () => {
     setLoadingOrders(true);
@@ -348,6 +361,24 @@ export default function InternalSettlementModule({
 
   const logCollectionEvent = useCallback((event: string, payload?: Record<string, unknown>) => {
     const prefix = '[internal-settlement][take-payment][quick-charge][tap-to-pay]';
+    if (mode === 'quick_charge' && quickChargeAttemptStartMsRef.current != null) {
+      const now = Date.now();
+      quickChargeEventSequenceRef.current += 1;
+      const context = payload && typeof payload === 'object' ? payload : {};
+      quickChargeUiEventHistoryRef.current.push({
+        sequence: quickChargeEventSequenceRef.current,
+        absoluteTimestamp: new Date(now).toISOString(),
+        timestampMs: now,
+        elapsedMsSinceAttemptStart: Math.max(0, now - (quickChargeAttemptStartMsRef.current || now)),
+        eventName: `ui.${event}`,
+        sessionId: activeSessionId,
+        flowRunId: flowRunIdRef.current,
+        paymentIntentId: quickChargePaymentIntentIdRef.current,
+        processName: typeof context?.processName === 'string' ? context.processName : null,
+        activityIdentityHash: null,
+        context,
+      });
+    }
     if (event.includes('error') || event.includes('exception')) {
       console.error(prefix, event, payload);
       return;
@@ -362,7 +393,7 @@ export default function InternalSettlementModule({
     ) {
       console.info(prefix, event, payload);
     }
-  }, []);
+  }, [activeSessionId, mode]);
 
   const logQuickChargeSequenceEvent = useCallback(
     (
@@ -431,6 +462,14 @@ export default function InternalSettlementModule({
     setQuickChargeSuccessSnapshot(null);
     setQuickChargeRawNativePayload(null);
     setQuickChargeRawServerVerificationPayload(null);
+    if (mode === 'quick_charge') {
+      const now = Date.now();
+      quickChargeAttemptStartMsRef.current = now;
+      quickChargeAttemptEndMsRef.current = null;
+      quickChargeEventSequenceRef.current = 0;
+      quickChargeUiEventHistoryRef.current = [];
+      quickChargePaymentIntentIdRef.current = null;
+    }
     if (!tapAvailabilityReady) {
       setState('failed');
       setMessage(tapAvailabilityReason || 'Tap to Pay is not available for this restaurant.');
@@ -580,6 +619,7 @@ export default function InternalSettlementModule({
       const paymentIntentClientSecret = intentPayload?.clientSecret ? String(intentPayload.clientSecret) : '';
       const paymentIntentId = intentPayload?.paymentIntentId ? String(intentPayload.paymentIntentId) : '';
       const paymentIntentStatus = intentPayload?.status ? String(intentPayload.status) : '';
+      quickChargePaymentIntentIdRef.current = paymentIntentId || null;
       if (!paymentIntentClientSecret) {
         throw new Error('Payment intent client secret missing from settlement response.');
       }
@@ -670,6 +710,9 @@ export default function InternalSettlementModule({
           : null;
       if (mode === 'quick_charge') {
         setQuickChargeRawNativePayload(nativeResult && typeof nativeResult === 'object' ? (nativeResult as Record<string, unknown>) : null);
+      }
+      if (nativeResult.paymentIntentId) {
+        quickChargePaymentIntentIdRef.current = nativeResult.paymentIntentId;
       }
       logCollectionEvent(nativeResult.status === 'succeeded' ? 'native_collect.success' : 'native_collect.error', { sessionId, result: nativeResult });
       logCollectionEvent(nativeResult.status === 'succeeded' ? 'native_process.success' : 'native_process.error', {
@@ -902,6 +945,9 @@ export default function InternalSettlementModule({
         }
 
         if (verifyRes?.ok === true && verifiedState === 'finalized') {
+          if (mode === 'quick_charge') {
+            quickChargeAttemptEndMsRef.current = Date.now();
+          }
           setState('completed');
           setMessage(mode === 'order_payment' ? 'Order payment collected successfully.' : 'Quick charge collected successfully.');
           setActiveSessionId(null);
@@ -912,6 +958,9 @@ export default function InternalSettlementModule({
         }
 
         setState(isUnsupportedDeviceError(nativeResult.code) ? 'unsupported_device' : 'failed');
+        if (mode === 'quick_charge') {
+          quickChargeAttemptEndMsRef.current = Date.now();
+        }
         setMessage(verifiedReason);
         logCollectionEvent('final_persisted_outcome_and_reason', {
           sessionId,
@@ -1044,6 +1093,9 @@ export default function InternalSettlementModule({
       logCollectionEvent('finalize.success', { sessionId, ok: finalizeRes.ok });
 
       setState('completed');
+      if (mode === 'quick_charge') {
+        quickChargeAttemptEndMsRef.current = Date.now();
+      }
       setMessage(mode === 'order_payment' ? 'Order payment collected successfully.' : 'Quick charge collected successfully.');
       setQuickChargeFailureSnapshot(null);
       setActiveSessionId(null);
@@ -1088,6 +1140,9 @@ export default function InternalSettlementModule({
         return;
       }
       setState('failed');
+      if (mode === 'quick_charge') {
+        quickChargeAttemptEndMsRef.current = Date.now();
+      }
       setMessage(error?.message || 'Payment failed.');
       if (sessionIdForCleanup) {
         await persistFlowOutcome({
@@ -1210,6 +1265,7 @@ export default function InternalSettlementModule({
       });
       logCollectionEvent('app_cancel_requested', { sessionId: activeSessionId });
       setState('failed');
+      quickChargeAttemptEndMsRef.current = Date.now();
       setMessage('Payment canceled.');
       setQuickChargeFailureSnapshot(null);
       setQuickChargeSuccessSnapshot(null);

--- a/lib/payments/tapToPayDiagnostics.ts
+++ b/lib/payments/tapToPayDiagnostics.ts
@@ -1,0 +1,301 @@
+const asRecord = (value: unknown): Record<string, unknown> | null => {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+};
+
+const asArray = (value: unknown): unknown[] => (Array.isArray(value) ? value : []);
+
+const asString = (value: unknown): string | null => (typeof value === 'string' && value.trim() ? value : null);
+
+const asNumber = (value: unknown): number | null => (typeof value === 'number' && Number.isFinite(value) ? value : null);
+
+type UnifiedEvent = {
+  sequence: number;
+  absoluteTimestamp: string | null;
+  timestampMs: number | null;
+  elapsedMsSinceAttemptStart: number | null;
+  eventName: string;
+  sessionId: string | null;
+  flowRunId: string | null;
+  paymentIntentId: string | null;
+  processName: string | null;
+  activityIdentityHash: number | null;
+  context: Record<string, unknown>;
+  source: 'ui' | 'native';
+};
+
+type BuildInput = {
+  attemptSummary: Record<string, unknown>;
+  rawNativePayload: Record<string, unknown> | null;
+  rawServerVerificationPayload: Record<string, unknown> | null;
+  uiContext: Record<string, unknown>;
+  uiEventHistory: Record<string, unknown>[];
+};
+
+const normalizeUiEvent = (event: Record<string, unknown>, attemptStartMs: number | null): UnifiedEvent => {
+  const timestampMs = asNumber(event.timestampMs);
+  const elapsedMs = asNumber(event.elapsedMsSinceAttemptStart);
+  const computedElapsed = elapsedMs ?? (timestampMs != null && attemptStartMs != null ? Math.max(0, timestampMs - attemptStartMs) : null);
+  const context = asRecord(event.context) || {};
+  const absoluteTimestamp = asString(event.absoluteTimestamp) ?? (timestampMs != null ? new Date(timestampMs).toISOString() : null);
+  return {
+    sequence: asNumber(event.sequence) ?? 0,
+    absoluteTimestamp,
+    timestampMs,
+    elapsedMsSinceAttemptStart: computedElapsed,
+    eventName: asString(event.eventName) || 'ui.unknown',
+    sessionId: asString(event.sessionId),
+    flowRunId: asString(event.flowRunId),
+    paymentIntentId: asString(event.paymentIntentId),
+    processName: asString(event.processName),
+    activityIdentityHash: asNumber(event.activityIdentityHash),
+    context,
+    source: 'ui',
+  };
+};
+
+const normalizeNativeEvent = (event: Record<string, unknown>, attemptStartMs: number | null): UnifiedEvent => {
+  const timestampMs = asNumber(event.timestampMs);
+  const elapsedMs = asNumber(event.elapsedMsSinceAttemptStart);
+  const computedElapsed = elapsedMs ?? (timestampMs != null && attemptStartMs != null ? Math.max(0, timestampMs - attemptStartMs) : null);
+  const context = asRecord(event.context) || {};
+  const absoluteTimestamp = asString(event.absoluteTimestamp) ?? (timestampMs != null ? new Date(timestampMs).toISOString() : null);
+  return {
+    sequence: asNumber(event.sequence) ?? 0,
+    absoluteTimestamp,
+    timestampMs,
+    elapsedMsSinceAttemptStart: computedElapsed,
+    eventName: asString(event.eventName) || 'native.unknown',
+    sessionId: asString(event.sessionId),
+    flowRunId: asString(event.flowRunId),
+    paymentIntentId: asString(event.paymentIntentId),
+    processName: asString(event.processName),
+    activityIdentityHash: asNumber(event.activityIdentityHash),
+    context,
+    source: 'native',
+  };
+};
+
+const sortEvents = (events: UnifiedEvent[]): UnifiedEvent[] => {
+  return [...events].sort((a, b) => {
+    const aTs = a.timestampMs ?? Number.MAX_SAFE_INTEGER;
+    const bTs = b.timestampMs ?? Number.MAX_SAFE_INTEGER;
+    if (aTs !== bTs) return aTs - bTs;
+    if (a.source !== b.source) return a.source === 'ui' ? -1 : 1;
+    return a.sequence - b.sequence;
+  });
+};
+
+const inferPresentments = (events: UnifiedEvent[]) => {
+  const presentments: Record<string, unknown>[] = [];
+  let current: Record<string, unknown> | null = null;
+
+  const closeCurrent = (result: string, endTs: number | null, notes: string) => {
+    if (!current) return;
+    current.endedAtMs = endTs;
+    current.result = result;
+    current.notes = notes;
+    presentments.push(current);
+    current = null;
+  };
+
+  for (const event of events) {
+    const nativeStatus = event.eventName === 'native.terminal_payment_status_change'
+      ? asString(event.context.paymentStatus)
+      : null;
+
+    if (nativeStatus === 'WAITING_FOR_INPUT') {
+      if (current) {
+        closeCurrent('superseded_by_new_waiting_for_input', event.timestampMs, 'Inferred boundary: another WAITING_FOR_INPUT appeared before explicit completion.');
+      }
+      current = {
+        presentmentIndex: presentments.length + 1,
+        startedAtMs: event.timestampMs,
+        endedAtMs: null,
+        result: 'in_progress',
+        ledToCollectSuccess: false,
+        ledToProcessStart: false,
+        ledToProcessSuccess: false,
+        ledToProcessFailure: false,
+        paymentIntentId: event.paymentIntentId,
+        flowRunId: event.flowRunId,
+        basis: 'inferred_from_payment_status_WAITING_FOR_INPUT',
+        directCardReadSignalObserved: false,
+        notes: 'Presentment opportunity inferred from Stripe Terminal payment status callback.',
+      };
+      continue;
+    }
+
+    if (!current) continue;
+
+    if (event.eventName === 'native.collect_success_callback') {
+      current.ledToCollectSuccess = true;
+    }
+    if (event.eventName === 'native.process_start' || event.eventName === 'native.process_invoked_before_sdk_call') {
+      current.ledToProcessStart = true;
+    }
+    if (event.eventName === 'native.process_success_callback') {
+      current.ledToProcessSuccess = true;
+      closeCurrent('process_success', event.timestampMs, 'Collect/process callbacks indicate this presentment completed successfully.');
+      continue;
+    }
+    if (event.eventName === 'native.collect_failure_callback') {
+      closeCurrent('collect_failure', event.timestampMs, 'Collect callback failed for this presentment.');
+      continue;
+    }
+    if (event.eventName === 'native.process_failure_callback') {
+      current.ledToProcessFailure = true;
+      closeCurrent('process_failure', event.timestampMs, 'Process callback failed for this presentment.');
+      continue;
+    }
+  }
+
+  if (current) {
+    closeCurrent('abandoned_or_unresolved', current.startedAtMs as number | null, 'No terminal collect/process completion callback observed before attempt end.');
+  }
+
+  return presentments;
+};
+
+const inferRuns = (events: UnifiedEvent[], presentments: Record<string, unknown>[]) => {
+  const runMap = new Map<string, Record<string, unknown>>();
+  let runCounter = 0;
+
+  for (const event of events) {
+    const flowRunId = event.flowRunId || `missing_flow_run_${runCounter + 1}`;
+    if (!runMap.has(flowRunId)) {
+      runCounter += 1;
+      runMap.set(flowRunId, {
+        runIndex: runCounter,
+        flowRunId: event.flowRunId,
+        paymentIntentId: event.paymentIntentId,
+        collectCount: 0,
+        processInvokeCount: 0,
+        collectSuccessCallbackCount: 0,
+        collectFailureCallbackCount: 0,
+        processSuccessCallbackCount: 0,
+        processFailureCallbackCount: 0,
+        outcome: 'in_progress',
+        linkedPresentmentIndices: [],
+      });
+    }
+    const run = runMap.get(flowRunId)!;
+    if (!run.paymentIntentId && event.paymentIntentId) run.paymentIntentId = event.paymentIntentId;
+    if (event.eventName === 'native.collect_invoked') run.collectCount = Number(run.collectCount) + 1;
+    if (event.eventName === 'native.process_start' || event.eventName === 'native.process_invoked_before_sdk_call') {
+      run.processInvokeCount = Number(run.processInvokeCount) + 1;
+    }
+    if (event.eventName === 'native.collect_success_callback') run.collectSuccessCallbackCount = Number(run.collectSuccessCallbackCount) + 1;
+    if (event.eventName === 'native.collect_failure_callback') run.collectFailureCallbackCount = Number(run.collectFailureCallbackCount) + 1;
+    if (event.eventName === 'native.process_success_callback') {
+      run.processSuccessCallbackCount = Number(run.processSuccessCallbackCount) + 1;
+      run.outcome = 'succeeded';
+    }
+    if (event.eventName === 'native.process_failure_callback') {
+      run.processFailureCallbackCount = Number(run.processFailureCallbackCount) + 1;
+      if (run.outcome !== 'succeeded') run.outcome = 'failed';
+    }
+  }
+
+  presentments.forEach((presentment) => {
+    const run = Array.from(runMap.values()).find((candidate) => candidate.flowRunId === presentment.flowRunId);
+    if (!run) return;
+    const indices = run.linkedPresentmentIndices as number[];
+    const idx = asNumber(presentment.presentmentIndex);
+    if (idx != null && !indices.includes(idx)) indices.push(idx);
+  });
+
+  return Array.from(runMap.values());
+};
+
+const buildFinalOutcome = (presentments: Record<string, unknown>[]) => {
+  const first = presentments[0] || null;
+  const second = presentments[1] || null;
+  const firstComplete = !!first && ((first.ledToProcessSuccess === true) || (first.ledToProcessFailure === true));
+  const neededSecond = presentments.length > 1;
+  const final = presentments[presentments.length - 1] || null;
+  const finalFrom = final ? asNumber(final.presentmentIndex) : null;
+  const strandedFirst = !!first && firstComplete === false && neededSecond;
+
+  let conclusion = 'Insufficient data to determine presentment behavior.';
+  if (first && !neededSecond && first.ledToProcessSuccess === true) {
+    conclusion = 'Single presentment completed successfully.';
+  } else if (first && strandedFirst && second) {
+    conclusion = 'First presentment did not reach process completion, and a second presentment opportunity occurred.';
+  } else if (first && neededSecond && (second?.ledToProcessSuccess === true || second?.ledToProcessFailure === true)) {
+    conclusion = 'Attempt required a second presentment to reach a final process callback.';
+  }
+
+  return {
+    didFirstPresentmentComplete: firstComplete,
+    didAttemptRequireSecondPresentment: neededSecond,
+    finalSuccessOrFailureFromPresentmentIndex: finalFrom,
+    abandonedOrStrandedFirstRunDetected: strandedFirst,
+    conclusion,
+  };
+};
+
+export const buildCombinedTapToPayDiagnosticsPayload = (input: BuildInput) => {
+  const nativeSnapshot = asRecord(input.rawNativePayload?.quickChargeTraceSnapshot) || {};
+  const nativeHistoryRaw = asArray(nativeSnapshot.eventHistory);
+  const uiHistoryRaw = asArray(input.uiEventHistory);
+
+  const attemptStartMs = asNumber(input.uiContext.attemptStartTimestampMs)
+    ?? asNumber(nativeSnapshot.attemptStartTimestampMs)
+    ?? null;
+
+  const uiEvents = uiHistoryRaw
+    .map((event) => asRecord(event))
+    .filter((event): event is Record<string, unknown> => !!event)
+    .map((event) => normalizeUiEvent(event, attemptStartMs));
+
+  const nativeEvents = nativeHistoryRaw
+    .map((event) => asRecord(event))
+    .filter((event): event is Record<string, unknown> => !!event)
+    .map((event) => normalizeNativeEvent(event, attemptStartMs));
+
+  const eventHistory = sortEvents([...uiEvents, ...nativeEvents]).map((event, index) => ({
+    ...event,
+    sequence: index + 1,
+  }));
+
+  const presentments = inferPresentments(eventHistory);
+  const runs = inferRuns(eventHistory, presentments);
+  const finalOutcome = buildFinalOutcome(presentments);
+
+  const attemptEndMs = asNumber(input.uiContext.attemptEndTimestampMs)
+    ?? asNumber(nativeSnapshot.attemptEndTimestampMs)
+    ?? eventHistory[eventHistory.length - 1]?.timestampMs
+    ?? null;
+
+  const attemptMeta = {
+    sessionId: asString(input.uiContext.sessionId) ?? asString(input.rawNativePayload?.sessionId) ?? null,
+    flowRunId: asString(input.uiContext.flowRunId) ?? asString(input.rawNativePayload?.flowRunId) ?? null,
+    paymentIntentId:
+      asString(input.uiContext.paymentIntentId)
+      ?? asString(input.rawNativePayload?.paymentIntentId)
+      ?? asString(nativeSnapshot.paymentIntentId)
+      ?? null,
+    restaurantId: asString(input.uiContext.restaurantId),
+    terminalLocationId: asString(input.uiContext.terminalLocationId),
+    startTimestamp: attemptStartMs != null ? new Date(attemptStartMs).toISOString() : null,
+    endTimestamp: attemptEndMs != null ? new Date(attemptEndMs).toISOString() : null,
+    totalDurationMs: attemptStartMs != null && attemptEndMs != null ? Math.max(0, attemptEndMs - attemptStartMs) : null,
+    nativePluginVersionMarkers: {
+      sdkVersion: asString((nativeSnapshot.tapToPayProcessAwareness as Record<string, unknown> | null)?.sdkVersion),
+      pluginInstanceId: asNumber(nativeSnapshot.pluginInstanceId),
+      activeRunSequence: asNumber(nativeSnapshot.activeRunSequence),
+    },
+    hadMoreThanOnePresentmentReadOpportunity: presentments.length > 1,
+  };
+
+  return {
+    attemptMeta,
+    eventHistory,
+    presentments,
+    runs,
+    finalOutcome,
+    rawNativePayload: input.rawNativePayload,
+    rawServerVerificationPayload: input.rawServerVerificationPayload,
+    uiContext: input.uiContext,
+  };
+};


### PR DESCRIPTION
### Motivation
- The existing Tap to Pay diagnostics only surfaced the final native run and did not provide full presentment-level, end-to-end visibility needed to prove double-tap / first-presentment issues. 
- This change is diagnostics-only and must not alter any payment behavior, timers, gates, or retries.

### Description
- Add a shared diagnostics serializer `lib/payments/tapToPayDiagnostics.ts` that composes one combined JSON payload with the required top-level sections (`attemptMeta`, `eventHistory`, `presentments`, `runs`, `finalOutcome`, `rawNativePayload`, `rawServerVerificationPayload`, `uiContext`).
- Instrument the Android Tap to Pay plugin to record run-scoped native timeline events into an ordered `eventHistory` with sequence, timestamps, elapsed deltas, IDs, activity hash and compact context, and attach the full run history and attempt-level start/end markers to `quickChargeTraceSnapshot` on all success/failure/cancel/exception return paths. 
- Extend the POS/Quick-charge UI (`components/payments/InternalSettlementModule.tsx`) to record UI-side per-attempt events, attempt start/end timestamps and payment intent context, and to call the shared serializer to render a single monospaced JSON diagnostics object with one copy button. 
- Preserve existing raw native and server verification payloads (now nested under the combined object) and infer presentment boundaries from status/callback sequences when explicit card-read callbacks are unavailable, without changing any payment flow logic.

### Testing
- Type-check: ran `npx tsc --noEmit` which completed with no TypeScript errors (pass). 
- Verified the new combined diagnostics payload is produced by the UI and includes merged UI + native ordered `eventHistory`, inferred `presentments`, per-run summaries, and `finalOutcome` in one copyable JSON object (manual inspection via UI instrumentation after instrumentation changes).
- No runtime payment behavior changes were introduced, as only telemetry/serialization and UI diagnostics wiring were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfda0fb5588325a61858a7cb3976d0)