### PR TITLE
fix(payments): unify full-screen native Tap to Pay transition overlay across Kiosk / POS / Take Payment

### DIFF
--- a/components/payments/InternalSettlementModule.tsx
+++ b/components/payments/InternalSettlementModule.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useRouter } from 'next/router';
 import { tapToPayBridge } from '@/lib/kiosk/tapToPayBridge';
 import { formatPrice } from '@/lib/orderDisplay';
 import { resolveNativeTapToPayReadiness } from '@/lib/kiosk/tapToPayNativeReadiness';
@@ -6,10 +7,16 @@ import { type AppFlowState } from '@/lib/app/launcherBootstrap';
 import { internalSettlementActiveRunStore } from '@/lib/payments/internalSettlementActiveRunStore';
 import { buildCombinedTapToPayDiagnosticsPayload } from '@/lib/payments/tapToPayDiagnostics';
 import NativeTapToPayPreHandoverOverlay from '@/components/payments/NativeTapToPayPreHandoverOverlay';
-import { isNativeTapToPayPreHandoverPhase, resolveNativeTapToPayUiPhase } from '@/lib/payments/nativeTapToPayUiPhases';
+import {
+  isNativeTapToPayCancelableOverlayPhase,
+  isNativeTapToPayOverlayVisiblePhase,
+  POST_HANDOVER_PROGRESS_LINES,
+  PRE_HANDOVER_PROGRESS_LINES,
+  resolveNativeTapToPayUiPhase,
+} from '@/lib/payments/nativeTapToPayUiPhases';
 
 type SettlementMode = 'order_payment' | 'quick_charge';
-type CollectionState = AppFlowState | 'idle' | 'handover';
+type CollectionState = AppFlowState | 'idle' | 'handover' | 'canceled';
 type CollectionFailureCategory =
   | 'customer_cancelled'
   | 'app_cancelled'
