### PR TITLE
fix(payments): enforce live Tap-to-Pay availability at staff checkpoints

### DIFF
--- a/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
+++ b/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
@@ -7,6 +7,7 @@ import android.content.pm.ActivityInfo;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.location.LocationManager;
+import android.nfc.NfcAdapter;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.SystemClock;
@@ -383,16 +384,21 @@ public class OrderfastTapToPayPlugin extends Plugin {
         logStartupStage("native_support_check_entered", new JSObject());
         JSObject result = new JSObject();
         boolean hasNfc = getContext().getPackageManager().hasSystemFeature(PackageManager.FEATURE_NFC);
+        boolean nfcEnabled = isNfcEnabled();
 
         if (!hasNfc) {
             result.put("supported", false);
             result.put("reason", "NFC is not available on this device.");
+        } else if (!nfcEnabled) {
+            result.put("supported", true);
+            result.put("reason", "NFC is turned off. Turn on NFC to use Tap to Pay.");
         } else {
             result.put("supported", true);
             result.put("reason", "Tap to Pay hardware prerequisites satisfied.");
         }
         result.put("permissionState", permissionStateToString(getPermissionState("location")));
         result.put("hasNfc", hasNfc);
+        result.put("nfcEnabled", nfcEnabled);
         result.put("locationServicesEnabled", isLocationServicesEnabled());
         result.put("nativeStage", "native_support_check_result");
         logStartupStage("native_support_check_result", result);
@@ -464,23 +470,32 @@ public class OrderfastTapToPayPlugin extends Plugin {
 
     private JSObject buildReadinessPayload() {
         boolean hasNfc = getContext().getPackageManager().hasSystemFeature(PackageManager.FEATURE_NFC);
+        boolean nfcEnabled = isNfcEnabled();
         PermissionState permissionState = getPermissionState("location");
         boolean hasLocationPermission = permissionState == PermissionState.GRANTED;
         boolean locationServicesEnabled = isLocationServicesEnabled();
 
         JSObject payload = new JSObject();
-        payload.put("ready", hasNfc && hasLocationPermission && locationServicesEnabled);
+        payload.put("ready", hasNfc && nfcEnabled && hasLocationPermission && locationServicesEnabled);
         payload.put("supported", hasNfc);
         payload.put("reason", !hasNfc
             ? "NFC is not available on this device."
-            : (!hasLocationPermission
-                ? "Location permission is required for Tap to Pay."
-                : (locationServicesEnabled
-                    ? "Tap to Pay device prerequisites satisfied."
-                    : "Location services must be enabled for Tap to Pay.")));
+            : (!nfcEnabled
+                ? "NFC is turned off. Turn on NFC to use Tap to Pay."
+                : (!hasLocationPermission
+                    ? "Location permission is required for Tap to Pay."
+                    : (locationServicesEnabled
+                        ? "Tap to Pay device prerequisites satisfied."
+                        : "Location services must be enabled for Tap to Pay."))));
+        payload.put("nfcEnabled", nfcEnabled);
         payload.put("permissionState", permissionStateToString(permissionState));
         payload.put("locationServicesEnabled", locationServicesEnabled);
         return payload;
+    }
+
+    private boolean isNfcEnabled() {
+        NfcAdapter adapter = NfcAdapter.getDefaultAdapter(getContext());
+        return adapter != null && adapter.isEnabled();
     }
 
     @PluginMethod

--- a/components/payments/InternalSettlementModule.tsx
+++ b/components/payments/InternalSettlementModule.tsx
@@ -291,6 +291,41 @@ export default function InternalSettlementModule({
     void loadOrders();
   }, [loadOrders]);
 
+  const resolveStaffContactlessAvailability = useCallback(
+    async (checkpoint: 'screen_entry' | 'selection' | 'before_native_start') => {
+      console.info('[payments][contactless_eligibility]', 'staff_availability_check_started', {
+        entryPoint,
+        checkpoint,
+        source: 'live_server_and_native',
+      });
+      const response = await fetch('/api/dashboard/internal-settlement/tap-to-pay-availability', { cache: 'no-store' });
+      const payload = await response.json().catch(() => ({}));
+      const serverAvailable = response.ok && payload?.tap_to_pay_available === true;
+      const serverReason = response.ok
+        ? (serverAvailable ? '' : String(payload?.reason || 'Tap to Pay is not available for this restaurant.'))
+        : String(payload?.message || `HTTP ${response.status}`);
+      const resolved = await resolveContactlessEligibility({
+        checkpoint,
+        audience: 'staff',
+        entryPoint,
+        restaurantAllowsContactless: serverAvailable,
+        entryPointSupportsContactless: true,
+      });
+      console.info('[payments][contactless_eligibility]', 'staff_availability_checked', {
+        entryPoint,
+        checkpoint,
+        source: 'live_server_and_native',
+        httpStatus: response.status,
+        serverAvailable,
+        serverReason: serverReason || null,
+        nativeEligibility: resolved.eligible,
+        nativeReason: resolved.reason,
+      });
+      return { resolved, serverAvailable, serverReason };
+    },
+    [entryPoint]
+  );
+
   useEffect(() => {
     let active = true;
 
@@ -300,27 +335,24 @@ export default function InternalSettlementModule({
         entryPoint,
       });
       try {
-        const response = await fetch('/api/dashboard/internal-settlement/tap-to-pay-availability');
-        const payload = await response.json().catch(() => ({}));
+        const availability = await resolveStaffContactlessAvailability('screen_entry');
         if (!active) return;
-        if (!response.ok) throw new Error(payload?.message || `HTTP ${response.status}`);
+        if (tapAvailabilityReady && !availability.serverAvailable) {
+          console.info('[payments][contactless_eligibility]', 'cached_result_rejected_in_favor_of_live_check', {
+            entryPoint,
+            checkpoint: 'screen_entry',
+            cachedAvailable: true,
+            liveAvailable: false,
+          });
+        }
         console.info('[payments][contactless_eligibility]', 'eligibility_checked_at_page_render', {
           entryPoint,
-          tapToPayAvailable: payload?.tap_to_pay_available === true,
-          reason: payload?.reason || null,
+          tapToPayAvailable: availability.serverAvailable,
+          reason: availability.serverReason || null,
         });
-        const available = payload?.tap_to_pay_available === true;
-        setTapAvailabilityReady(available);
-        setTapAvailabilityReason(available ? '' : String(payload?.reason || 'Tap to Pay is not available for this restaurant.'));
-        const eligibilityResolved = await resolveContactlessEligibility({
-          checkpoint: 'screen_entry',
-          audience: 'staff',
-          entryPoint,
-          restaurantAllowsContactless: available,
-          entryPointSupportsContactless: true,
-        });
-        if (!active) return;
-        setContactlessEligibility(eligibilityResolved);
+        setTapAvailabilityReady(availability.serverAvailable);
+        setTapAvailabilityReason(availability.serverReason);
+        setContactlessEligibility(availability.resolved);
       } catch (error: any) {
         if (!active) return;
         setTapAvailabilityReady(false);
@@ -343,7 +375,7 @@ export default function InternalSettlementModule({
     return () => {
       active = false;
     };
-  }, [entryPoint]);
+  }, [entryPoint, resolveStaffContactlessAvailability, tapAvailabilityReady]);
 
   useEffect(() => {
     console.info('[payments][contactless_eligibility]', 'rendered_payment_methods', {
@@ -361,6 +393,10 @@ export default function InternalSettlementModule({
       return;
     }
     if (readiness.state === 'permission_not_requested') {
+      setState('setup_failed');
+      return;
+    }
+    if (readiness.state === 'nfc_disabled') {
       setState('setup_failed');
       return;
     }
@@ -803,22 +839,51 @@ export default function InternalSettlementModule({
       quickChargePaymentIntentIdRef.current = null;
     }
     if (!tapAvailabilityReady) {
+      console.info('[payments][contactless_eligibility]', 'cached_result_rejected_in_favor_of_live_check', {
+        entryPoint,
+        checkpoint: 'selection',
+        cachedAvailable: false,
+        liveCheckRequested: true,
+      });
+    }
+    const selectionAvailability = await resolveStaffContactlessAvailability('selection').catch((error: any) => {
+      const reason = error?.message || 'Tap to Pay availability could not be confirmed.';
+      setTapAvailabilityReady(false);
+      setTapAvailabilityReason(reason);
+      console.info('[payments][contactless_eligibility]', 'contactless_start_blocked_by_eligibility_guard', {
+        entryPoint,
+        checkpoint: 'selection',
+        reason: 'live_availability_request_failed',
+        detail: reason,
+      });
+      return null;
+    });
+    if (!selectionAvailability) {
       setState('failed');
-      setMessage(tapAvailabilityReason || 'Tap to Pay is not available for this restaurant.');
+      setMessage(tapAvailabilityReason || 'Tap to Pay availability could not be confirmed.');
       return;
     }
-    const selectionEligibility = await resolveContactlessEligibility({
-      checkpoint: 'selection',
-      audience: 'staff',
-      entryPoint,
-      restaurantAllowsContactless: tapAvailabilityReady,
-      entryPointSupportsContactless: true,
-    });
+    if (tapAvailabilityReady !== selectionAvailability.serverAvailable) {
+      console.info('[payments][contactless_eligibility]', 'cached_result_rejected_in_favor_of_live_check', {
+        entryPoint,
+        checkpoint: 'selection',
+        cachedAvailable: tapAvailabilityReady,
+        liveAvailable: selectionAvailability.serverAvailable,
+      });
+    }
+    setTapAvailabilityReady(selectionAvailability.serverAvailable);
+    setTapAvailabilityReason(selectionAvailability.serverReason);
+    const selectionEligibility = selectionAvailability.resolved;
     setContactlessEligibility(selectionEligibility);
     if (!selectionEligibility.eligible) {
       setState('failed');
       setMessage(selectionEligibility.detail || 'Tap to Pay is not available for this account/device.');
       console.info('[payments][contactless_eligibility]', 'contactless_start_blocked_by_eligibility_guard', {
+        entryPoint,
+        checkpoint: 'selection',
+        reason: selectionEligibility.reason,
+      });
+      console.info('[payments][contactless_eligibility]', 'ui_disabled_or_blocked_due_to_live_unavailability', {
         entryPoint,
         checkpoint: 'selection',
         reason: selectionEligibility.reason,
@@ -894,7 +959,7 @@ export default function InternalSettlementModule({
         setMessage('Payment canceled.');
         return;
       }
-      const readinessRes = await fetch('/api/dashboard/internal-settlement/tap-to-pay-availability');
+      const readinessRes = await fetch('/api/dashboard/internal-settlement/tap-to-pay-availability', { cache: 'no-store' });
       const readinessPayload = await readinessRes.json().catch(() => ({}));
       if (!readinessRes.ok || !readinessPayload?.tap_to_pay_available) {
         logCollectionEvent('readiness_refresh.result', {
@@ -1035,7 +1100,7 @@ export default function InternalSettlementModule({
       }
       logCollectionEvent('prepare_result', { stage: 'native_prepare', ok: true, sessionId, result: prepared });
 
-      const readinessRecheckRes = await fetch('/api/dashboard/internal-settlement/tap-to-pay-availability');
+      const readinessRecheckRes = await fetch('/api/dashboard/internal-settlement/tap-to-pay-availability', { cache: 'no-store' });
       const readinessRecheckPayload = await readinessRecheckRes.json().catch(() => ({}));
       if (shouldBlockRunContinuation(flowRunId, 'after_readiness_recheck')) {
         releaseHandoverOwner('readiness_recheck_blocked_dead_run');
@@ -1056,23 +1121,39 @@ export default function InternalSettlementModule({
         releaseHandoverOwner('readiness_changed_before_handover');
         return;
       }
-      const nativeStartEligibility = await resolveContactlessEligibility({
-        checkpoint: 'before_native_start',
-        audience: 'staff',
-        entryPoint,
-        restaurantAllowsContactless: true,
-        entryPointSupportsContactless: true,
-      });
-      setContactlessEligibility(nativeStartEligibility);
-      if (!nativeStartEligibility.eligible) {
+      const beforeStartAvailability = await resolveStaffContactlessAvailability('before_native_start');
+      if (tapAvailabilityReady !== beforeStartAvailability.serverAvailable) {
+        console.info('[payments][contactless_eligibility]', 'cached_result_rejected_in_favor_of_live_check', {
+          entryPoint,
+          checkpoint: 'before_native_start',
+          cachedAvailable: tapAvailabilityReady,
+          liveAvailable: beforeStartAvailability.serverAvailable,
+        });
+      }
+      setTapAvailabilityReady(beforeStartAvailability.serverAvailable);
+      setTapAvailabilityReason(beforeStartAvailability.serverReason);
+      setContactlessEligibility(beforeStartAvailability.resolved);
+      if (!beforeStartAvailability.resolved.eligible) {
         logCollectionEvent('contactless_start_blocked_by_eligibility_guard', {
           checkpoint: 'before_native_start',
-          reason: nativeStartEligibility.reason,
-          detail: nativeStartEligibility.detail,
+          reason: beforeStartAvailability.resolved.reason,
+          detail: beforeStartAvailability.resolved.detail,
         });
         setState('failed');
-        setMessage(nativeStartEligibility.detail || 'Tap to Pay is unavailable right now.');
-        releaseHandoverOwner('before_native_start_ineligible');
+        setMessage(beforeStartAvailability.resolved.detail || 'Tap to Pay is unavailable right now.');
+        console.info('[payments][contactless_eligibility]', 'contactless_start_blocked_by_live_unavailability', {
+          entryPoint,
+          checkpoint: 'before_native_start',
+          source: 'live_server_and_native',
+          reason: beforeStartAvailability.resolved.reason,
+          detail: beforeStartAvailability.resolved.detail,
+        });
+        console.info('[payments][contactless_eligibility]', 'ui_disabled_or_blocked_due_to_live_unavailability', {
+          entryPoint,
+          checkpoint: 'before_native_start',
+          reason: beforeStartAvailability.resolved.reason,
+        });
+        releaseHandoverOwner('before_native_start_live_unavailable');
         return;
       }
 
@@ -1628,6 +1709,7 @@ export default function InternalSettlementModule({
     quickNote,
     quickReference,
     refreshNativeReadiness,
+    resolveStaffContactlessAvailability,
     releaseHandoverOwner,
     selectedOrderId,
     shouldBlockRunContinuation,

--- a/hooks/useTapToPayBootstrap.ts
+++ b/hooks/useTapToPayBootstrap.ts
@@ -6,6 +6,7 @@ export const TAP_TO_PAY_SETUP_STORAGE_KEY = 'orderfast_kiosk_tap_to_pay_setup_re
 export type TapToPayBootstrapState =
   | 'idle'
   | 'requesting_permissions'
+  | 'nfc_disabled'
   | 'permission_not_requested'
   | 'permission_denied'
   | 'location_services_disabled'

--- a/lib/kiosk/tapToPayBridge.ts
+++ b/lib/kiosk/tapToPayBridge.ts
@@ -48,6 +48,7 @@ export interface TapToPayPlugin {
     supported: boolean;
     reason?: string;
     permissionState?: string;
+    nfcEnabled?: boolean;
     locationServicesEnabled?: boolean;
     nativeStage?: string;
   }>;
@@ -55,6 +56,7 @@ export interface TapToPayPlugin {
     supported: boolean;
     reason?: string;
     permissionState?: string;
+    nfcEnabled?: boolean;
     locationServicesEnabled?: boolean;
     nativeStage?: string;
   }>;
@@ -63,6 +65,7 @@ export interface TapToPayPlugin {
     supported: boolean;
     reason?: string;
     permissionState?: string;
+    nfcEnabled?: boolean;
     locationServicesEnabled?: boolean;
     nativeStage?: string;
   }>;

--- a/lib/kiosk/tapToPayNativeReadiness.ts
+++ b/lib/kiosk/tapToPayNativeReadiness.ts
@@ -6,6 +6,7 @@ export type NativeTapToPayReadiness = {
   state: TapToPaySetupState;
   reason: string;
   permissionState: string | null;
+  nfcEnabled: boolean | null;
   permissionStateBeforeRequest: string | null;
   permissionRequestAttempted: boolean;
   locationServicesEnabled: boolean | null;
@@ -23,6 +24,7 @@ export const resolveNativeTapToPayReadiness = async (options?: {
     state: setup.state,
     reason: setup.reason,
     permissionState: setup.permissionState,
+    nfcEnabled: typeof setup.nfcEnabled === 'boolean' ? setup.nfcEnabled : null,
     permissionStateBeforeRequest: setup.permissionStateBeforeRequest,
     permissionRequestAttempted: setup.permissionRequestAttempted,
     locationServicesEnabled: setup.locationServicesEnabled,

--- a/lib/kiosk/tapToPaySetupBootstrap.ts
+++ b/lib/kiosk/tapToPaySetupBootstrap.ts
@@ -2,6 +2,7 @@ import { tapToPayBridge } from '@/lib/kiosk/tapToPayBridge';
 
 export type TapToPaySetupState =
   | 'ready'
+  | 'nfc_disabled'
   | 'permission_not_requested'
   | 'permission_denied'
   | 'location_services_disabled'
@@ -14,6 +15,7 @@ export type TapToPaySetupBootstrapResult = {
   state: TapToPaySetupState;
   reason: string;
   permissionState: string | null;
+  nfcEnabled: boolean | null;
   permissionStateBeforeRequest: string | null;
   locationServicesEnabled: boolean | null;
   nativeStage: string | null;
@@ -28,10 +30,12 @@ const normalizePermissionState = (value: string | null | undefined) => {
 const deriveState = (payload: {
   ready: boolean;
   supported: boolean;
+  nfcEnabled: boolean | null;
   permissionState: string | null;
   locationServicesEnabled: boolean | null;
 }): TapToPaySetupState => {
   if (!payload.supported) return 'unsupported_device';
+  if (payload.nfcEnabled === false) return 'nfc_disabled';
 
   if (payload.permissionState === 'denied') return 'permission_denied';
 
@@ -57,6 +61,10 @@ const deriveReason = (payload: {
 
   if (payload.state === 'permission_denied') {
     return 'Location permission was denied. Allow location to use Tap to Pay.';
+  }
+
+  if (payload.state === 'nfc_disabled') {
+    return 'NFC is turned off. Turn on NFC to use Tap to Pay.';
   }
 
   if (payload.state === 'location_services_disabled') {
@@ -103,6 +111,7 @@ export const runTapToPaySetupBootstrap = async (options?: {
   const state = deriveState({
     ready,
     supported,
+    nfcEnabled: typeof readiness.nfcEnabled === 'boolean' ? readiness.nfcEnabled : null,
     permissionState,
     locationServicesEnabled,
   });
@@ -117,6 +126,7 @@ export const runTapToPaySetupBootstrap = async (options?: {
     }),
     state,
     permissionState,
+    nfcEnabled: typeof readiness.nfcEnabled === 'boolean' ? readiness.nfcEnabled : null,
     permissionStateBeforeRequest,
     locationServicesEnabled,
     nativeStage: readiness.nativeStage || requestNativeStage || locationCheck.nativeStage || supportCheck.nativeStage || null,


### PR DESCRIPTION
### Motivation

- A live bug allowed staff Take Payment / POS flows to proceed even when device NFC was actually turned off, because availability relied on stale/cached signals rather than a fresh live native capability check before transaction start.  
- The goal is to make staff-side Contactless/Tap to Pay depend on a fresh authoritative live check immediately before native handover while preserving existing Stripe handover, cancel protections, overlays, and kiosk/customer gating.  
- This change is a wiring fix to use the true native capability signal at the required checkpoints, not a redesign of flow sequencing or kiosk behavior.

### Description

- Added a live server+native availability helper and wired it into the staff flows so availability is checked freshly at `screen_entry`, `selection`, and the authoritative `before_native_start` checkpoint; this logic is implemented in `components/payments/InternalSettlementModule.tsx` via `resolveStaffContactlessAvailability` and used to gate UI and transaction start.  
- Hardened server readiness requests with `cache: 'no-store'` at transaction-critical fetches and added logging events for `staff_availability_check_started`, `staff_availability_checked`, `cached_result_rejected_in_favor_of_live_check`, `contactless_start_blocked_by_live_unavailability`, and `ui_disabled_or_blocked_due_to_live_unavailability`.  
- Fixed native Android readiness to use the true NFC enabled state by checking `NfcAdapter.isEnabled()` in the Android plugin and including `nfcEnabled` in the readiness payload; propagated this through the bridge and bootstrap types (`lib/kiosk/tapToPayBridge.ts`, `lib/kiosk/tapToPaySetupBootstrap.ts`, `lib/kiosk/tapToPayNativeReadiness.ts`) and added an explicit `nfc_disabled` setup state handled by `hooks/useTapToPayBootstrap.ts` and the UI bootstrap logic.  
- Preserved existing Stripe handover, cancel/dead-run protections, overlay ownership, and kiosk/customer gating while only tightening staff-side availability wiring; roll back by reverting these changes if needed to restore prior behavior.

### Testing

- Ran a full TypeScript typecheck with `npm -s exec tsc --noEmit`, which completed successfully.  
- Verified `tsc` passes with the updated bridge/bootstrap/readiness types and the modified `InternalSettlementModule` (no automated unit tests were added or modified in this change).  
- Manual runtime validation note: the change is scoped to staff availability wiring and native readiness signal propagation; existing Stripe handover and cancel/dead-run flows were left intact to avoid regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e50b28dca883258ed30bbbc1c64d57)