### PR TITLE
fix(payments): gate staff Take Payment on live Tap-to-Pay/NFC availability

### DIFF
--- a/components/payments/InternalSettlementModule.tsx
+++ b/components/payments/InternalSettlementModule.tsx
@@ -11,6 +11,7 @@ import {
   resolveContactlessPresentation,
   type ContactlessEligibilityResult,
 } from '@/lib/payments/contactlessEligibility';
+import { resolveStaffTapToPayAvailability } from '@/lib/payments/staffTapToPayAvailability';
 import NativeTapToPayPreHandoverOverlay from '@/components/payments/NativeTapToPayPreHandoverOverlay';
 import {
   canCloseNativeTapToPayPreHandoverOverlay,
@@ -292,37 +293,12 @@ export default function InternalSettlementModule({
   }, [loadOrders]);
 
   const resolveStaffContactlessAvailability = useCallback(
-    async (checkpoint: 'screen_entry' | 'selection' | 'before_native_start') => {
-      console.info('[payments][contactless_eligibility]', 'staff_availability_check_started', {
-        entryPoint,
+    async (checkpoint: 'screen_entry' | 'selection' | 'before_native_start') =>
+      resolveStaffTapToPayAvailability({
         checkpoint,
-        source: 'live_server_and_native',
-      });
-      const response = await fetch('/api/dashboard/internal-settlement/tap-to-pay-availability', { cache: 'no-store' });
-      const payload = await response.json().catch(() => ({}));
-      const serverAvailable = response.ok && payload?.tap_to_pay_available === true;
-      const serverReason = response.ok
-        ? (serverAvailable ? '' : String(payload?.reason || 'Tap to Pay is not available for this restaurant.'))
-        : String(payload?.message || `HTTP ${response.status}`);
-      const resolved = await resolveContactlessEligibility({
-        checkpoint,
-        audience: 'staff',
         entryPoint,
-        restaurantAllowsContactless: serverAvailable,
-        entryPointSupportsContactless: true,
-      });
-      console.info('[payments][contactless_eligibility]', 'staff_availability_checked', {
-        entryPoint,
-        checkpoint,
-        source: 'live_server_and_native',
-        httpStatus: response.status,
-        serverAvailable,
-        serverReason: serverReason || null,
-        nativeEligibility: resolved.eligible,
-        nativeReason: resolved.reason,
-      });
-      return { resolved, serverAvailable, serverReason };
-    },
+        source: 'internal_settlement',
+      }),
     [entryPoint]
   );
 
@@ -386,6 +362,17 @@ export default function InternalSettlementModule({
       methods: contactlessEligibility?.eligible ? ['contactless'] : [],
     });
   }, [contactlessEligibility, entryPoint]);