@@ -39,6 +46,7 @@ type InternalSettlementModuleProps = {
   eyebrow?: string;
   restaurantId?: string | null;
   onFlowActivityChange?: (active: boolean) => void;
+  entryPoint?: 'pos' | 'take_payment';
 };
 
 type QuickChargeFailureSnapshot = {
@@ -126,7 +134,9 @@ export default function InternalSettlementModule({
   eyebrow = 'Internal settlement module',
   restaurantId = null,
   onFlowActivityChange,
+  entryPoint = 'take_payment',
 }: InternalSettlementModuleProps) {
+  const router = useRouter();
   const [mode, setMode] = useState<SettlementMode>('order_payment');
   const [orders, setOrders] = useState<UnpaidOrder[]>([]);
   const [loadingOrders, setLoadingOrders] = useState(true);
@@ -151,9 +161,13 @@ export default function InternalSettlementModule({
   const [quickChargeRawServerVerificationPayload, setQuickChargeRawServerVerificationPayload] = useState<Record<string, unknown> | null>(null);
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
   const [activeTerminalLocationId, setActiveTerminalLocationId] = useState<string | null>(null);
-  const [preHandoverMessageIndex, setPreHandoverMessageIndex] = useState(0);
+  const [overlayMessageIndex, setOverlayMessageIndex] = useState(0);
+  const [cancelInFlight, setCancelInFlight] = useState(false);
+  const [showSuccessTick, setShowSuccessTick] = useState(false);
+  const [successRouteLock, setSuccessRouteLock] = useState(false);
   const flowActiveRef = useRef(false);
   const flowRunIdRef = useRef<string | null>(null);
+  const overlayPhaseEnteredAtMsRef = useRef<number | null>(null);
   const quickChargeAttemptStartMsRef = useRef<number | null>(null);
   const quickChargeAttemptEndMsRef = useRef<number | null>(null);
   const quickChargeEventSequenceRef = useRef(0);
@@ -162,7 +176,18 @@ export default function InternalSettlementModule({
 
   const selectedOrder = useMemo(() => orders.find((order) => order.id === selectedOrderId) || null, [orders, selectedOrderId]);
   const uiPhase = useMemo(() => resolveNativeTapToPayUiPhase(state), [state]);
-  const showPreHandoverOverlay = useMemo(() => isNativeTapToPayPreHandoverPhase(state), [state]);
+  const showTransitionOverlay = useMemo(() => isNativeTapToPayOverlayVisiblePhase(state) || showSuccessTick, [showSuccessTick, state]);
+  const canCloseOverlay = useMemo(
+    () => isNativeTapToPayCancelableOverlayPhase(state) && !cancelInFlight && !showSuccessTick,
+    [cancelInFlight, showSuccessTick, state]
+  );
+  const overlayLines = useMemo(
+    () =>
+      uiPhase === 'processing_returned_result' || uiPhase === 'verifying_paid_outcome' || uiPhase === 'finalizing_session'
+        ? POST_HANDOVER_PROGRESS_LINES
+        : PRE_HANDOVER_PROGRESS_LINES,
+    [uiPhase]
+  );
 
   const amountCents = useMemo(() => {
     if (mode === 'order_payment') return Number(selectedOrder?.total_price || 0);
@@ -420,15 +445,41 @@ export default function InternalSettlementModule({
   }, [busy, onFlowActivityChange]);
 
   useEffect(() => {
-    if (!showPreHandoverOverlay) {
-      setPreHandoverMessageIndex(0);
+    logCollectionEvent('phase_entered', { phase: uiPhase, state });
+    return () => {
+      logCollectionEvent('phase_exited', { phase: uiPhase, state });
+    };
+  }, [logCollectionEvent, state, uiPhase]);
+
+  useEffect(() => {
+    if (!showTransitionOverlay) {
+      setOverlayMessageIndex(0);
+      overlayPhaseEnteredAtMsRef.current = null;
+      logCollectionEvent('overlay_hidden', { phase: uiPhase });
       return;
     }
+    overlayPhaseEnteredAtMsRef.current = Date.now();
+    logCollectionEvent('overlay_shown', { phase: uiPhase });
     const interval = window.setInterval(() => {
-      setPreHandoverMessageIndex((previous) => previous + 1);
-    }, 2200);
+      setOverlayMessageIndex((previous) => {
+        const next = previous + 1;
+        logCollectionEvent('joke_line_changed', { index: next % overlayLines.length, phase: uiPhase });
+        return next;
+      });
+    }, 3600);
     return () => window.clearInterval(interval);
-  }, [showPreHandoverOverlay]);
+  }, [logCollectionEvent, overlayLines.length, showTransitionOverlay, uiPhase]);
+
+  useEffect(() => {
+    if (!isNativeTapToPayOverlayVisiblePhase(state)) return;
+    const timeout = window.setTimeout(() => {
+      if (!isNativeTapToPayOverlayVisiblePhase(state)) return;
+      logCollectionEvent('watchdog_triggered', { phase: uiPhase, state });
+      setState('failed');
+      setMessage('Payment transition took too long. Please close and try again.');
+    }, 60000);
+    return () => window.clearTimeout(timeout);
+  }, [logCollectionEvent, state, uiPhase]);
 
   const classifyNativeFailure = useCallback((nativeResult: Awaited<ReturnType<typeof tapToPayBridge.startTapToPayPayment>>) => {
     const detail =
@@ -1275,9 +1326,38 @@ export default function InternalSettlementModule({
     };
   }, [logCollectionEvent, nativeRestaurantId]);
 
+  useEffect(() => {
+    if (state !== 'completed' || successRouteLock) return;
+    setSuccessRouteLock(true);
+    setShowSuccessTick(true);
+    logCollectionEvent('success_tick_shown', { entryPoint, restaurantId: nativeRestaurantId });
+    const timeout = window.setTimeout(() => {
+      setShowSuccessTick(false);
+      if (!nativeRestaurantId) return;
+      const target = `/pos/${nativeRestaurantId}?stage=paymentComplete&source=${entryPoint === 'pos' ? 'pos-contactless' : 'take-payment'}`;
+      logCollectionEvent('success_route_target_selected', { target, entryPoint });
+      router.push(target).catch(() => undefined);
+    }, 900);
+    return () => window.clearTimeout(timeout);
+  }, [entryPoint, logCollectionEvent, nativeRestaurantId, router, state, successRouteLock]);
+
+  useEffect(() => {
+    if (state === 'completed') return;
+    setShowSuccessTick(false);
+    setSuccessRouteLock(false);
+  }, [state]);
+
   const handleCancel = useCallback(async () => {
-    if (!activeSessionId) return;
+    if (cancelInFlight) return;
+    if (!activeSessionId) {
+      setState('canceled');
+      setMessage('Payment closed.');
+      logCollectionEvent('overlay_dismissed_reason', { reason: 'no_active_session' });
+      return;
+    }
+    setCancelInFlight(true);
     setBusy(true);
+    logCollectionEvent('cancel_requested', { sessionId: activeSessionId });
     try {
       await tapToPayBridge.cancelTapToPayPayment().catch(() => undefined);
       await fetch('/api/dashboard/internal-settlement/cancel', {
@@ -1291,8 +1371,8 @@ export default function InternalSettlementModule({
           flow_run_id: flowRunIdRef.current,
         }),
       });
-      logCollectionEvent('app_cancel_requested', { sessionId: activeSessionId });
-      setState('failed');
+      logCollectionEvent('cancel_succeeded', { sessionId: activeSessionId });
+      setState('canceled');
       quickChargeAttemptEndMsRef.current = Date.now();
       setMessage('Payment canceled.');
       setQuickChargeFailureSnapshot(null);
@@ -1303,21 +1383,28 @@ export default function InternalSettlementModule({
       setActiveTerminalLocationId(null);
       internalSettlementActiveRunStore.clear();
       await loadOrders();
+    } catch (error: any) {
+      logCollectionEvent('cancel_blocked_or_failed', { sessionId: activeSessionId, error: error?.message || 'unknown_error' });
+      setMessage('Unable to cancel right now. Please wait for the current payment phase.');
     } finally {
+      setCancelInFlight(false);
       setBusy(false);
       flowActiveRef.current = false;
       flowRunIdRef.current = null;
     }
-  }, [activeSessionId, loadOrders, logCollectionEvent]);
+  }, [activeSessionId, cancelInFlight, loadOrders, logCollectionEvent]);
 
   return (
     <section className="relative rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
       <NativeTapToPayPreHandoverOverlay
-        visible={showPreHandoverOverlay}
-        phaseLabel="Preparing payment mode"
-        title="Contactless payments"
-        message={message}
-        lineIndex={preHandoverMessageIndex}
+        visible={showTransitionOverlay}
+        lines={overlayLines}
+        lineIndex={overlayMessageIndex}
+        showSuccessTick={showSuccessTick}
+        canClose={canCloseOverlay}
+        onClose={() => {
+          void handleCancel();
+        }}
       />
       <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{eyebrow}</p>
       <h1 className="mt-2 text-2xl font-semibold tracking-tight text-slate-900 sm:text-3xl">{title}</h1>
@@ -1407,29 +1494,14 @@ export default function InternalSettlementModule({
         <div className="space-y-4 rounded-2xl border border-slate-200 p-4">
           <h2 className="text-sm font-semibold text-slate-900">Payment method</h2>
 
-          <div
-            className={`rounded-2xl border px-4 py-3 text-sm ${
-              state === 'completed'
-                ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
-                : state === 'failed' || state === 'permission_denied'
-                  ? 'border-rose-200 bg-rose-50 text-rose-700'
-                  : state === 'unsupported_device' || state === 'location_services_disabled' || state === 'setup_failed' || state === 'interrupted'
-                    ? 'border-amber-200 bg-amber-50 text-amber-700'
-                    : 'border-slate-200 bg-slate-50 text-slate-700'
-            }`}
-          >
-            <p className="font-semibold">Collection state: {uiPhase.replaceAll('_', ' ')}</p>
-            <p className="mt-1 text-xs">{message}</p>
+          <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700">
             {!tapAvailabilityLoading && !tapAvailabilityReady ? (
-              <p className="mt-2 text-xs text-amber-700">
-                Tap to Pay unavailable: {tapAvailabilityReason || 'Tap to Pay is not ready on this account/device.'}
-              </p>
+              <p className="text-xs text-amber-700">{tapAvailabilityReason || 'Tap to Pay is not ready on this account/device.'}</p>
             ) : null}
             {!nativeReadinessLoading && !nativeReadinessReady ? (
-              <p className="mt-2 text-xs text-amber-700">
-                Device setup required: {nativeReadinessReason || 'Location permission and location services are required.'}
-              </p>
+              <p className="mt-2 text-xs text-amber-700">{nativeReadinessReason || 'Location permission and location services are required.'}</p>
             ) : null}
+            {state === 'failed' || state === 'canceled' ? <p className="mt-2 text-xs text-rose-700">{message}</p> : null}
             {quickChargeAttemptDiagnosticsSerialized ? (
               <div
                 className={`mt-3 rounded-xl border bg-white/90 p-3 text-[11px] ${

--- a/components/payments/NativeTapToPayPreHandoverOverlay.tsx
+++ b/components/payments/NativeTapToPayPreHandoverOverlay.tsx
@@ -1,28 +1,28 @@
+import { CheckCircleIcon, XMarkIcon } from '@heroicons/react/24/solid';
 import { useMemo } from 'react';
 
 type NativeTapToPayPreHandoverOverlayProps = {
   visible: boolean;
-  title?: string;
-  message?: string;
-  phaseLabel?: string;
   lines?: string[];
   lineIndex?: number;
+  showSuccessTick?: boolean;
+  canClose?: boolean;
+  onClose?: () => void;
+  recoveryActionLabel?: string;
+  onRecoveryAction?: () => void;
 };
 
-const DEFAULT_LINES = [
-  'Activating contactless payments…',
-  'Preparing Tap to Pay…',
-  'Waking up the payment magic…',
-  'Getting ready for contactless…',
-];
+const DEFAULT_LINES = ['Preparing payment…'];
 
 export default function NativeTapToPayPreHandoverOverlay({
   visible,
-  title = 'Contactless payments',
-  message,
-  phaseLabel = 'Preparing payment mode',
   lines = DEFAULT_LINES,
   lineIndex = 0,
+  showSuccessTick = false,
+  canClose = false,
+  onClose,
+  recoveryActionLabel,
+  onRecoveryAction,
 }: NativeTapToPayPreHandoverOverlayProps) {
   const activeLine = useMemo(() => {
     if (!lines.length) return '';
@@ -33,13 +33,34 @@ export default function NativeTapToPayPreHandoverOverlay({
   if (!visible) return null;
 
   return (
-    <div className="fixed inset-0 z-[90] flex items-center justify-center bg-slate-500/45 px-4 py-6 backdrop-blur-[2px]">
-      <section className="w-full max-w-xl rounded-[2rem] border border-slate-200/70 bg-slate-100/95 p-7 text-center shadow-2xl sm:p-9">
-        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{phaseLabel}</p>
-        <div className="mx-auto mt-5 h-11 w-11 animate-spin rounded-full border-4 border-white/80 border-t-slate-600" />
-        <h2 className="mt-5 text-2xl font-semibold tracking-tight text-slate-900">{title}</h2>
-        <p className="mt-3 text-base font-medium text-slate-700">{message || activeLine}</p>
-      </section>
+    <div className="fixed inset-0 z-[120] flex items-center justify-center bg-slate-900/45 px-6 py-8 backdrop-blur-md">
+      {canClose ? (
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute right-5 top-5 rounded-full border border-white/40 bg-white/15 p-2 text-white transition hover:bg-white/25"
+          aria-label="Close payment transition"
+        >
+          <XMarkIcon className="h-5 w-5" />
+        </button>
+      ) : null}
+      <div className="flex flex-col items-center gap-5 text-center text-white">
+        {showSuccessTick ? (
+          <CheckCircleIcon className="h-16 w-16 text-emerald-300" />
+        ) : (
+          <div className="h-14 w-14 animate-spin rounded-full border-4 border-white/45 border-t-white" />
+        )}
+        <p className="text-base font-medium tracking-wide text-white/95">{showSuccessTick ? 'Payment confirmed' : activeLine}</p>
+        {recoveryActionLabel && onRecoveryAction ? (
+          <button
+            type="button"
+            onClick={onRecoveryAction}
+            className="rounded-full border border-white/40 bg-white/15 px-5 py-2 text-sm font-semibold text-white transition hover:bg-white/25"
+          >
+            {recoveryActionLabel}
+          </button>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/lib/payments/nativeTapToPayUiPhases.ts
+++ b/lib/payments/nativeTapToPayUiPhases.ts
@@ -1,27 +1,73 @@
-type NativePreHandoverPhase =
+export type NativeTapToPayUiPhase =
   | 'bootstrapping'
   | 'checking_readiness'
   | 'preparing_native'
   | 'handover_to_stripe'
   | 'stripe_live_payment'
-  | 'success'
-  | 'canceled'
-  | 'failed';
+  | 'processing_returned_result'
+  | 'verifying_paid_outcome'
+  | 'finalizing_session'
+  | 'completing_success_transition'
+  | 'success_destination'
+  | 'canceled_destination'
+  | 'failed_destination';
 
-export const resolveNativeTapToPayUiPhase = (state: string): NativePreHandoverPhase => {
+export const resolveNativeTapToPayUiPhase = (state: string): NativeTapToPayUiPhase => {
   if (state === 'bootstrapping') return 'checking_readiness';
   if (state === 'preparing') return 'preparing_native';
   if (state === 'handover') return 'handover_to_stripe';
-  if (state === 'collecting' || state === 'processing' || state === 'finalizing') return 'stripe_live_payment';
-  if (state === 'completed' || state === 'succeeded') return 'success';
-  if (state === 'canceled') return 'canceled';
-  if (state === 'failed' || state === 'permission_denied' || state === 'unsupported_device' || state === 'setup_failed' || state === 'location_services_disabled') {
-    return 'failed';
+  if (state === 'collecting') return 'stripe_live_payment';
+  if (state === 'processing') return 'processing_returned_result';
+  if (state === 'verifying') return 'verifying_paid_outcome';
+  if (state === 'finalizing') return 'finalizing_session';
+  if (state === 'completing_success') return 'completing_success_transition';
+  if (state === 'completed' || state === 'succeeded') return 'success_destination';
+  if (state === 'canceled') return 'canceled_destination';
+  if (
+    state === 'failed' ||
+    state === 'permission_denied' ||
+    state === 'unsupported_device' ||
+    state === 'setup_failed' ||
+    state === 'location_services_disabled'
+  ) {
+    return 'failed_destination';
   }
   return 'bootstrapping';
 };
 
-export const isNativeTapToPayPreHandoverPhase = (state: string) => {
+export const isNativeTapToPayOverlayVisiblePhase = (state: string) => {
   const phase = resolveNativeTapToPayUiPhase(state);
-  return phase === 'checking_readiness' || phase === 'preparing_native' || phase === 'handover_to_stripe';
+  return (
+    phase === 'checking_readiness' ||
+    phase === 'preparing_native' ||
+    phase === 'handover_to_stripe' ||
+    phase === 'processing_returned_result' ||
+    phase === 'verifying_paid_outcome' ||
+    phase === 'finalizing_session' ||
+    phase === 'completing_success_transition'
+  );
 };
+
+export const isNativeTapToPayTerminalPhase = (state: string) => {
+  const phase = resolveNativeTapToPayUiPhase(state);
+  return phase === 'success_destination' || phase === 'canceled_destination' || phase === 'failed_destination';
+};
+
+export const isNativeTapToPayCancelableOverlayPhase = (state: string) => {
+  const phase = resolveNativeTapToPayUiPhase(state);
+  return phase !== 'stripe_live_payment' && isNativeTapToPayOverlayVisiblePhase(state);
+};
+
+export const PRE_HANDOVER_PROGRESS_LINES = [
+  'Warming up the payment rails…',
+  'Calling in the tap-to-pay orchestra…',
+  'Polishing the card reader vibes…',
+  'Securing a smooth handoff to Stripe…',
+];
+
+export const POST_HANDOVER_PROGRESS_LINES = [
+  'Verifying the result with Stripe…',
+  'Locking in payment confirmation…',
+  'Wrapping up the final settlement steps…',
+  'Adding the final success sparkle…',
+];

--- a/pages/dashboard/take-payment.tsx
+++ b/pages/dashboard/take-payment.tsx
@@ -8,6 +8,7 @@ export default function DashboardTakePaymentPage() {
         <InternalSettlementModule
           eyebrow="Payments"
           title="Take Payment"
+          entryPoint="take_payment"
         />
       </div>
     </DashboardLayout>

--- a/pages/kiosk/[restaurantId]/payment-entry.tsx
+++ b/pages/kiosk/[restaurantId]/payment-entry.tsx
@@ -3,7 +3,6 @@ import { useRouter } from 'next/router';
 import {
   BanknotesIcon,
   BuildingStorefrontIcon,
-  CheckCircleIcon,
   CreditCardIcon,
   DevicePhoneMobileIcon,
   ExclamationTriangleIcon,
@@ -23,7 +22,13 @@ import type { KioskTerminalMode } from '@/lib/kiosk/terminalMode';
 import { setKioskLastRealOrderNumber } from '@/utils/kiosk/orders';
 import { requestPrintJobCreation } from '@/lib/print-jobs/request';
 import NativeTapToPayPreHandoverOverlay from '@/components/payments/NativeTapToPayPreHandoverOverlay';
-import { isNativeTapToPayPreHandoverPhase } from '@/lib/payments/nativeTapToPayUiPhases';
+import {
+  isNativeTapToPayCancelableOverlayPhase,
+  isNativeTapToPayOverlayVisiblePhase,
+  POST_HANDOVER_PROGRESS_LINES,
+  PRE_HANDOVER_PROGRESS_LINES,
+  resolveNativeTapToPayUiPhase,
+} from '@/lib/payments/nativeTapToPayUiPhases';
 
 type Restaurant = {
   id: string;
@@ -100,19 +105,6 @@ const OPERATOR_DEBUG_STORAGE_KEY = 'orderfast_kiosk_operator_debug';
 const KIOSK_CHECKOUT_CONTEXT_STORAGE_KEY = 'orderfast_kiosk_checkout_context';
 const OPERATOR_DEBUG_TAP_THRESHOLD = 7;
 const OPERATOR_DEBUG_TAP_WINDOW_MS = 8000;
-const PAYMENT_PREP_MESSAGES = [
-  'Loading up the payment magic...',
-  'Deliciousness secured... now time to secure the payment.',
-  'Waking up the card goblins...',
-  'Getting the tap ready...',
-  'One tiny beep away from greatness...',
-];
-const PAYMENT_COLLECT_MESSAGES = [
-  'Ready when you are — tap to pay.',
-  'One quick tap and we are done.',
-  'Phones, cards, watches — all welcome.',
-  'Tap now and we will fire your order.',
-];
 const STARTUP_TRACE_LABELS: Record<StartupTraceKey, string> = {
   availability: 'availability',
   session_create: 'session create',
@@ -226,7 +218,7 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
   const [autoSubmitAttemptedMethod, setAutoSubmitAttemptedMethod] = useState<'cash' | 'pay_at_counter' | 'contactless' | null>(null);
   const [suppressStageAutoSubmit, setSuppressStageAutoSubmit] = useState(false);
   const [prepMessageIndex, setPrepMessageIndex] = useState(0);
-  const [collectMessageIndex, setCollectMessageIndex] = useState(0);
+  const [successTickVisible, setSuccessTickVisible] = useState(false);
   const [terminalMode, setTerminalMode] = useState<KioskTerminalMode>('real_tap_to_pay');
   const isVerifiedPaidPayload = useCallback((verification: PaymentVerification | null | undefined) => {
     if (!verification || verification.verifiedPaid !== true) return false;
@@ -395,17 +387,16 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
   }, [CONTACTLESS_SESSION_STORAGE_KEY, stage]);
 
   useEffect(() => {
-    if (!orderSubmitting && !contactlessBusy && contactlessStatus !== 'preparing' && contactlessStatus !== 'collecting') {
+    const overlayVisible = isNativeTapToPayOverlayVisiblePhase(contactlessStatus) || successTickVisible;
+    if (!overlayVisible) {
       setPrepMessageIndex(0);
-      setCollectMessageIndex(0);
       return;
     }
     const interval = window.setInterval(() => {
-      setPrepMessageIndex((prev) => (prev + 1) % PAYMENT_PREP_MESSAGES.length);
-      setCollectMessageIndex((prev) => (prev + 1) % PAYMENT_COLLECT_MESSAGES.length);
-    }, 1800);
+      setPrepMessageIndex((prev) => prev + 1);
+    }, 3400);
     return () => window.clearInterval(interval);
-  }, [contactlessBusy, contactlessStatus, orderSubmitting]);
+  }, [contactlessStatus, successTickVisible]);
 
   const reconcileSession = useCallback(
     async (sessionId: string, reason: string) => {
@@ -1263,6 +1254,20 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
       ring: hexToRgba(primary, 0.28),
     };
   }, [restaurant?.brand_primary_color, restaurant?.brand_secondary_color]);
+  const contactlessUiPhase = useMemo(() => resolveNativeTapToPayUiPhase(contactlessStatus), [contactlessStatus]);
+  const showSharedTransitionOverlay = useMemo(
+    () => isNativeTapToPayOverlayVisiblePhase(contactlessStatus) || successTickVisible,
+    [contactlessStatus, successTickVisible]
+  );
+  const transitionLines = useMemo(
+    () =>
+      contactlessUiPhase === 'processing_returned_result' ||
+      contactlessUiPhase === 'verifying_paid_outcome' ||
+      contactlessUiPhase === 'finalizing_session'
+        ? POST_HANDOVER_PROGRESS_LINES
+        : PRE_HANDOVER_PROGRESS_LINES,
+    [contactlessUiPhase]
+  );
 
   useEffect(() => {
     const shouldLock =
@@ -1312,22 +1317,8 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
 
   useEffect(() => {
     if (stage !== 'contactless') return;
-    if (contactlessBusy) return;
-    if (contactlessStatus !== 'failed' && contactlessStatus !== 'canceled') return;
-    const timeout = window.setTimeout(() => {
-      returnToFallback(
-        contactlessStatus === 'canceled'
-          ? 'Payment cancelled'
-          : contactlessError || 'Contactless payment is unavailable right now. Please choose another payment method.'
-      );
-    }, 900);
-    return () => window.clearTimeout(timeout);
-  }, [contactlessBusy, contactlessError, contactlessStatus, returnToFallback, stage]);
-
-  useEffect(() => {
-    if (stage !== 'contactless') return;
     if (!contactlessSessionId || !restaurantId) return;
-    if (contactlessStatus !== 'processing' && contactlessStatus !== 'collecting') return;
+    if (!isNativeTapToPayOverlayVisiblePhase(contactlessStatus)) return;
 
     const watchdog = window.setTimeout(() => {
       void (async () => {
@@ -1335,7 +1326,7 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
         await reconcileSession(contactlessSessionId, 'watchdog');
         window.setTimeout(() => {
           setContactlessStatus((current) => {
-            if (current === 'processing' || current === 'collecting') {
+            if (isNativeTapToPayOverlayVisiblePhase(current)) {
               setContactlessError('Payment did not complete. Please choose another payment method and try again.');
               return 'failed';
             }
@@ -1363,8 +1354,15 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
 
   useEffect(() => {
     if (contactlessStatus !== 'succeeded' || orderSubmitting || autoSubmitAttemptedMethod === 'contactless') return;
-    setAutoSubmitAttemptedMethod('contactless');
-    void submitOrderAndRedirect('contactless');
+    setSuccessTickVisible(true);
+    const timeout = window.setTimeout(() => {
+      setAutoSubmitAttemptedMethod('contactless');
+      void submitOrderAndRedirect('contactless');
+    }, 900);
+    return () => {
+      window.clearTimeout(timeout);
+      setSuccessTickVisible(false);
+    };
   }, [autoSubmitAttemptedMethod, contactlessStatus, orderSubmitting, submitOrderAndRedirect]);
 
   useEffect(() => {
@@ -1485,39 +1483,19 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
   );
 
   const renderContactlessOverlay = () => (
-    <div
-      className="fixed inset-0 z-[75] flex items-center justify-center px-4 py-6 backdrop-blur-[3px] sm:px-6"
-      style={{
-        background: `linear-gradient(165deg, rgba(148, 163, 184, 0.42), ${hexToRgba(paymentTheme.primary, 0.2)} 55%, ${hexToRgba(paymentTheme.secondary, 0.18)})`,
-      }}
-    >
-      <section className="w-full max-w-3xl text-center">
-        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-600">Contactless payment</p>
-        <div className="mx-auto mt-4 h-12 w-12 animate-spin rounded-full border-4 border-white/70" style={{ borderTopColor: paymentTheme.primary }} />
+    <div className="rounded-[2rem] border border-slate-200 bg-white/95 p-6 shadow-xl">
+      <section className="text-center">
         <div
-          className="mx-auto mt-6 inline-flex h-16 w-16 items-center justify-center rounded-3xl shadow-lg"
+          className="mx-auto inline-flex h-14 w-14 items-center justify-center rounded-2xl text-white shadow-lg"
           style={{ background: `linear-gradient(135deg, ${paymentTheme.primary}, ${paymentTheme.secondary})` }}
           aria-hidden="true"
         >
-          <DevicePhoneMobileIcon className="h-9 w-9 text-white" />
+          <DevicePhoneMobileIcon className="h-7 w-7 text-white" />
         </div>
-        <p className="mt-5 text-xl font-semibold tracking-tight text-slate-900 sm:text-2xl">Contactless payment</p>
-        <p className="mx-auto mt-2 max-w-lg text-sm text-slate-700 sm:text-base">Complete the payment flow to place your order.</p>
-        {contactlessStatus === 'preparing' || contactlessStatus === 'idle' ? (
-          <p className="mt-5 text-base font-medium text-slate-800">{PAYMENT_PREP_MESSAGES[prepMessageIndex]}</p>
-        ) : null}
-        {contactlessStatus === 'collecting' ? (
-          <p className="mt-5 text-base font-medium text-slate-800">{PAYMENT_COLLECT_MESSAGES[collectMessageIndex]}</p>
-        ) : null}
-        {contactlessStatus === 'processing' ? <p className="mt-3 text-base font-medium text-amber-700">Finalizing payment result...</p> : null}
-        {contactlessStatus === 'succeeded' ? (
-          <p className="mt-4 flex items-center justify-center gap-2 text-base font-medium text-emerald-700">
-            <CheckCircleIcon className="h-5 w-5 shrink-0" />
-            Payment approved. Sending your order now...
-          </p>
-        ) : null}
+        <p className="mt-3 text-lg font-semibold text-slate-900">Tap when prompted on Stripe</p>
+        {contactlessStatus === 'collecting' ? <p className="mt-2 text-sm text-slate-600">Card/phone collection is active.</p> : null}
         {contactlessStatus === 'failed' || contactlessStatus === 'canceled' ? (
-          <p className="mx-auto mt-4 flex max-w-xl items-center justify-center gap-2 text-base font-medium text-rose-700">
+          <p className="mx-auto mt-4 flex max-w-xl items-center justify-center gap-2 text-sm font-medium text-rose-700">
             <ExclamationTriangleIcon className="h-5 w-5 shrink-0" />
             {contactlessStatus === 'canceled'
               ? 'Payment was canceled. Please choose a payment method to continue.'
@@ -1527,11 +1505,7 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
                   : 'Payment failed, please try again or choose another payment method.')}
           </p>
         ) : null}
-        {showOperatorDetails ? <p className="mt-2 text-[11px] font-medium uppercase tracking-[0.12em] text-slate-500">Debug: {contactlessDebug}</p> : null}
-        {showOperatorDetails && contactlessDebugDetail ? (
-          <p className="mt-1 text-xs font-medium text-slate-600">Detail: {contactlessDebugDetail}</p>
-        ) : null}
-        {showOperatorDetails ? (
+        {showOperatorDetails && (contactlessStatus === 'failed' || contactlessStatus === 'canceled') ? (
           <div className="mt-3 rounded-xl border border-slate-200 bg-slate-50 p-3">
             <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-500">Tap to Pay startup diagnostics</p>
             <p className="mt-1 text-xs text-slate-700">
@@ -1547,7 +1521,9 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
             </div>
           </div>
         ) : null}
-        <div className="mx-auto mt-7 grid max-w-md grid-cols-1 gap-3 sm:grid-cols-2">
+        {showOperatorDetails ? <p className="mt-2 text-[11px] font-medium uppercase tracking-[0.12em] text-slate-500">Debug: {contactlessDebug}</p> : null}
+        {showOperatorDetails && contactlessDebugDetail ? <p className="mt-1 text-xs font-medium text-slate-600">Detail: {contactlessDebugDetail}</p> : null}
+        <div className="mx-auto mt-6 grid max-w-md grid-cols-1 gap-3 sm:grid-cols-2">
           <button
             type="button"
             onClick={() => {
@@ -1684,11 +1660,14 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
           {!settingsLoading && stage === 'contactless' ? renderContactlessOverlay() : null}
           {!settingsLoading && stage === 'contactless' ? (
             <NativeTapToPayPreHandoverOverlay
-              visible={isNativeTapToPayPreHandoverPhase(contactlessStatus)}
-              phaseLabel="Preparing payment mode"
-              title="Contactless payments"
-              message={PAYMENT_PREP_MESSAGES[prepMessageIndex]}
+              visible={showSharedTransitionOverlay}
+              lines={transitionLines}
               lineIndex={prepMessageIndex}
+              showSuccessTick={successTickVisible}
+              canClose={isNativeTapToPayCancelableOverlayPhase(contactlessStatus) && !contactlessBusy}
+              onClose={() => {
+                void cancelTapToPay();
+              }}
             />
           ) : null}
           {!settingsLoading && orderSubmitting ? renderOrderSubmittingOverlay() : null}

--- a/pages/pos/[restaurantId]/index.tsx
+++ b/pages/pos/[restaurantId]/index.tsx
@@ -88,6 +88,7 @@ const orderTypeLabel: Record<OrderType, string> = {
 export default function PosHomePage() {
   const router = useRouter();
   const { restaurantId: routeParam } = router.query;
+  const stageParam = Array.isArray(router.query.stage) ? router.query.stage[0] : router.query.stage;
   const restaurantId = Array.isArray(routeParam) ? routeParam[0] : routeParam;
   const storageKey = useMemo(
     () => (restaurantId ? `orderfast_pos_cart_${restaurantId}` : null),
@@ -95,8 +96,13 @@ export default function PosHomePage() {
   );
 
   const [stage, setStage] = useState<'orderType' | 'deliveryDetails' | 'sell' | 'checkout' | 'paymentComplete'>(
-    'orderType'
+    stageParam === 'paymentComplete' ? 'paymentComplete' : 'orderType'
   );
+  useEffect(() => {
+    if (stageParam === 'paymentComplete') {
+      setStage('paymentComplete');
+    }
+  }, [stageParam]);
   const [orderType, setOrderType] = useState<OrderType | null>(null);
   const [deliveryDetails, setDeliveryDetails] = useState<DeliveryDetails>(emptyDeliveryDetails);
   const [orderNote, setOrderNote] = useState('');

--- a/pages/pos/[restaurantId]/payment-entry.tsx
+++ b/pages/pos/[restaurantId]/payment-entry.tsx
@@ -48,6 +48,7 @@ export default function PosPaymentEntryPage() {
           title="Take Payment"
           restaurantId={restaurantId || null}
           onFlowActivityChange={setFlowActive}
+          entryPoint="pos"
         />
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Stop layered/stacked transition UI and replace with one intentional, full‑screen app-owned overlay for native/contactless flows. 
- Make the post‑Stripe return/resolution feel premium and resilient while preserving the existing safety around canceled/failed payments. 
- Reuse existing POS receipt flow for Take Payment and keep kiosk order confirmation behavior unchanged.

### Description
- Introduced a single shared full‑screen overlay component `components/payments/NativeTapToPayPreHandoverOverlay.tsx` that shows a spinner, a subtle rotating progress line pool, an optional close/X (cancel‑first semantics), and a success tick state. 
- Expanded and clarified phase mapping in `lib/payments/nativeTapToPayUiPhases.ts` to separate app‑owned pre/post‑Stripe phases (overlay visible) from the Stripe‑owned live collection (overlay hidden), and added pre/post handover progress line pools. 
- Rewrote `components/payments/InternalSettlementModule.tsx` to use the shared overlay (removed duplicate inline/card render paths), added structured overlay/phase logging, a watchdog that recovers app‑owned stuck phases, idempotent cancel handling with cancel‑in‑flight protection, and a spinner→tick success beat that holds briefly before routing to the correct destination. 
- Updated Kiosk and POS flows to use the shared overlay: kiosk `pages/kiosk/[restaurantId]/payment-entry.tsx` now uses the overlay for app‑owned phases and shows a brief success tick before submitting/continuing; POS and Take Payment (dashboard) now pass an `entryPoint` so `InternalSettlementModule` routes success into the existing POS receipt options (`/pos/:restaurantId?stage=paymentComplete`) rather than creating a new receipt screen. 
- Kept existing payment safety: canceled/failed native flows are still prevented from placing orders or finalizing as paid, server verification/finalize boundaries unchanged, and session cleanup preserved.

### Testing
- Ran TypeScript check with `npx tsc --noEmit`, which completed successfully with no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e00d07d740832582b143d5fc9cf5a2)