### PR TITLE
fix(payments): stabilize pre-Stripe overlay ownership and restore kiosk exit affordance

### DIFF
--- a/components/payments/InternalSettlementModule.tsx
+++ b/components/payments/InternalSettlementModule.tsx
@@ -326,11 +326,14 @@ export default function InternalSettlementModule({
   }, []);
 
   const refreshNativeReadiness = useCallback(
-    async (promptIfNeeded: boolean) => {
+    async (promptIfNeeded: boolean, options?: { suppressStateUpdates?: boolean }) => {
+      const suppressStateUpdates = options?.suppressStateUpdates === true;
       if (!nativeRestaurantId) {
         setNativeReadinessReady(false);
         setNativeReadinessReason('Restaurant context is missing. Return to launcher and open Take Payment again.');
-        setState('failed');
+        if (!suppressStateUpdates) {
+          setState('failed');
+        }
         return null;
       }
 
@@ -340,18 +343,24 @@ export default function InternalSettlementModule({
         if (!readiness.supported || !readiness.ready) {
           setNativeReadinessReady(false);
           setNativeReadinessReason(readiness.reason);
-          applyBootstrapState(readiness);
+          if (!suppressStateUpdates) {
+            applyBootstrapState(readiness);
+          }
           return readiness;
         }
         setNativeReadinessReady(true);
         setNativeReadinessReason('');
-        setState('ready');
+        if (!suppressStateUpdates) {
+          setState('ready');
+        }
         return readiness;
       } catch (error: any) {
         const reason = error?.message || 'Tap to Pay setup check failed.';
         setNativeReadinessReady(false);
         setNativeReadinessReason(reason);
-        setState('failed');
+        if (!suppressStateUpdates) {
+          setState('failed');
+        }
         return null;
       } finally {
         setNativeReadinessLoading(false);
@@ -437,14 +446,24 @@ export default function InternalSettlementModule({
       cancelBarrierRef.current = null;
       setPreHandoverOverlayOwned(true);
       logCollectionEvent('handover_owner_established', { flowRunId, reason });
+      logCollectionEvent('take_payment_overlay_owner_established', { flowRunId, reason });
     },
     [logCollectionEvent]
   );
 
   const releaseHandoverOwner = useCallback(
     (reason: string) => {
-      if (handoverOwnerRef.current) {
-        logCollectionEvent('handover_owner_released', { flowRunId: handoverOwnerRef.current.flowRunId, reason });
+      const owner = handoverOwnerRef.current;
+      if (owner) {
+        logCollectionEvent('handover_owner_released', { flowRunId: owner.flowRunId, reason });
+        logCollectionEvent('take_payment_overlay_owner_released', { flowRunId: owner.flowRunId, reason });
+        if (reason.includes('stripe_handover') || reason.includes('verified_finalized') || reason === 'completed') {
+          logCollectionEvent('owner_released_due_to_stripe_takeover', { flowRunId: owner.flowRunId, reason });
+        } else if (reason.includes('cancel')) {
+          logCollectionEvent('owner_released_due_to_cancel', { flowRunId: owner.flowRunId, reason });
+        } else {
+          logCollectionEvent('owner_released_due_to_failure', { flowRunId: owner.flowRunId, reason });
+        }
       }
       handoverOwnerRef.current = null;
       setPreHandoverOverlayOwned(false);
@@ -508,6 +527,7 @@ export default function InternalSettlementModule({
       logCollectionEvent('overlay_hidden', { phase: uiPhase });
       if (preHandoverOverlayOwned) {
         logCollectionEvent('overlay_hidden_while_handover_active', { phase: uiPhase, state });
+        logCollectionEvent('take_payment_overlay_hidden_while_handover_active', { phase: uiPhase, state });
       }
       return;
     }
@@ -546,12 +566,21 @@ export default function InternalSettlementModule({
         state,
         flowRunId: handoverOwnerRef.current.flowRunId,
       });
+      logCollectionEvent('take_payment_payment_options_revealed_while_handover_active', {
+        state,
+        flowRunId: handoverOwnerRef.current.flowRunId,
+      });
     }
   }, [logCollectionEvent, state]);
 
   useEffect(() => {
     if (!showTransitionOverlay || !preHandoverOverlayOwned) return;
     logCollectionEvent('duplicate_prehandover_render_attempt', {
+      state,
+      phase: uiPhase,
+      flowRunId: handoverOwnerRef.current?.flowRunId || null,
+    });
+    logCollectionEvent('take_payment_duplicate_prehandover_render_attempt', {
       state,
       phase: uiPhase,
       flowRunId: handoverOwnerRef.current?.flowRunId || null,
@@ -691,7 +720,7 @@ export default function InternalSettlementModule({
         terminalLocationId: readinessPayload?.terminal_location_id || null,
       });
 
-      const nativeReadiness = await refreshNativeReadiness(false);
+      const nativeReadiness = await refreshNativeReadiness(false, { suppressStateUpdates: true });
       if (!nativeReadiness || !nativeReadiness.supported || !nativeReadiness.ready) {
         setState('failed');
         setMessage(nativeReadiness?.reason || 'Tap to Pay setup is incomplete on this device.');
@@ -824,6 +853,7 @@ export default function InternalSettlementModule({
         return;
       }
 
+      logCollectionEvent('stripe_takeover_started', { sessionId, flowRunId });
       let nativeResult = await tapToPayBridge.startTapToPayPayment({
         restaurantId: nativeRestaurantId,
         sessionId,

--- a/pages/kiosk/[restaurantId]/payment-entry.tsx
+++ b/pages/kiosk/[restaurantId]/payment-entry.tsx
@@ -1479,6 +1479,14 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
         preHandoverOverlayOwned),
     [contactlessStatus, contactlessTerminalState, preHandoverOverlayOwned, stage, successTickVisible]
   );
+  const canCloseSharedTransitionOverlay = useMemo(
+    () =>
+      stage === 'contactless' &&
+      !contactlessBusy &&
+      contactlessStatus !== 'collecting' &&
+      (preHandoverOverlayOwned || isNativeTapToPayCancelableOverlayPhase(contactlessStatus)),
+    [contactlessBusy, contactlessStatus, preHandoverOverlayOwned, stage]
+  );
   const transitionLines = useMemo(
     () =>
       contactlessUiPhase === 'processing_returned_result' ||
@@ -1558,6 +1566,16 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
       status: contactlessStatus,
     });
   }, [contactlessStatus, contactlessUiPhase, logContactlessState, showSharedTransitionOverlay, stage]);
+
+  useEffect(() => {
+    if (stage !== 'contactless') return;
+    if (!showSharedTransitionOverlay) return;
+    if (!canCloseSharedTransitionOverlay) return;
+    logContactlessState('kiosk_exit_cross_rendered', {
+      phase: contactlessUiPhase,
+      status: contactlessStatus,
+    });
+  }, [canCloseSharedTransitionOverlay, contactlessStatus, contactlessUiPhase, logContactlessState, showSharedTransitionOverlay, stage]);
 
   useEffect(() => {
     if (stage !== 'contactless') return;
@@ -1683,6 +1701,7 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
     setContactlessBusy(true);
     setContactlessDebug('canceling');
     logContactlessState('exit_cross_clicked', { sessionId: contactlessSessionId });
+    logContactlessState('kiosk_exit_cross_clicked', { sessionId: contactlessSessionId });
     if (contactlessOwnerRef.current?.active) {
       contactlessOwnerRef.current = { ...contactlessOwnerRef.current, active: false, cancelRequested: true };
       logContactlessState('cancel_barrier_set', { ownerId: contactlessOwnerRef.current.id, sessionId: contactlessSessionId });
@@ -1903,7 +1922,7 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
               lines={transitionLines}
               lineIndex={prepMessageIndex}
               showSuccessTick={successTickVisible}
-              canClose={isNativeTapToPayCancelableOverlayPhase(contactlessStatus) && !contactlessBusy}
+              canClose={canCloseSharedTransitionOverlay}
               onClose={() => {
                 void cancelTapToPay().then(() => returnToFallback('Payment cancelled'));
               }}


### PR DESCRIPTION
### Motivation
- Prevent the pre-Stripe overlay from flickering on Take Payment by making the pre-handover ownership and readiness checks non-destructive to an active run, and restore the missing visible kiosk exit/cancel affordance during app-controlled pre-handover phases.
- Keep the working Stripe Tap to Pay execution boundary and cancel barrier semantics intact while tightening ownership/logging so canceled or stale runs remain suppressed.

### Description
- Add an optional `suppressStateUpdates` flag to `refreshNativeReadiness` and use it during an active pre-handover attempt so readiness checks no longer force `ready`/other state transitions mid-run, preventing the overlay from briefly unmounting (changes in `components/payments/InternalSettlementModule.tsx`).
- Harden pre-handover ownership lifecycle by emitting explicit owner events and reason-tagged release signals, and add `stripe_takeover_started` just before invoking the native `startTapToPayPayment` call (changes in `components/payments/InternalSettlementModule.tsx`).
- Restore kiosk exit affordance by computing `canCloseSharedTransitionOverlay` and passing it to the shared `NativeTapToPayPreHandoverOverlay`, and log `kiosk_exit_cross_rendered` and `kiosk_exit_cross_clicked` so the kiosk overlay shows a visible exit cross during app-controlled pre-handover phases but not during Stripe-owned live collection (changes in `pages/kiosk/[restaurantId]/payment-entry.tsx`).
- Keep existing cancel-barrier behavior and stale/late-callback suppression paths unchanged, only stabilizing ownership and logging around them to avoid regressions.

### Testing
- Ran typecheck: `npx tsc --noEmit` and it passed successfully.
- Reviewed changed flows and logging to ensure cancel barrier and stale callback suppression paths remain intact; no automated unit tests were modified or required for this focused UX/state pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e28c4701f48325b73ede41684e0642)