### PR TITLE
fix(payments): unify pre-Stripe overlay ownership and terminal cancel handling

### DIFF
--- a/components/payments/InternalSettlementModule.tsx
+++ b/components/payments/InternalSettlementModule.tsx
@@ -8,7 +8,7 @@ import { internalSettlementActiveRunStore } from '@/lib/payments/internalSettlem
 import { buildCombinedTapToPayDiagnosticsPayload } from '@/lib/payments/tapToPayDiagnostics';
 import NativeTapToPayPreHandoverOverlay from '@/components/payments/NativeTapToPayPreHandoverOverlay';
 import {
-  isNativeTapToPayCancelableOverlayPhase,
+  canCloseNativeTapToPayPreHandoverOverlay,
   isNativeTapToPayOverlayVisiblePhase,
   POST_HANDOVER_PROGRESS_LINES,
   PRE_HANDOVER_PROGRESS_LINES,
@@ -164,12 +164,14 @@ export default function InternalSettlementModule({
   const [overlayMessageIndex, setOverlayMessageIndex] = useState(0);
   const [cancelInFlight, setCancelInFlight] = useState(false);
   const [showSuccessTick, setShowSuccessTick] = useState(false);
+  const [terminalVisualState, setTerminalVisualState] = useState<'success' | 'canceled' | 'failed' | null>(null);
   const [preHandoverOverlayOwned, setPreHandoverOverlayOwned] = useState(false);
   const successRouteCommittedRef = useRef(false);
   const flowActiveRef = useRef(false);
   const flowRunIdRef = useRef<string | null>(null);
   const handoverOwnerRef = useRef<{ flowRunId: string; active: boolean; cancelRequested: boolean } | null>(null);
   const cancelBarrierRef = useRef<{ flowRunId: string; requestedAt: number } | null>(null);
+  const suppressRecoveryRef = useRef<{ reason: 'canceled' | 'failed'; at: number } | null>(null);
   const overlayPhaseEnteredAtMsRef = useRef<number | null>(null);
   const quickChargeAttemptStartMsRef = useRef<number | null>(null);
   const quickChargeAttemptEndMsRef = useRef<number | null>(null);
@@ -180,12 +182,23 @@ export default function InternalSettlementModule({
   const selectedOrder = useMemo(() => orders.find((order) => order.id === selectedOrderId) || null, [orders, selectedOrderId]);
   const uiPhase = useMemo(() => resolveNativeTapToPayUiPhase(state), [state]);
   const showTransitionOverlay = useMemo(
-    () => isNativeTapToPayOverlayVisiblePhase(state) || showSuccessTick || preHandoverOverlayOwned,
-    [preHandoverOverlayOwned, showSuccessTick, state]
+    () =>
+      isNativeTapToPayOverlayVisiblePhase(state) ||
+      showSuccessTick ||
+      preHandoverOverlayOwned ||
+      terminalVisualState === 'canceled' ||
+      terminalVisualState === 'failed',
+    [preHandoverOverlayOwned, showSuccessTick, state, terminalVisualState]
   );
   const canCloseOverlay = useMemo(
-    () => isNativeTapToPayCancelableOverlayPhase(state) && !cancelInFlight && !showSuccessTick,
-    [cancelInFlight, showSuccessTick, state]
+    () =>
+      canCloseNativeTapToPayPreHandoverOverlay({
+        state,
+        inCancelTransition: cancelInFlight,
+        inSuccessTransition: showSuccessTick || terminalVisualState === 'canceled' || terminalVisualState === 'failed',
+        preHandoverOverlayOwned,
+      }),
+    [cancelInFlight, preHandoverOverlayOwned, showSuccessTick, state, terminalVisualState]
   );
   const overlayLines = useMemo(
     () =>
@@ -442,6 +455,14 @@ export default function InternalSettlementModule({
 
   const establishHandoverOwner = useCallback(
     (flowRunId: string, reason: string) => {
+      if (suppressRecoveryRef.current) {
+        logCollectionEvent('owner_recreated_after_terminal_cancel', {
+          flowRunId,
+          reason,
+          priorTerminalReason: suppressRecoveryRef.current.reason,
+          priorTerminalAt: suppressRecoveryRef.current.at,
+        });
+      }
       handoverOwnerRef.current = { flowRunId, active: true, cancelRequested: false };
       cancelBarrierRef.current = null;
       setPreHandoverOverlayOwned(true);
@@ -533,6 +554,13 @@ export default function InternalSettlementModule({
     }
     overlayPhaseEnteredAtMsRef.current = Date.now();
     logCollectionEvent('overlay_shown', { phase: uiPhase });
+    if (suppressRecoveryRef.current) {
+      logCollectionEvent('overlay_shown_after_terminal_cancel', {
+        phase: uiPhase,
+        terminalReason: suppressRecoveryRef.current.reason,
+        terminalAt: suppressRecoveryRef.current.at,
+      });
+    }
     const interval = window.setInterval(() => {
       setOverlayMessageIndex((previous) => {
         const next = previous + 1;
@@ -561,6 +589,12 @@ export default function InternalSettlementModule({
   }, [releaseHandoverOwner, state]);
 
   useEffect(() => {
+    if (state !== 'canceled' && state !== 'failed') return;
+    suppressRecoveryRef.current = { reason: state, at: Date.now() };
+    logCollectionEvent('cancel_terminal_committed', { reason: state });
+  }, [logCollectionEvent, state]);
+
+  useEffect(() => {
     if ((state === 'idle' || state === 'ready') && handoverOwnerRef.current?.active) {
       logCollectionEvent('payment_options_revealed_while_handover_active', {
         state,
@@ -586,6 +620,19 @@ export default function InternalSettlementModule({
       flowRunId: handoverOwnerRef.current?.flowRunId || null,
     });
   }, [logCollectionEvent, preHandoverOverlayOwned, showTransitionOverlay, state, uiPhase]);
+
+  useEffect(() => {
+    if (!showTransitionOverlay) return;
+    logCollectionEvent('close_affordance_eligibility_evaluated', {
+      entryPoint,
+      phase: uiPhase,
+      canCloseOverlay,
+      preHandoverOverlayOwned,
+      cancelInFlight,
+      showSuccessTick,
+      terminalVisualState,
+    });
+  }, [cancelInFlight, canCloseOverlay, entryPoint, logCollectionEvent, preHandoverOverlayOwned, showSuccessTick, showTransitionOverlay, terminalVisualState, uiPhase]);
 
   const classifyNativeFailure = useCallback((nativeResult: Awaited<ReturnType<typeof tapToPayBridge.startTapToPayPayment>>) => {
     const detail =
@@ -631,6 +678,7 @@ export default function InternalSettlementModule({
 
   const handleCollectContactless = useCallback(async () => {
     if (busy) return;
+    suppressRecoveryRef.current = null;
     setQuickChargeFailureSnapshot(null);
     setQuickChargeSuccessSnapshot(null);
     setQuickChargeRawNativePayload(null);
@@ -1401,6 +1449,14 @@ export default function InternalSettlementModule({
   useEffect(() => {
     if (!nativeRestaurantId) return;
     const recover = async (source: 'mount' | 'resume') => {
+      if (suppressRecoveryRef.current) {
+        logCollectionEvent('overlay_recovery_blocked_after_terminal_cancel', {
+          source,
+          reason: suppressRecoveryRef.current.reason,
+          suppressedAt: suppressRecoveryRef.current.at,
+        });
+        return;
+      }
       if (source === 'resume' && flowActiveRef.current) {
         logCollectionEvent('app_resume_recovery_skipped_local_active_run', { source });
         return;
@@ -1466,6 +1522,7 @@ export default function InternalSettlementModule({
     if (state !== 'completed' || successRouteCommittedRef.current) return;
     successRouteCommittedRef.current = true;
     setShowSuccessTick(true);
+    setTerminalVisualState('success');
     logCollectionEvent('terminal_route_selected', {
       terminalType: 'success',
       entryPoint,
@@ -1477,6 +1534,7 @@ export default function InternalSettlementModule({
         : null;
       logCollectionEvent('success_tick_shown', { entryPoint, restaurantId: nativeRestaurantId, target });
       setShowSuccessTick(false);
+      setTerminalVisualState(null);
       if (!target) {
         logCollectionEvent('terminal_route_committed', {
           terminalType: 'success',
@@ -1496,8 +1554,33 @@ export default function InternalSettlementModule({
   useEffect(() => {
     if (state === 'completed') return;
     setShowSuccessTick(false);
+    if (terminalVisualState === 'success') {
+      setTerminalVisualState(null);
+    }
     successRouteCommittedRef.current = false;
-  }, [state]);
+  }, [state, terminalVisualState]);
+
+  useEffect(() => {
+    if (state !== 'canceled' && state !== 'failed') return;
+    const visualState = state === 'canceled' ? 'canceled' : 'failed';
+    setTerminalVisualState(visualState);
+    logCollectionEvent('terminal_route_selected', {
+      terminalType: visualState,
+      entryPoint,
+      restaurantId: nativeRestaurantId,
+    });
+    const timeout = window.setTimeout(() => {
+      logCollectionEvent('terminal_route_committed', {
+        terminalType: visualState,
+        entryPoint,
+        route: 'stay_on_take_payment_reset_to_ready',
+      });
+      setTerminalVisualState(null);
+      setState('idle');
+      setMessage('Ready to collect payment.');
+    }, 900);
+    return () => window.clearTimeout(timeout);
+  }, [entryPoint, logCollectionEvent, nativeRestaurantId, state]);
 
   const handleCancel = useCallback(async () => {
     if (cancelInFlight) return;
@@ -1577,6 +1660,7 @@ export default function InternalSettlementModule({
         lines={overlayLines}
         lineIndex={overlayMessageIndex}
         showSuccessTick={showSuccessTick}
+        terminalState={terminalVisualState}
         canClose={canCloseOverlay}
         onClose={() => {
           void handleCancel();

--- a/components/payments/NativeTapToPayPreHandoverOverlay.tsx
+++ b/components/payments/NativeTapToPayPreHandoverOverlay.tsx
@@ -1,4 +1,4 @@
-import { CheckCircleIcon, XMarkIcon } from '@heroicons/react/24/solid';
+import { CheckCircleIcon, ExclamationTriangleIcon, XCircleIcon, XMarkIcon } from '@heroicons/react/24/solid';
 import { useMemo } from 'react';
 
 type NativeTapToPayPreHandoverOverlayProps = {
@@ -8,6 +8,7 @@ type NativeTapToPayPreHandoverOverlayProps = {
   showSuccessTick?: boolean;
   canClose?: boolean;
   onClose?: () => void;
+  terminalState?: 'success' | 'canceled' | 'failed' | null;
   recoveryActionLabel?: string;
   onRecoveryAction?: () => void;
 };
@@ -21,6 +22,7 @@ export default function NativeTapToPayPreHandoverOverlay({
   showSuccessTick = false,
   canClose = false,
   onClose,
+  terminalState = null,
   recoveryActionLabel,
   onRecoveryAction,
 }: NativeTapToPayPreHandoverOverlayProps) {
@@ -31,6 +33,16 @@ export default function NativeTapToPayPreHandoverOverlay({
   }, [lineIndex, lines]);
 
   if (!visible) return null;
+
+  const activeTerminalState = terminalState || (showSuccessTick ? 'success' : null);
+  const statusCopy =
+    activeTerminalState === 'success'
+      ? 'Payment confirmed'
+      : activeTerminalState === 'canceled'
+        ? 'Payment canceled'
+        : activeTerminalState === 'failed'
+          ? 'Payment failed'
+          : activeLine;
 
   return (
     <div className="fixed inset-0 z-[120] flex items-center justify-center bg-slate-900/45 px-6 py-8 backdrop-blur-md">
@@ -45,12 +57,16 @@ export default function NativeTapToPayPreHandoverOverlay({
         </button>
       ) : null}
       <div className="flex flex-col items-center gap-5 text-center text-white">
-        {showSuccessTick ? (
+        {activeTerminalState === 'success' ? (
           <CheckCircleIcon className="h-16 w-16 text-emerald-300" />
+        ) : activeTerminalState === 'canceled' ? (
+          <XCircleIcon className="h-16 w-16 text-amber-300" />
+        ) : activeTerminalState === 'failed' ? (
+          <ExclamationTriangleIcon className="h-16 w-16 text-rose-300" />
         ) : (
           <div className="h-14 w-14 animate-spin rounded-full border-4 border-white/45 border-t-white" />
         )}
-        <p className="text-base font-medium tracking-wide text-white/95">{showSuccessTick ? 'Payment confirmed' : activeLine}</p>
+        <p className="text-base font-medium tracking-wide text-white/95">{statusCopy}</p>
         {recoveryActionLabel && onRecoveryAction ? (
           <button
             type="button"

--- a/lib/payments/nativeTapToPayUiPhases.ts
+++ b/lib/payments/nativeTapToPayUiPhases.ts
@@ -58,6 +58,22 @@ export const isNativeTapToPayCancelableOverlayPhase = (state: string) => {
   return phase !== 'stripe_live_payment' && isNativeTapToPayOverlayVisiblePhase(state);
 };
 
+export const canCloseNativeTapToPayPreHandoverOverlay = ({
+  state,
+  inCancelTransition = false,
+  inSuccessTransition = false,
+  preHandoverOverlayOwned = false,
+}: {
+  state: string;
+  inCancelTransition?: boolean;
+  inSuccessTransition?: boolean;
+  preHandoverOverlayOwned?: boolean;
+}) => {
+  if (inCancelTransition || inSuccessTransition) return false;
+  if (preHandoverOverlayOwned) return true;
+  return isNativeTapToPayCancelableOverlayPhase(state);
+};
+
 export const PRE_HANDOVER_PROGRESS_LINES = [
   'Warming up the payment rails…',
   'Calling in the tap-to-pay orchestra…',

--- a/pages/kiosk/[restaurantId]/payment-entry.tsx
+++ b/pages/kiosk/[restaurantId]/payment-entry.tsx
@@ -21,7 +21,7 @@ import { setKioskLastRealOrderNumber } from '@/utils/kiosk/orders';
 import { requestPrintJobCreation } from '@/lib/print-jobs/request';
 import NativeTapToPayPreHandoverOverlay from '@/components/payments/NativeTapToPayPreHandoverOverlay';
 import {
-  isNativeTapToPayCancelableOverlayPhase,
+  canCloseNativeTapToPayPreHandoverOverlay,
   isNativeTapToPayOverlayVisiblePhase,
   POST_HANDOVER_PROGRESS_LINES,
   PRE_HANDOVER_PROGRESS_LINES,
@@ -218,6 +218,7 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
   const [suppressStageAutoSubmit, setSuppressStageAutoSubmit] = useState(false);
   const [prepMessageIndex, setPrepMessageIndex] = useState(0);
   const [successTickVisible, setSuccessTickVisible] = useState(false);
+  const [terminalVisualState, setTerminalVisualState] = useState<'success' | 'canceled' | 'failed' | null>(null);
   const [terminalMode, setTerminalMode] = useState<KioskTerminalMode>('real_tap_to_pay');
   const [contactlessTerminalState, setContactlessTerminalState] = useState<ContactlessTerminalState>('idle');
   const [preHandoverOverlayOwned, setPreHandoverOverlayOwned] = useState(false);
@@ -229,6 +230,7 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
   const flowLockRef = useRef(false);
   const orderSubmitLockRef = useRef(false);
   const cancelLockRef = useRef(false);
+  const terminalTransitionLockRef = useRef(false);
   const contactlessOwnerRef = useRef<{ id: string; active: boolean; cancelRequested: boolean } | null>(null);
   const contactlessTerminalRouteCommittedRef = useRef(false);
   const contactlessOverlayVisibleRef = useRef(false);
@@ -1475,17 +1477,23 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
       stage === 'contactless' &&
       (isNativeTapToPayOverlayVisiblePhase(contactlessStatus) ||
         successTickVisible ||
+        terminalVisualState === 'canceled' ||
+        terminalVisualState === 'failed' ||
         contactlessTerminalState === 'in_progress' ||
         preHandoverOverlayOwned),
-    [contactlessStatus, contactlessTerminalState, preHandoverOverlayOwned, stage, successTickVisible]
+    [contactlessStatus, contactlessTerminalState, preHandoverOverlayOwned, stage, successTickVisible, terminalVisualState]
   );
   const canCloseSharedTransitionOverlay = useMemo(
-    () =>
-      stage === 'contactless' &&
-      !contactlessBusy &&
-      contactlessStatus !== 'collecting' &&
-      (preHandoverOverlayOwned || isNativeTapToPayCancelableOverlayPhase(contactlessStatus)),
-    [contactlessBusy, contactlessStatus, preHandoverOverlayOwned, stage]
+    () => {
+      if (stage !== 'contactless') return false;
+      return canCloseNativeTapToPayPreHandoverOverlay({
+        state: contactlessStatus,
+        inCancelTransition: cancelLockRef.current,
+        inSuccessTransition: successTickVisible || terminalVisualState === 'canceled' || terminalVisualState === 'failed',
+        preHandoverOverlayOwned,
+      });
+    },
+    [contactlessStatus, preHandoverOverlayOwned, stage, successTickVisible, terminalVisualState]
   );
   const transitionLines = useMemo(
     () =>
@@ -1570,6 +1578,29 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
   useEffect(() => {
     if (stage !== 'contactless') return;
     if (!showSharedTransitionOverlay) return;
+    logContactlessState('close_affordance_eligibility_evaluated', {
+      canCloseSharedTransitionOverlay,
+      phase: contactlessUiPhase,
+      status: contactlessStatus,
+      preHandoverOverlayOwned,
+      contactlessBusy,
+      terminalVisualState,
+    });
+  }, [
+    canCloseSharedTransitionOverlay,
+    contactlessBusy,
+    contactlessStatus,
+    contactlessUiPhase,
+    logContactlessState,
+    preHandoverOverlayOwned,
+    showSharedTransitionOverlay,
+    stage,
+    terminalVisualState,
+  ]);
+
+  useEffect(() => {
+    if (stage !== 'contactless') return;
+    if (!showSharedTransitionOverlay) return;
     if (!canCloseSharedTransitionOverlay) return;
     logContactlessState('kiosk_exit_cross_rendered', {
       phase: contactlessUiPhase,
@@ -1628,6 +1659,7 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
     contactlessTerminalRouteCommittedRef.current = true;
     logContactlessState('kiosk_terminal_route_selected', { terminalType: 'success', destination: 'order_confirmation' });
     setSuccessTickVisible(true);
+    setTerminalVisualState('success');
     const timeout = window.setTimeout(() => {
       setAutoSubmitAttemptedMethod('contactless');
       logContactlessState('kiosk_terminal_route_committed', { terminalType: 'success', destination: 'order_confirmation' });
@@ -1636,6 +1668,7 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
     return () => {
       window.clearTimeout(timeout);
       setSuccessTickVisible(false);
+      setTerminalVisualState(null);
     };
   }, [autoSubmitAttemptedMethod, contactlessStatus, contactlessTerminalState, logContactlessState, orderSubmitting, submitOrderAndRedirect]);
 
@@ -1648,14 +1681,27 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
     if (stage !== 'contactless') return;
     if (contactlessBusy) return;
     if (contactlessStatus !== 'failed' && contactlessStatus !== 'canceled') return;
-    const message =
-      contactlessStatus === 'canceled'
-        ? 'Payment cancelled'
-        : contactlessUnsupportedDevice
-          ? 'This kiosk device does not support Tap to Pay on this hardware. Please use another payment method.'
-          : contactlessError || 'Payment failed, please try again or choose another payment method.';
-    returnToFallback(message);
-  }, [contactlessBusy, contactlessError, contactlessStatus, contactlessUnsupportedDevice, returnToFallback, stage]);
+    if (terminalTransitionLockRef.current) return;
+    terminalTransitionLockRef.current = true;
+    const visual = contactlessStatus === 'canceled' ? 'canceled' : 'failed';
+    setTerminalVisualState(visual);
+    logContactlessState('terminal_visual_state_selected', { terminalType: visual, stage });
+    const timeout = window.setTimeout(() => {
+      const message =
+        contactlessStatus === 'canceled'
+          ? 'Payment cancelled'
+          : contactlessUnsupportedDevice
+            ? 'This kiosk device does not support Tap to Pay on this hardware. Please use another payment method.'
+            : contactlessError || 'Payment failed, please try again or choose another payment method.';
+      setTerminalVisualState(null);
+      terminalTransitionLockRef.current = false;
+      returnToFallback(message);
+    }, 900);
+    return () => {
+      window.clearTimeout(timeout);
+      terminalTransitionLockRef.current = false;
+    };
+  }, [contactlessBusy, contactlessError, contactlessStatus, contactlessUnsupportedDevice, logContactlessState, returnToFallback, stage]);
 
   useEffect(() => {
     if (stage !== 'contactless' || !restaurantId) return;
@@ -1924,8 +1970,9 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
               showSuccessTick={successTickVisible}
               canClose={canCloseSharedTransitionOverlay}
               onClose={() => {
-                void cancelTapToPay().then(() => returnToFallback('Payment cancelled'));
+                void cancelTapToPay();
               }}
+              terminalState={terminalVisualState}
             />
           ) : null}
           {!settingsLoading && orderSubmitting ? renderOrderSubmittingOverlay() : null}


### PR DESCRIPTION
### Motivation

- Prevent canceled pre-Stripe runs from being resurrected by late recovery/owner reattachment and stop dead loading overlays after user-cancel.  
- Ensure kiosk and Take Payment actually share the same pre-Stripe overlay component and close-eligibility rules so the UX and ownership semantics are identical.  
- Surface a clear terminal UX beat for cancel/failure (analogous to success) before returning/resetting.  
- Improve diagnostics for overlay ownership, close affordance eligibility, and recovery suppression to make regressions visible in logs.

### Description

- Introduced `canCloseNativeTapToPayPreHandoverOverlay(...)` in `lib/payments/nativeTapToPayUiPhases.ts` and wired it into both `InternalSettlementModule` and kiosk `payment-entry` so both entry points share the same close-eligibility logic.  
- Extended the shared overlay `components/payments/NativeTapToPayPreHandoverOverlay.tsx` to accept a `terminalState` prop (`success | canceled | failed`) and render matching terminal visuals/text so canceled/failed show a short terminal beat like success.  
- Strengthened Take Payment ownership/recovery by adding `suppressRecoveryRef` and `terminalVisualState` in `components/payments/InternalSettlementModule.tsx` so canceled/failed runs set a recovery suppression barrier, block rehydration that would revive the loader, and present a clean canceled/failed beat before resetting to `idle`.  
- Aligned kiosk behavior in `pages/kiosk/[restaurantId]/payment-entry.tsx` to use the shared `canCloseNativeTapToPayPreHandoverOverlay(...)`, removed the previous immediate fallback chaining from the overlay close handler, and added a short terminal visual beat (and a lock) before returning to method picker so the exit cross renders correctly and flows mirror Take Payment.  
- Added diagnostic logging around close-affordance eligibility, owner recreation after terminal cancel, overlay shown after terminal cancel, recovery blocked after terminal cancel, and terminal visual state selection to aid debugging.

### Testing

- Ran TypeScript typecheck with `npx tsc --noEmit`, which completed successfully.  
- No automated UI/browser tests were added; changes are implemented in a focused set of files only (`components/payments/InternalSettlementModule.tsx`, `components/payments/NativeTapToPayPreHandoverOverlay.tsx`, `lib/payments/nativeTapToPayUiPhases.ts`, `pages/kiosk/[restaurantId]/payment-entry.tsx`).  
- Manual runtime verification is expected in real device testing to confirm the following acceptance outcomes: canceled runs stay canceled, canceled runs do not revive overlays, kiosk shows exit cross when eligible, and cancel/failure show a terminal beat before reset.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e29373f8ac832590fc0c7b79db3a36)