### PR TITLE
feat(payments): centralize contactless eligibility and simplify kiosk payment selection

### DIFF
--- a/components/payments/InternalSettlementModule.tsx
+++ b/components/payments/InternalSettlementModule.tsx
@@ -6,6 +6,10 @@ import { resolveNativeTapToPayReadiness } from '@/lib/kiosk/tapToPayNativeReadin
 import { type AppFlowState } from '@/lib/app/launcherBootstrap';
 import { internalSettlementActiveRunStore } from '@/lib/payments/internalSettlementActiveRunStore';
 import { buildCombinedTapToPayDiagnosticsPayload } from '@/lib/payments/tapToPayDiagnostics';
+import {
+  resolveContactlessEligibility,
+  type ContactlessEligibilityResult,
+} from '@/lib/payments/contactlessEligibility';
 import NativeTapToPayPreHandoverOverlay from '@/components/payments/NativeTapToPayPreHandoverOverlay';
 import {
   canCloseNativeTapToPayPreHandoverOverlay,
@@ -144,6 +148,7 @@ export default function InternalSettlementModule({
   const [tapAvailabilityLoading, setTapAvailabilityLoading] = useState(true);
   const [tapAvailabilityReady, setTapAvailabilityReady] = useState(false);
   const [tapAvailabilityReason, setTapAvailabilityReason] = useState('');
+  const [contactlessEligibility, setContactlessEligibility] = useState<ContactlessEligibilityResult | null>(null);
   const [nativeReadinessLoading, setNativeReadinessLoading] = useState(false);
   const [nativeReadinessReady, setNativeReadinessReady] = useState(false);
   const [nativeReadinessReason, setNativeReadinessReason] = useState('');
@@ -298,10 +303,24 @@ export default function InternalSettlementModule({
         const available = payload?.tap_to_pay_available === true;
         setTapAvailabilityReady(available);
         setTapAvailabilityReason(available ? '' : String(payload?.reason || 'Tap to Pay is not available for this restaurant.'));
+        const eligibilityResolved = await resolveContactlessEligibility({
+          entryPoint,
+          restaurantAllowsContactless: available,
+          entryPointSupportsContactless: true,
+        });
+        if (!active) return;
+        setContactlessEligibility(eligibilityResolved);
       } catch (error: any) {
         if (!active) return;
         setTapAvailabilityReady(false);
         setTapAvailabilityReason(error?.message || 'Tap to Pay availability could not be confirmed.');
+        const eligibilityResolved = await resolveContactlessEligibility({
+          entryPoint,
+          restaurantAllowsContactless: false,
+          entryPointSupportsContactless: true,
+        });
+        if (!active) return;
+        setContactlessEligibility(eligibilityResolved);
       } finally {
         if (active) setTapAvailabilityLoading(false);
       }
@@ -311,7 +330,17 @@ export default function InternalSettlementModule({
     return () => {
       active = false;
     };
-  }, []);
+  }, [entryPoint]);
+
+  useEffect(() => {
+    console.info('[payments][contactless_eligibility]', 'rendered_payment_methods', {
+      entryPoint,
+      runtime: contactlessEligibility?.runtime || null,
+      eligible: contactlessEligibility?.eligible === true,
+      reason: contactlessEligibility?.reason || null,
+      methods: contactlessEligibility?.eligible ? ['contactless'] : [],
+    });
+  }, [contactlessEligibility, entryPoint]);
 
   const applyBootstrapState = useCallback((readiness: Awaited<ReturnType<typeof resolveNativeTapToPayReadiness>>) => {
     if (!readiness.supported) {
@@ -1939,21 +1968,23 @@ export default function InternalSettlementModule({
           </div>
 
           <div className="flex flex-wrap gap-3">
-            <button
-              type="button"
-              disabled={
-                busy ||
-                tapAvailabilityLoading ||
-                nativeReadinessLoading ||
-                !tapAvailabilityReady ||
-                amountCents <= 0 ||
-                (mode === 'order_payment' && !selectedOrderId)
-              }
-              onClick={handleCollectContactless}
-              className="rounded-full bg-slate-900 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-300"
-            >
-              {busy ? 'Collecting…' : state === 'setup_failed' ? 'Resolve setup & collect' : 'Collect contactless'}
-            </button>
+            {contactlessEligibility?.eligible ? (
+              <button
+                type="button"
+                disabled={
+                  busy ||
+                  tapAvailabilityLoading ||
+                  nativeReadinessLoading ||
+                  !tapAvailabilityReady ||
+                  amountCents <= 0 ||
+                  (mode === 'order_payment' && !selectedOrderId)
+                }
+                onClick={handleCollectContactless}
+                className="rounded-full bg-slate-900 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-300"
+              >
+                {busy ? 'Collecting…' : state === 'setup_failed' ? 'Resolve setup & collect' : 'Collect contactless'}
+              </button>
+            ) : null}
             <button
               type="button"
               disabled={busy || !activeSessionId}

--- a/lib/payments/contactlessEligibility.ts
+++ b/lib/payments/contactlessEligibility.ts
@@ -1,0 +1,116 @@
+import { resolveNativeTapToPayReadiness } from '@/lib/kiosk/tapToPayNativeReadiness';
+
+export type ContactlessEntryPoint = 'kiosk' | 'pos' | 'take_payment';
+export type ContactlessRuntime = 'native' | 'web' | 'server';
+export type ContactlessIneligibilityReason =
+  | 'restaurant_setting_disabled'
+  | 'entry_point_not_supported'
+  | 'runtime_not_native'
+  | 'native_device_not_supported'
+  | 'native_setup_not_ready';
+
+export type ContactlessEligibilityResult = {
+  eligible: boolean;
+  runtime: ContactlessRuntime;
+  reason: ContactlessIneligibilityReason | null;
+  detail: string;
+};
+
+type ResolveContactlessEligibilityInput = {
+  entryPoint: ContactlessEntryPoint;
+  restaurantAllowsContactless: boolean;
+  entryPointSupportsContactless: boolean;
+};
+
+type CapacitorWindow = Window & {
+  Capacitor?: {
+    isNativePlatform?: () => boolean;
+  };
+};
+
+const resolveRuntime = (): ContactlessRuntime => {
+  if (typeof window === 'undefined') return 'server';
+  const native = Boolean((window as CapacitorWindow).Capacitor?.isNativePlatform?.());
+  return native ? 'native' : 'web';
+};
+
+const logEligibility = (entryPoint: ContactlessEntryPoint, event: string, payload?: Record<string, unknown>) => {
+  console.info('[payments][contactless_eligibility]', event, { entryPoint, ...payload });
+};
+
+export const resolveContactlessEligibility = async (
+  input: ResolveContactlessEligibilityInput
+): Promise<ContactlessEligibilityResult> => {
+  const runtime = resolveRuntime();
+  logEligibility(input.entryPoint, 'runtime_detected', { runtime });
+  logEligibility(input.entryPoint, 'eligibility_evaluation_started', {
+    runtime,
+    restaurantAllowsContactless: input.restaurantAllowsContactless,
+    entryPointSupportsContactless: input.entryPointSupportsContactless,
+  });
+
+  if (!input.restaurantAllowsContactless) {
+    const result: ContactlessEligibilityResult = {
+      eligible: false,
+      runtime,
+      reason: 'restaurant_setting_disabled',
+      detail: 'Restaurant settings disabled contactless.',
+    };
+    logEligibility(input.entryPoint, 'eligibility_resolved', result);
+    return result;
+  }
+
+  if (!input.entryPointSupportsContactless) {
+    const result: ContactlessEligibilityResult = {
+      eligible: false,
+      runtime,
+      reason: 'entry_point_not_supported',
+      detail: 'This payment entry point does not support contactless.',
+    };
+    logEligibility(input.entryPoint, 'eligibility_resolved', result);
+    return result;
+  }
+
+  if (runtime !== 'native') {
+    const result: ContactlessEligibilityResult = {
+      eligible: false,
+      runtime,
+      reason: 'runtime_not_native',
+      detail: 'Contactless is unavailable outside the native app runtime.',
+    };
+    logEligibility(input.entryPoint, 'eligibility_resolved', result);
+    return result;
+  }
+
+  const readiness = await resolveNativeTapToPayReadiness({ promptIfNeeded: false });
+  if (!readiness.supported) {
+    const result: ContactlessEligibilityResult = {
+      eligible: false,
+      runtime,
+      reason: 'native_device_not_supported',
+      detail: readiness.reason || 'Native Tap to Pay is not supported on this device/runtime.',
+    };
+    logEligibility(input.entryPoint, 'eligibility_resolved', result);
+    return result;
+  }
+
+  if (!readiness.ready) {
+    const result: ContactlessEligibilityResult = {
+      eligible: false,
+      runtime,
+      reason: 'native_setup_not_ready',
+      detail: readiness.reason || 'Native Tap to Pay setup is not ready.',
+    };
+    logEligibility(input.entryPoint, 'eligibility_resolved', result);
+    return result;
+  }
+
+  const result: ContactlessEligibilityResult = {
+    eligible: true,
+    runtime,
+    reason: null,
+    detail: 'Contactless is eligible and can be rendered.',
+  };
+  logEligibility(input.entryPoint, 'eligibility_resolved', result);
+  return result;
+};

--- a/pages/kiosk/[restaurantId]/payment-entry.tsx
+++ b/pages/kiosk/[restaurantId]/payment-entry.tsx
@@ -14,6 +14,10 @@ import {
   type KioskPaymentMethod,
   type KioskPaymentSettingsRow,
 } from '@/lib/kiosk/paymentSettings';
+import {
+  resolveContactlessEligibility,
+  type ContactlessEligibilityResult,
+} from '@/lib/payments/contactlessEligibility';
 import { resolveNativeTapToPayReadiness } from '@/lib/kiosk/tapToPayNativeReadiness';
 import { tapToPayBridge, type TapToPayResult, type TapToPayStatus } from '@/lib/kiosk/tapToPayBridge';
 import type { KioskTerminalMode } from '@/lib/kiosk/terminalMode';
@@ -197,6 +201,7 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
   const [restaurantLoading, setRestaurantLoading] = useState(true);
   const [settingsLoading, setSettingsLoading] = useState(true);
   const [enabledMethods, setEnabledMethods] = useState<KioskPaymentMethod[]>(['pay_at_counter']);
+  const [contactlessEligibility, setContactlessEligibility] = useState<ContactlessEligibilityResult | null>(null);
   const [stage, setStage] = useState<PaymentStage>('method_picker');
   const [contactlessStatus, setContactlessStatus] = useState<TapToPayStatus>('idle');
   const [contactlessBusy, setContactlessBusy] = useState(false);
@@ -387,7 +392,15 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
 
         const normalized = normalizeKioskPaymentSettings((data as KioskPaymentSettingsRow | null) || null);
         setTerminalMode(normalized.terminalMode);
-        const nextMethods = normalized.enabledMethods;
+        const contactlessResolved = await resolveContactlessEligibility({
+          entryPoint: 'kiosk',
+          restaurantAllowsContactless: normalized.enableContactless,
+          entryPointSupportsContactless: true,
+        });
+        setContactlessEligibility(contactlessResolved);
+        const nextMethods = normalized.enabledMethods.filter((method) =>
+          method === 'contactless' ? contactlessResolved.eligible : true
+        );
         setEnabledMethods(nextMethods);
 
         if (preferredStageFromQuery === 'method_picker' && nextMethods.length > 1) {
@@ -410,6 +423,7 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
       } catch (err) {
         if (!active) return;
         console.error('[kiosk] failed to resolve kiosk payment methods', err);
+        setContactlessEligibility(null);
         setEnabledMethods(['pay_at_counter']);
         setStage('pay_at_counter');
       } finally {
@@ -423,6 +437,18 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
       active = false;
     };
   }, [preferredStageFromQuery, restaurantId]);
+
+  useEffect(() => {
+    if (settingsLoading) return;
+    console.info('[payments][contactless_eligibility]', 'rendered_payment_methods', {
+      entryPoint: 'kiosk',
+      runtime: contactlessEligibility?.runtime || null,
+      eligible: contactlessEligibility?.eligible === true,
+      reason: contactlessEligibility?.reason || null,
+      methods: enabledMethods,
+      stage,
+    });
+  }, [contactlessEligibility, enabledMethods, settingsLoading, stage]);
 
   useEffect(() => {
     stageRef.current = stage;
@@ -1789,17 +1815,9 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
   }, [CONTACTLESS_SESSION_STORAGE_KEY, contactlessSessionId, logContactlessState, releaseContactlessOwner, restaurantId]);
 
   const renderMethodPicker = () => (
-    <section
-      className="w-full rounded-[2rem] border bg-white/95 p-5 shadow-xl shadow-slate-200/70 sm:p-8"
-      style={{ borderColor: paymentTheme.ring }}
-    >
-      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Kiosk checkout</p>
-      <h1 className="mt-2 text-2xl font-semibold tracking-tight text-slate-900 sm:text-3xl">Choose how you want to pay</h1>
-      <p className="mt-3 text-sm leading-relaxed text-slate-600 sm:text-base">
-        Select your payment method to continue checkout.
-      </p>
-
-      <div className="mt-6 grid gap-3 sm:grid-cols-2">
+    <section className="w-full">
+      <h1 className="text-2xl font-semibold tracking-tight text-slate-900 sm:text-3xl">Choose payment</h1>
+      <div className="mt-4 grid gap-3 sm:grid-cols-2">
         {enabledMethods.map((method) => {
           const meta = PAYMENT_METHOD_META[method];
           const Icon = meta.icon;
@@ -1834,7 +1852,7 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
                 <Icon className="h-6 w-6" />
               </div>
               <p className="mt-4 text-lg font-semibold text-slate-900">{meta.title}</p>
-              <p className="mt-1 text-sm text-slate-600">{meta.subtitle}</p>
+              {method !== 'pay_at_counter' ? <p className="mt-1 text-sm text-slate-600">{meta.subtitle}</p> : null}
             </button>
           );
         })}
@@ -1900,7 +1918,7 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
                 }}
                 className="rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-slate-800"
               >
-                Back to kiosk cart
+                Back to cart
               </button>
             </div>
           </div>
@@ -1913,6 +1931,11 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
           {!settingsLoading && paymentNotice ? (
             <section className="w-full rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-medium text-amber-900">
               {paymentNotice}
+            </section>
+          ) : null}
+          {!settingsLoading && stage === 'method_picker' && contactlessEligibility && !contactlessEligibility.eligible ? (
+            <section className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-xs text-slate-600">
+              Contactless is unavailable on this device/runtime.
             </section>
           ) : null}
           {!settingsLoading && orderSubmitError ? (


### PR DESCRIPTION
### Motivation
- Prevent Contactless from appearing where it cannot work (PWA/web or unsupported devices) and avoid users reaching checkout only to be told their device is unsupported.
- Centralize eligibility logic so Kiosk, POS, and Take Payment share one source of truth and do not diverge.
- Simplify the kiosk payment selection UI to feel lighter, more premium, and keep tiles as the visual focus.

### Description
- Add a shared resolver `resolveContactlessEligibility` (lib/payments/contactlessEligibility.ts) that evaluates runtime (native/web/server), restaurant settings, entry-point support, and native Tap to Pay readiness, and emits internal eligibility/debug logs.
- Wire the resolver into the kiosk payment-entry page (pages/kiosk/[restaurantId]/payment-entry.tsx) to filter out `contactless` before rendering methods, surface a concise informational notice when Contactless is ineligible, and simplify the method picker UI (title now “Choose payment”, reduced chrome, shorter back label, trimmed tile copy).
- Wire the resolver into the Internal Settlement module (components/payments/InternalSettlementModule.tsx) so POS/Take Payment hide the Contactless action when ineligible and emit rendered-method logs.
- Preserve existing Tap to Pay native flow, overlay/cancel state-machine behavior, and native execution paths while only changing eligibility/rendering and UI chrome.
- Add internal logging points for runtime detection, eligibility evaluation start/resolve, ineligibility reason, and rendered payment methods; include a rollback note to revert this change if needed.

### Testing
- Ran TypeScript check: `npx tsc --noEmit` (passed).
- No additional automated test suites were added; changes are limited to eligibility resolution and UI rendering logic to minimize regression risk.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2a18b40408325ab5a1b0eb5bfceeb)