### PR TITLE
fix(payments): stop false Tap to Pay cancellations at Stripe handoff boundary

### DIFF
--- a/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
+++ b/android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java
@@ -1697,6 +1697,12 @@ public class OrderfastTapToPayPlugin extends Plugin {
     private String classifyTerminalFailureCategory(String normalizedCode) {
         if ("canceled".equals(normalizedCode)) {
             if (cancelRequestedByApp) return "app_cancelled";
+            if (readerDisconnectedDuringActiveRun() || lifecyclePausedDuringActiveFlow || backgroundInterruptionCandidate || confirmedBackgroundInterruption) {
+                return "lifecycle_interrupted";
+            }
+            if (stripeTakeoverObserved && !isAppInBackground()) {
+                return "lifecycle_interrupted";
+            }
             if (isConfirmedLifecycleInterruption()) {
                 return "lifecycle_interrupted";
             }

--- a/pages/kiosk/[restaurantId]/payment-entry.tsx
+++ b/pages/kiosk/[restaurantId]/payment-entry.tsx
@@ -1168,6 +1168,11 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
       setContactlessStatus('collecting');
       setContactlessDebug('native_collect_process');
       console.info('[kiosk][tap_to_pay_collect_start]', { sessionId, restaurantId, terminalLocationId });
+      logContactlessState('stripe_handoff_started', {
+        sessionId,
+        ownerId,
+        overlayOwner: 'app_pre_stripe',
+      });
       setTapStartupTrace((prev) => ({ ...prev, native_start: { status: 'pending', detail: 'Starting native collection flow.' } }));
       if (!isActiveContactlessOwner(ownerId)) {
         logContactlessState('stripe_handover_attempt_blocked_due_to_cancel', { sessionId, ownerId, reason: 'owner_invalid_before_start' });
@@ -1179,6 +1184,12 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
       preHandoverInFlightRef.current = false;
       setPreHandoverOverlayOwned(false);
       if (isStaleOwner('native_start_result')) return;
+      logContactlessState('stripe_handoff_committed', {
+        sessionId,
+        ownerId,
+        startedStatus: started.status,
+        startedCode: started.code || null,
+      });
       console.info('[kiosk][tap_to_pay_native_collect_raw_result]', { sessionId, restaurantId, result: started });
       updateReaderHintFromDetail(started.detail);
       const isNativeSuccessOrProcessing = started.status === 'succeeded' || started.status === 'processing';
@@ -1193,6 +1204,11 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
         const reasonCategory = typeof nativeDetail?.reasonCategory === 'string' ? nativeDetail.reasonCategory : null;
         const interruptionReasonCode = typeof nativeDetail?.interruptionReasonCode === 'string' ? nativeDetail.interruptionReasonCode : null;
         const terminalCode = typeof nativeDetail?.terminalCode === 'string' ? nativeDetail.terminalCode : null;
+        const definitiveCustomerCancelSignal =
+          (typeof nativeDetail?.definitiveCustomerCancelSignal === 'boolean' && nativeDetail.definitiveCustomerCancelSignal) ||
+          (typeof (started as { definitiveCustomerCancelSignal?: unknown }).definitiveCustomerCancelSignal === 'boolean' &&
+            (started as { definitiveCustomerCancelSignal?: boolean }).definitiveCustomerCancelSignal === true);
+        const explicitAppCancelRequested = contactlessOwnerRef.current?.id === ownerId && contactlessOwnerRef.current?.cancelRequested === true;
         const lifecycleInterrupted =
           interruptionReasonCode === 'background_loss_confirmed' ||
           reasonCategory === 'lifecycle_interrupted' ||
@@ -1201,27 +1217,52 @@ function KioskPaymentEntryScreen({ restaurantId }: { restaurantId?: string | nul
           started.status === 'canceled' &&
           started.code === 'canceled' &&
           terminalCode === 'CANCELED' &&
-          (reasonCategory === 'customer_cancelled' || reasonCategory === 'app_cancelled' || !lifecycleInterrupted);
+          (definitiveCustomerCancelSignal || reasonCategory === 'customer_cancelled' || reasonCategory === 'app_cancelled');
+        const ambiguousCanceledDuringHandoff = started.status === 'canceled' && !customerOrReaderCancel && !explicitAppCancelRequested;
 
         logNativeOutcome('start_non_success', {
           started,
           reasonCategory,
           interruptionReasonCode,
           terminalCode,
+          definitiveCustomerCancelSignal,
+          explicitAppCancelRequested,
           lifecycleInterrupted,
           customerOrReaderCancel,
+          ambiguousCanceledDuringHandoff,
         });
 
         setContactlessUnsupportedDevice(unsupportedDevice);
-        if (lifecycleInterrupted) {
+        if (lifecycleInterrupted || ambiguousCanceledDuringHandoff) {
+          logContactlessState('interruption_classification_received', {
+            sessionId,
+            source: lifecycleInterrupted ? 'native_lifecycle_inference' : 'ambiguous_canceled_during_handoff',
+            reasonCategory,
+            interruptionReasonCode,
+            definitiveCustomerCancelSignal,
+            explicitAppCancelRequested,
+          });
           setContactlessStatus('processing');
           setContactlessError('');
-          setContactlessDebug('native_lifecycle_interrupted');
-          setContactlessDebugDetail(`Lifecycle interruption detected. raw=${formatDetail(started)}`);
-          await reconcileSession(sessionId, 'native_lifecycle_interrupted');
+          setContactlessDebug(lifecycleInterrupted ? 'native_lifecycle_interrupted' : 'native_canceled_ambiguous_reconcile');
+          setContactlessDebugDetail(
+            `${lifecycleInterrupted ? 'Lifecycle interruption detected.' : 'Ambiguous canceled result during Stripe handoff.'} raw=${formatDetail(
+              started
+            )}`
+          );
+          await reconcileSession(sessionId, lifecycleInterrupted ? 'native_lifecycle_interrupted' : 'native_canceled_ambiguous');
           return;
         }
 
+        logContactlessState('terminal_outcome_committed', {
+          sessionId,
+          outcome: customerOrReaderCancel ? 'canceled' : 'failed',
+          source: customerOrReaderCancel ? 'authoritative_cancel_signal' : 'native_non_success',
+          definitiveCustomerCancelSignal,
+          explicitAppCancelRequested,
+          reasonCategory,
+          interruptionReasonCode,
+        });
         setContactlessStatus(customerOrReaderCancel ? 'canceled' : 'failed');
         setContactlessTerminalState(customerOrReaderCancel ? 'canceled' : 'failed');
         logContactlessState(customerOrReaderCancel ? 'kiosk_cancel_received' : 'kiosk_failure_received', {


### PR DESCRIPTION
### Motivation
- Restore reliable Tap to Pay runs by ensuring ambiguous native `canceled` results that occur during Stripe takeover or lifecycle transitions are not treated as authoritative customer cancels. 
- Preserve the recent shared pre-Stripe overlay and NFC/launcher gating while isolating the handoff/lifecycle classification regression. 

### Description
- Web kiosk: tightened handoff lifecycle resolution in `pages/kiosk/[restaurantId]/payment-entry.tsx` so the flow only commits a `canceled` terminal state when an authoritative signal is present (explicit app cancel or a definitive native customer-cancel flag), and treats ambiguous canceled responses during takeover as lifecycle interruptions that go to reconciliation instead. 
- Web kiosk: added focused diagnostics/log events `stripe_handoff_started`, `stripe_handoff_committed`, `interruption_classification_received`, and `terminal_outcome_committed` to capture overlay ownership, handoff commit, interruption source, and terminal outcome reasoning for easier future diagnosis. 
- Native plugin: hardened native classification in `android/app/src/main/java/com/orderfast/app/OrderfastTapToPayPlugin.java` so `canceled` error codes observed during reader disconnects, takeover observation, or other lifecycle ambiguity are classified as `lifecycle_interrupted` (reconcile path) rather than `customer_cancelled`, preserving explicit app cancel behavior. 
- Scope: changes are narrow and focused to handoff, lifecycle inference, and outcome ownership; no launcher/NFC gating or UI redesign was changed. 
- Rollback: revert this change to return to prior behaviour if necessary (will restore previous ambiguous-cancel classification). 

### Testing
- Ran TypeScript check with `npx tsc --noEmit`, which passed. 
- Attempted production build with `npm run build`, but page data collection failed due to missing server environment variable `SUPABASE_URL` in the build environment, so a full Next.js page-data collection run could not complete (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e73f718d60832591e2e4433dbfede4)