### PR TITLE
fix(payments): restore shared pre‑handover Tap to Pay UX and prevent cancel/failure finalization

### DIFF
--- a/components/payments/InternalSettlementModule.tsx
+++ b/components/payments/InternalSettlementModule.tsx
@@ -5,9 +5,11 @@ import { resolveNativeTapToPayReadiness } from '@/lib/kiosk/tapToPayNativeReadin
 import { type AppFlowState } from '@/lib/app/launcherBootstrap';
 import { internalSettlementActiveRunStore } from '@/lib/payments/internalSettlementActiveRunStore';
 import { buildCombinedTapToPayDiagnosticsPayload } from '@/lib/payments/tapToPayDiagnostics';
+import NativeTapToPayPreHandoverOverlay from '@/components/payments/NativeTapToPayPreHandoverOverlay';
+import { isNativeTapToPayPreHandoverPhase, resolveNativeTapToPayUiPhase } from '@/lib/payments/nativeTapToPayUiPhases';
 
 type SettlementMode = 'order_payment' | 'quick_charge';
-type CollectionState = AppFlowState | 'idle';
+type CollectionState = AppFlowState | 'idle' | 'handover';
 type CollectionFailureCategory =
   | 'customer_cancelled'
   | 'app_cancelled'
@@ -149,6 +151,7 @@ export default function InternalSettlementModule({
   const [quickChargeRawServerVerificationPayload, setQuickChargeRawServerVerificationPayload] = useState<Record<string, unknown> | null>(null);
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
   const [activeTerminalLocationId, setActiveTerminalLocationId] = useState<string | null>(null);
+  const [preHandoverMessageIndex, setPreHandoverMessageIndex] = useState(0);
   const flowActiveRef = useRef(false);
   const flowRunIdRef = useRef<string | null>(null);
   const quickChargeAttemptStartMsRef = useRef<number | null>(null);
@@ -158,6 +161,8 @@ export default function InternalSettlementModule({
   const quickChargePaymentIntentIdRef = useRef<string | null>(null);
 
   const selectedOrder = useMemo(() => orders.find((order) => order.id === selectedOrderId) || null, [orders, selectedOrderId]);
+  const uiPhase = useMemo(() => resolveNativeTapToPayUiPhase(state), [state]);
+  const showPreHandoverOverlay = useMemo(() => isNativeTapToPayPreHandoverPhase(state), [state]);
 
   const amountCents = useMemo(() => {
     if (mode === 'order_payment') return Number(selectedOrder?.total_price || 0);
@@ -414,6 +419,17 @@ export default function InternalSettlementModule({
     onFlowActivityChange?.(busy || flowActiveRef.current);
   }, [busy, onFlowActivityChange]);
 
+  useEffect(() => {
+    if (!showPreHandoverOverlay) {
+      setPreHandoverMessageIndex(0);
+      return;
+    }
+    const interval = window.setInterval(() => {
+      setPreHandoverMessageIndex((previous) => previous + 1);
+    }, 2200);
+    return () => window.clearInterval(interval);
+  }, [showPreHandoverOverlay]);
+
   const classifyNativeFailure = useCallback((nativeResult: Awaited<ReturnType<typeof tapToPayBridge.startTapToPayPayment>>) => {
     const detail =
       nativeResult.detail && typeof nativeResult.detail === 'object'
@@ -664,8 +680,8 @@ export default function InternalSettlementModule({
         return;
       }
 
-      setState('collecting');
-      setMessage('Present card/phone to collect payment…');
+      setState('handover');
+      setMessage('Handing over to Stripe Tap to Pay…');
       logCollectionEvent('native_collect.start', { sessionId });
 
       let nativeResult = await tapToPayBridge.startTapToPayPayment({
@@ -945,6 +961,18 @@ export default function InternalSettlementModule({
         }
 
         if (verifyRes?.ok === true && verifiedState === 'finalized') {
+          const verificationPaid = verifyPayload?.verification?.verifiedPaid === true;
+          if (!verificationPaid) {
+            setState('failed');
+            setMessage(
+              verifyPayload?.verification?.reason ||
+                'Payment did not complete successfully. Please retry or choose another method.'
+            );
+            setActiveSessionId(null);
+            setActiveTerminalLocationId(null);
+            internalSettlementActiveRunStore.clear();
+            return;
+          }
           if (mode === 'quick_charge') {
             quickChargeAttemptEndMsRef.current = Date.now();
           }
@@ -1283,7 +1311,14 @@ export default function InternalSettlementModule({
   }, [activeSessionId, loadOrders, logCollectionEvent]);
 
   return (
-    <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+    <section className="relative rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+      <NativeTapToPayPreHandoverOverlay
+        visible={showPreHandoverOverlay}
+        phaseLabel="Preparing payment mode"
+        title="Contactless payments"
+        message={message}
+        lineIndex={preHandoverMessageIndex}
+      />
       <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{eyebrow}</p>
       <h1 className="mt-2 text-2xl font-semibold tracking-tight text-slate-900 sm:text-3xl">{title}</h1>
 
@@ -1371,28 +1406,6 @@ export default function InternalSettlementModule({
 
         <div className="space-y-4 rounded-2xl border border-slate-200 p-4">
           <h2 className="text-sm font-semibold text-slate-900">Payment method</h2>
-          <p className="text-sm text-slate-600">Contactless card-present via Tap to Pay</p>
-          {tapAvailabilityLoading ? (
-            <p className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-600">
-              Checking Tap to Pay availability…
-            </p>
-          ) : null}
-          {!tapAvailabilityLoading && !tapAvailabilityReady ? (
-            <p className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
-              Tap to Pay unavailable: {tapAvailabilityReason || 'Tap to Pay is not ready on this account/device.'}
-            </p>
-          ) : null}
-          {nativeReadinessLoading ? (
-            <p className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-600">
-              Checking device Tap to Pay prerequisites…
-            </p>
-          ) : null}
-          {!nativeReadinessLoading && !nativeReadinessReady ? (
-            <p className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
-              Device setup required:{' '}
-              {nativeReadinessReason || 'Location permission and location services are required.'}
-            </p>
-          ) : null}
 
           <div
             className={`rounded-2xl border px-4 py-3 text-sm ${
@@ -1405,8 +1418,18 @@ export default function InternalSettlementModule({
                     : 'border-slate-200 bg-slate-50 text-slate-700'
             }`}
           >
-            <p className="font-semibold">Collection state: {state.replace('_', ' ')}</p>
+            <p className="font-semibold">Collection state: {uiPhase.replaceAll('_', ' ')}</p>
             <p className="mt-1 text-xs">{message}</p>
+            {!tapAvailabilityLoading && !tapAvailabilityReady ? (
+              <p className="mt-2 text-xs text-amber-700">
+                Tap to Pay unavailable: {tapAvailabilityReason || 'Tap to Pay is not ready on this account/device.'}
+              </p>
+            ) : null}
+            {!nativeReadinessLoading && !nativeReadinessReady ? (
+              <p className="mt-2 text-xs text-amber-700">
+                Device setup required: {nativeReadinessReason || 'Location permission and location services are required.'}
+              </p>
+            ) : null}
             {quickChargeAttemptDiagnosticsSerialized ? (
               <div
                 className={`mt-3 rounded-xl border bg-white/90 p-3 text-[11px] ${
@@ -1443,10 +1466,6 @@ export default function InternalSettlementModule({
                   {quickChargeAttemptDiagnosticsSerialized}
                 </pre>
               </div>
-            ) : null}
-            {activeSessionId ? <p className="mt-2 text-[11px] text-slate-500">Session: {activeSessionId}</p> : null}
-            {activeTerminalLocationId ? (
-              <p className="mt-1 text-[11px] text-slate-500">Terminal location: {activeTerminalLocationId}</p>
             ) : null}
           </div>
 

--- a/components/payments/NativeTapToPayPreHandoverOverlay.tsx
+++ b/components/payments/NativeTapToPayPreHandoverOverlay.tsx
@@ -1,0 +1,45 @@
+import { useMemo } from 'react';
+
+type NativeTapToPayPreHandoverOverlayProps = {
+  visible: boolean;
+  title?: string;
+  message?: string;
+  phaseLabel?: string;
+  lines?: string[];
+  lineIndex?: number;
+};
+
+const DEFAULT_LINES = [
+  'Activating contactless payments…',
+  'Preparing Tap to Pay…',
+  'Waking up the payment magic…',
+  'Getting ready for contactless…',
+];
+
+export default function NativeTapToPayPreHandoverOverlay({
+  visible,
+  title = 'Contactless payments',
+  message,
+  phaseLabel = 'Preparing payment mode',
+  lines = DEFAULT_LINES,
+  lineIndex = 0,
+}: NativeTapToPayPreHandoverOverlayProps) {
+  const activeLine = useMemo(() => {
+    if (!lines.length) return '';
+    const safeIndex = Number.isFinite(lineIndex) ? Math.abs(lineIndex) % lines.length : 0;
+    return lines[safeIndex] || lines[0];
+  }, [lineIndex, lines]);
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed inset-0 z-[90] flex items-center justify-center bg-slate-500/45 px-4 py-6 backdrop-blur-[2px]">
+      <section className="w-full max-w-xl rounded-[2rem] border border-slate-200/70 bg-slate-100/95 p-7 text-center shadow-2xl sm:p-9">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{phaseLabel}</p>
+        <div className="mx-auto mt-5 h-11 w-11 animate-spin rounded-full border-4 border-white/80 border-t-slate-600" />
+        <h2 className="mt-5 text-2xl font-semibold tracking-tight text-slate-900">{title}</h2>
+        <p className="mt-3 text-base font-medium text-slate-700">{message || activeLine}</p>
+      </section>
+    </div>
+  );
+}

--- a/lib/payments/nativeTapToPayUiPhases.ts
+++ b/lib/payments/nativeTapToPayUiPhases.ts
@@ -1,0 +1,27 @@
+type NativePreHandoverPhase =
+  | 'bootstrapping'
+  | 'checking_readiness'
+  | 'preparing_native'
+  | 'handover_to_stripe'
+  | 'stripe_live_payment'
+  | 'success'
+  | 'canceled'
+  | 'failed';
+
+export const resolveNativeTapToPayUiPhase = (state: string): NativePreHandoverPhase => {
+  if (state === 'bootstrapping') return 'checking_readiness';
+  if (state === 'preparing') return 'preparing_native';
+  if (state === 'handover') return 'handover_to_stripe';
+  if (state === 'collecting' || state === 'processing' || state === 'finalizing') return 'stripe_live_payment';
+  if (state === 'completed' || state === 'succeeded') return 'success';
+  if (state === 'canceled') return 'canceled';
+  if (state === 'failed' || state === 'permission_denied' || state === 'unsupported_device' || state === 'setup_failed' || state === 'location_services_disabled') {
+    return 'failed';
+  }
+  return 'bootstrapping';
+};
+
+export const isNativeTapToPayPreHandoverPhase = (state: string) => {
+  const phase = resolveNativeTapToPayUiPhase(state);
+  return phase === 'checking_readiness' || phase === 'preparing_native' || phase === 'handover_to_stripe';
+};

--- a/pages/kiosk/[restaurantId]/payment-entry.tsx
+++ b/pages/kiosk/[restaurantId]/payment-entry.tsx
@@ -22,6 +22,8 @@ import { tapToPayBridge, type TapToPayResult, type TapToPayStatus } from '@/lib/
 import type { KioskTerminalMode } from '@/lib/kiosk/terminalMode';
 import { setKioskLastRealOrderNumber } from '@/utils/kiosk/orders';
 import { requestPrintJobCreation } from '@/lib/print-jobs/request';
+import NativeTapToPayPreHandoverOverlay from '@/components/payments/NativeTapToPayPreHandoverOverlay';
+import { isNativeTapToPayPreHandoverPhase } from '@/lib/payments/nativeTapToPayUiPhases';
 
 type Restaurant = {
   id: string;
@@ -222,9 +224,9 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
   const [orderSubmitError, setOrderSubmitError] = useState('');
   const [currentOrderMethod, setCurrentOrderMethod] = useState<'cash' | 'pay_at_counter' | 'contactless' | null>(null);
   const [autoSubmitAttemptedMethod, setAutoSubmitAttemptedMethod] = useState<'cash' | 'pay_at_counter' | 'contactless' | null>(null);
+  const [suppressStageAutoSubmit, setSuppressStageAutoSubmit] = useState(false);
   const [prepMessageIndex, setPrepMessageIndex] = useState(0);
   const [collectMessageIndex, setCollectMessageIndex] = useState(0);
-  const [readerHint, setReaderHint] = useState('');
   const [terminalMode, setTerminalMode] = useState<KioskTerminalMode>('real_tap_to_pay');
   const isVerifiedPaidPayload = useCallback((verification: PaymentVerification | null | undefined) => {
     if (!verification || verification.verifiedPaid !== true) return false;
@@ -385,7 +387,7 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
       setContactlessDebug('idle');
       setTapStartupTrace(createStartupTrace());
       setContactlessTerminalLocationId(null);
-      setReaderHint('');
+      setSuppressStageAutoSubmit(false);
       if (typeof window !== 'undefined') {
         window.localStorage.removeItem(CONTACTLESS_SESSION_STORAGE_KEY);
       }
@@ -536,12 +538,8 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
       }
     };
 
-    const updateReaderHintFromDetail = (detail: unknown) => {
-      if (!detail || typeof detail !== 'object') return;
-      const maybeReaderLabel = (detail as { readerLabel?: unknown }).readerLabel;
-      if (typeof maybeReaderLabel === 'string' && maybeReaderLabel.trim()) {
-        setReaderHint(`Reader connected: ${maybeReaderLabel}. If unclear, tap near the center of this device.`);
-      }
+    const updateReaderHintFromDetail = (_detail: unknown) => {
+      return;
     };
 
     const logNativeOutcome = (label: string, payload: unknown) => {
@@ -1120,9 +1118,11 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
       setContactlessDebug('fallback');
       setContactlessDebugDetail('');
       setAutoSubmitAttemptedMethod(null);
+      setSuppressStageAutoSubmit(true);
       flowLockRef.current = false;
       cancelLockRef.current = false;
-      setStage(enabledMethods.length > 1 ? 'method_picker' : 'pay_at_counter');
+      const nonContactlessMethod = enabledMethods.find((method) => method !== 'contactless');
+      setStage(nonContactlessMethod ?? 'method_picker');
       if (typeof window !== 'undefined') {
         window.localStorage.removeItem(CONTACTLESS_SESSION_STORAGE_KEY);
       }
@@ -1351,6 +1351,7 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
   useEffect(() => {
     if (settingsLoading) return;
     if (orderSubmitting) return;
+    if (suppressStageAutoSubmit) return;
     if (stage === 'cash' && autoSubmitAttemptedMethod !== 'cash') {
       setAutoSubmitAttemptedMethod('cash');
       void submitOrderAndRedirect('cash');
@@ -1358,7 +1359,7 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
       setAutoSubmitAttemptedMethod('pay_at_counter');
       void submitOrderAndRedirect('pay_at_counter');
     }
-  }, [autoSubmitAttemptedMethod, orderSubmitting, settingsLoading, stage, submitOrderAndRedirect]);
+  }, [autoSubmitAttemptedMethod, orderSubmitting, settingsLoading, stage, submitOrderAndRedirect, suppressStageAutoSubmit]);
 
   useEffect(() => {
     if (contactlessStatus !== 'succeeded' || orderSubmitting || autoSubmitAttemptedMethod === 'contactless') return;
@@ -1500,10 +1501,8 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
         >
           <DevicePhoneMobileIcon className="h-9 w-9 text-white" />
         </div>
-        <p className="mt-5 text-xl font-semibold tracking-tight text-slate-900 sm:text-2xl">Tap card or phone near the reader</p>
-        <p className="mx-auto mt-2 max-w-lg text-sm text-slate-700 sm:text-base">
-          {readerHint || 'If the reader location is unclear, tap near the center of this device to continue.'}
-        </p>
+        <p className="mt-5 text-xl font-semibold tracking-tight text-slate-900 sm:text-2xl">Contactless payment</p>
+        <p className="mx-auto mt-2 max-w-lg text-sm text-slate-700 sm:text-base">Complete the payment flow to place your order.</p>
         {contactlessStatus === 'preparing' || contactlessStatus === 'idle' ? (
           <p className="mt-5 text-base font-medium text-slate-800">{PAYMENT_PREP_MESSAGES[prepMessageIndex]}</p>
         ) : null}
@@ -1683,6 +1682,15 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
 
           {!settingsLoading && stage === 'method_picker' ? renderMethodPicker() : null}
           {!settingsLoading && stage === 'contactless' ? renderContactlessOverlay() : null}
+          {!settingsLoading && stage === 'contactless' ? (
+            <NativeTapToPayPreHandoverOverlay
+              visible={isNativeTapToPayPreHandoverPhase(contactlessStatus)}
+              phaseLabel="Preparing payment mode"
+              title="Contactless payments"
+              message={PAYMENT_PREP_MESSAGES[prepMessageIndex]}
+              lineIndex={prepMessageIndex}
+            />
+          ) : null}
           {!settingsLoading && orderSubmitting ? renderOrderSubmittingOverlay() : null}
         </div>
       </div>


### PR DESCRIPTION
### Motivation

- Restore the original shared full‑screen pre‑handover loading UX that appears while native Tap to Pay is activating/preparing, and ensure the same experience is used across kiosk, POS/Take Payment, and Quick charge flows.  
- Remove the incorrect inline “card-present readiness” presentation that appeared prematurely in Take Payment.  
- Prevent canceled or failed native/contactless runs from finalizing an order or marking a payment as successful.

### Description

- Added a reusable overlay component `components/payments/NativeTapToPayPreHandoverOverlay.tsx` that implements the full‑screen grey modal, centered spinner, and rotating preparation copy (no card placement instructions).  
- Introduced a small shared phase mapper `lib/payments/nativeTapToPayUiPhases.ts` with `resolveNativeTapToPayUiPhase` and `isNativeTapToPayPreHandoverPhase` so the UI shows the overlay only for readiness/preparing/handover phases and not during Stripe‑owned live collection stages.  
- Wired the overlay and phase logic into the shared Take Payment/Internal settlement flow (`components/payments/InternalSettlementModule.tsx`) and the kiosk payment entry page (`pages/kiosk/[restaurantId]/payment-entry.tsx`), added a `handover` display state to mark the pre‑handover handoff, and removed the inline readiness card UX in favor of compact status lines.  
- Hardened cancel/failure handling: when the server verification path returns a `finalized` session during cancel/verify processing, the UI now requires `verification.verifiedPaid === true` before treating the flow as a successful/finalized payment; otherwise it fails safely and clears active run state.  
- Fixed kiosk fallback behavior so canceled/failed contactless attempts do not auto‑submit an order by suppressing the stage auto‑submit on fallback and returning the user to a non‑contactless recoverable state.

### Testing

- Ran typecheck: `npx tsc --noEmit` — succeeded.  
- Attempted production build: `npm run build` — failed in this environment during Next.js page data collection due to missing server env `SUPABASE_URL` (environment issue, unrelated to the client/type changes).  
- No additional automated tests were added; changes are focused and scoped to the native/contactless UI paths and server verification gating described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dff3538ac8832585482250424986a2)