+
+  useEffect(() => {
+    const presentation = contactlessEligibility ? resolveContactlessPresentation(contactlessEligibility) : null;
+    console.info('[payments][contactless_eligibility]', 'pos_take_payment_contactless_presentation_resolved_from_live_availability', {
+      entryPoint,
+      presentation: presentation?.presentation || null,
+      eligible: contactlessEligibility?.eligible === true,
+      reason: presentation?.detail || null,
+    });
+  }, [contactlessEligibility, entryPoint]);
+
 
   const applyBootstrapState = useCallback((readiness: Awaited<ReturnType<typeof resolveNativeTapToPayReadiness>>) => {
     if (!readiness.supported) {

--- a/lib/payments/staffTapToPayAvailability.ts
+++ b/lib/payments/staffTapToPayAvailability.ts
@@ -1,0 +1,69 @@
+import {
+  type ContactlessEligibilityCheckpoint,
+  type ContactlessEntryPoint,
+  resolveContactlessEligibility,
+} from '@/lib/payments/contactlessEligibility';
+
+export type StaffTapToPayAvailability = {
+  resolved: Awaited<ReturnType<typeof resolveContactlessEligibility>>;
+  serverAvailable: boolean;
+  serverReason: string;
+  httpStatus: number;
+};
+
+const logStaffAvailability = (entryPoint: ContactlessEntryPoint, event: string, payload?: Record<string, unknown>) => {
+  console.info('[payments][contactless_eligibility]', event, { entryPoint, ...payload });
+};
+
+export const resolveStaffTapToPayAvailability = async (input: {
+  checkpoint: ContactlessEligibilityCheckpoint;
+  entryPoint: ContactlessEntryPoint;
+  source: 'launcher' | 'internal_settlement';
+}): Promise<StaffTapToPayAvailability> => {
+  logStaffAvailability(input.entryPoint, 'staff_availability_check_started', {
+    checkpoint: input.checkpoint,
+    source: input.source,
+    model: 'live_server_and_native',
+  });
+
+  const response = await fetch('/api/dashboard/internal-settlement/tap-to-pay-availability', { cache: 'no-store' });
+  const payload = await response.json().catch(() => ({}));
+  const serverAvailable = response.ok && payload?.tap_to_pay_available === true;
+  const serverReason = response.ok
+    ? (serverAvailable ? '' : String(payload?.reason || 'Tap to Pay is not available for this restaurant.'))
+    : String(payload?.message || `HTTP ${response.status}`);
+
+  const resolved = await resolveContactlessEligibility({
+    checkpoint: input.checkpoint,
+    audience: 'staff',
+    entryPoint: input.entryPoint,
+    restaurantAllowsContactless: serverAvailable,
+    entryPointSupportsContactless: true,
+  });
+
+  logStaffAvailability(input.entryPoint, 'staff_availability_checked', {
+    checkpoint: input.checkpoint,
+    source: input.source,
+    httpStatus: response.status,
+    serverAvailable,
+    serverReason: serverReason || null,
+    nativeEligibility: resolved.eligible,
+    nativeReason: resolved.reason,
+  });
+
+  if (serverAvailable && !resolved.eligible) {
+    logStaffAvailability(input.entryPoint, 'settings_allowed_but_live_availability_denied', {
+      checkpoint: input.checkpoint,
+      source: input.source,
+      reason: resolved.detail,
+      nativeReason: resolved.reason,
+    });
+  }
+
+  return {
+    resolved,
+    serverAvailable,
+    serverReason,
+    httpStatus: response.status,
+  };
+};

--- a/pages/dashboard/launcher.tsx
+++ b/pages/dashboard/launcher.tsx
@@ -6,6 +6,8 @@ import {
   runLauncherBootstrap,
   type LauncherBootstrapSnapshot,
 } from '@/lib/app/launcherBootstrap';
+import { resolveContactlessEligibility, resolveContactlessPresentation } from '@/lib/payments/contactlessEligibility';
+import { resolveStaffTapToPayAvailability, type StaffTapToPayAvailability } from '@/lib/payments/staffTapToPayAvailability';
 
 type RestaurantOption = {
   id: string;
@@ -69,6 +71,8 @@ export default function DashboardLauncherPage() {
   const [launchingMode, setLaunchingMode] = useState<AppMode['key'] | null>(null);
   const [bootstrapSnapshot, setBootstrapSnapshot] = useState<LauncherBootstrapSnapshot | null>(null);
   const [bootstrapRunning, setBootstrapRunning] = useState(false);
+  const [staffTakePaymentAvailability, setStaffTakePaymentAvailability] = useState<StaffTapToPayAvailability | null>(null);
+  const [staffTakePaymentLoading, setStaffTakePaymentLoading] = useState(false);
 
   useEffect(() => {
     let active = true;
@@ -171,6 +175,45 @@ export default function DashboardLauncherPage() {
     [selectedRestaurant]
   );
 
+  const evaluateLauncherStaffTakePaymentAvailability = useCallback(async () => {
+    if (!selectedRestaurant) return null;
+    setStaffTakePaymentLoading(true);
+    try {
+      const resolved = await resolveStaffTapToPayAvailability({
+        checkpoint: 'before_render',
+        entryPoint: 'take_payment',
+        source: 'launcher',
+      });
+      console.info('[payments][contactless_eligibility]', 'launcher_staff_tap_to_pay_availability_evaluated', {
+        restaurantId: selectedRestaurant.id,
+        serverAvailable: resolved.serverAvailable,
+        eligible: resolved.resolved.eligible,
+        detail: resolved.resolved.detail,
+        reason: resolved.resolved.reason,
+      });
+      setStaffTakePaymentAvailability(resolved);
+      return resolved;
+    } catch (error: any) {
+      const resolved = await resolveContactlessEligibility({
+        checkpoint: 'before_render',
+        audience: 'staff',
+        entryPoint: 'take_payment',
+        restaurantAllowsContactless: false,
+        entryPointSupportsContactless: true,
+      });
+      const fallback = {
+        resolved,
+        serverAvailable: false,
+        serverReason: error?.message || 'Tap to Pay availability could not be confirmed.',
+        httpStatus: 0,
+      };
+      setStaffTakePaymentAvailability(fallback);
+      return fallback;
+    } finally {
+      setStaffTakePaymentLoading(false);
+    }
+  }, [selectedRestaurant]);
+
   useEffect(() => {
     const existing = readLauncherBootstrapSnapshot();
     if (selectedRestaurant && existing?.restaurantId === selectedRestaurant.id) {
@@ -183,6 +226,11 @@ export default function DashboardLauncherPage() {
 
   useEffect(() => {
     if (!selectedRestaurant) return;
+    void evaluateLauncherStaffTakePaymentAvailability();
+  }, [evaluateLauncherStaffTakePaymentAvailability, selectedRestaurant]);
+
+  useEffect(() => {
+    if (!selectedRestaurant) return;
 
     APP_MODES.forEach((mode) => {
       const href = getModeHref(mode.key, selectedRestaurant.id);
@@ -192,10 +240,26 @@ export default function DashboardLauncherPage() {
 
   const handleLaunch = async (mode: AppMode['key']) => {
     if (!selectedRestaurant) return;
-    if (bootstrapRunning) return;
+    if (bootstrapRunning || staffTakePaymentLoading) return;
 
     setLaunchingMode(mode);
     try {
+      if (mode === 'take_payment') {
+        const liveAvailability = await evaluateLauncherStaffTakePaymentAvailability();
+        if (!liveAvailability?.resolved?.eligible) {
+          console.info('[payments][contactless_eligibility]', 'launcher_take_payment_action_disabled_due_to_live_unavailability', {
+            restaurantId: selectedRestaurant.id,
+            reason: liveAvailability?.resolved?.detail || null,
+          });
+          console.info('[payments][contactless_eligibility]', 'launcher_navigation_blocked_due_to_live_unavailability', {
+            mode,
+            restaurantId: selectedRestaurant.id,
+            reason: liveAvailability?.resolved?.detail || null,
+          });
+          return;
+        }
+      }
+
       const latestSnapshot = await runBootstrap(true);
       if (!latestSnapshot) return;
       const href = getModeHref(mode, selectedRestaurant.id);
@@ -204,6 +268,27 @@ export default function DashboardLauncherPage() {
       setLaunchingMode(null);
     }
   };
+
+  const takePaymentPresentation = staffTakePaymentAvailability
+    ? resolveContactlessPresentation(staffTakePaymentAvailability.resolved)
+    : null;
+  const takePaymentUnavailable = takePaymentPresentation?.presentation === 'disabled';
+
+  useEffect(() => {
+    if (!staffTakePaymentAvailability) return;
+    if (!staffTakePaymentAvailability.resolved.eligible) {
+      console.info('[payments][contactless_eligibility]', 'live_nfc_off_state_propagated_to_launcher_and_payment_actions', {
+        reason: staffTakePaymentAvailability.resolved.detail,
+      });
+    }
+  }, [staffTakePaymentAvailability]);
+
+  useEffect(() => {
+    if (!takePaymentUnavailable) return;
+    console.info('[payments][contactless_eligibility]', 'launcher_take_payment_action_disabled_due_to_live_unavailability', {
+      reason: takePaymentPresentation?.detail || null,
+    });
+  }, [takePaymentPresentation?.detail, takePaymentUnavailable]);
 
   return (
     <main
@@ -346,21 +431,28 @@ export default function DashboardLauncherPage() {
                   onClick={() => {
                     handleLaunch(mode.key).catch(() => undefined);
                   }}
-                  disabled={launchingMode !== null || bootstrapRunning}
+                  disabled={launchingMode !== null || bootstrapRunning || staffTakePaymentLoading || (mode.key === 'take_payment' && takePaymentUnavailable)}
                   style={{
                     textAlign: 'left',
-                    background: '#fff',
-                    border: '1px solid #dbeafe',
                     borderRadius: '12px',
                     padding: '0.9rem',
                     opacity: launchingMode === null || launchingMode === mode.key ? 1 : 0.65,
+                    cursor: mode.key === 'take_payment' && takePaymentUnavailable ? 'not-allowed' : 'pointer',
+                    border: mode.key === 'take_payment' && takePaymentUnavailable ? '1px solid #f1f5f9' : '1px solid #dbeafe',
+                    background: mode.key === 'take_payment' && takePaymentUnavailable ? '#f8fafc' : '#fff',
                   }}
                 >
                   <span style={{ display: 'block', fontWeight: 700 }}>
-                    {launchingMode === mode.key ? `Opening ${mode.label}…` : mode.label}
+                    {mode.key === 'take_payment' && takePaymentUnavailable
+                      ? 'Take Payment unavailable'
+                      : launchingMode === mode.key
+                        ? `Opening ${mode.label}…`
+                        : mode.label}
                   </span>
                   <span style={{ display: 'block', marginTop: '0.25rem', color: '#475569', fontSize: '0.9rem' }}>
-                    {mode.description}
+                    {mode.key === 'take_payment' && takePaymentUnavailable
+                      ? takePaymentPresentation?.detail || 'Tap to Pay is unavailable on this device right now.'
+                      : mode.description}
                   </span>
                 </button>
               ))}


### PR DESCRIPTION
### Motivation
- Ensure staff-facing Tap to Pay is gated by the real live device/runtime availability (NFC/native readiness) so that when NFC is turned off staff cannot open or use Take Payment even if restaurant settings allow contactless.
- Keep a single source of truth for staff availability across launcher, Take Payment, and POS so dashboard settings never override live runtime state.
- Preserve existing Stripe execution paths, overlay/cancel protections, and existing behavior for kiosk/customer contactless flows.

### Description
- Added a shared resolver `lib/payments/staffTapToPayAvailability.ts` that combines the server-side availability endpoint with native runtime readiness via the existing `resolveContactlessEligibility` and emits unified staff-side eligibility logs.
- Wired the dashboard launcher (`pages/dashboard/launcher.tsx`) to call the shared availability resolver on render and again before navigation, render the `Take Payment` tile as disabled/unselectable when live availability is false, and block navigation while logging the blocked action.
- Updated the staff payment UI (`components/payments/InternalSettlementModule.tsx`) to reuse the same `resolveStaffTapToPayAvailability` helper and to log contactless presentation resolution coming from live availability so POS/Take Payment use the single source of truth.
- Added defensive fallback handling for server failures so the launcher and payment UIs treat unavailable live checks conservatively, and added the requested internal logging events such as `launcher_staff_tap_to_pay_availability_evaluated`, `launcher_take_payment_action_disabled_due_to_live_unavailability`, `launcher_navigation_blocked_due_to_live_unavailability`, `pos_take_payment_contactless_presentation_resolved_from_live_availability`, and `settings_allowed_but_live_availability_denied`.
- Rollback is simple by reverting these wiring changes and removing the new helper; the change is wiring-focused and additive so it can be rolled back without touching payment execution flows.

### Testing
- Type check: `npx tsc --noEmit` succeeded.
- Build: `npm run build` compiled application code successfully but page data collection failed in this environment due to missing server environment variable (`SUPABASE_URL`), so full end-to-end build artifacts could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5110dbdc88325b2f28b72437b713c)