### PR TITLE
fix(payments): refine POS Take Payment layout, money normalization, and receipt-step routing

### DIFF
--- a/components/payments/InternalSettlementModule.tsx
+++ b/components/payments/InternalSettlementModule.tsx
@@ -40,6 +40,7 @@ type UnpaidOrder = {
   order_type: string | null;
   status: string;
   total_price: number | null;
+  total_price_cents?: number | null;
   created_at: string;
 };
 
@@ -48,12 +49,6 @@ const toCurrencyCode = (value?: string | null) => (value || 'GBP').toUpperCase()
 const makeIdempotencyKey = (prefix: string) => `${prefix}:${Date.now()}:${Math.random().toString(36).slice(2, 10)}`;
 const QUICK_CHARGE_MINIMUM_CENTS = 50;
 const QUICK_CHIPS = [500, 1000, 2000, 5000];
-
-type CapacitorWindow = Window & {
-  Capacitor?: {
-    isNativePlatform?: () => boolean;
-  };
-};
 
 const formatAmountFromCents = (cents: number) => {
   const resolved = Number.isFinite(cents) ? Math.max(0, Math.floor(cents)) : 0;
@@ -238,19 +233,15 @@ export default function InternalSettlementModule({
   }, [quickAmountDigits]);
 
   const amountCents = useMemo(() => {
-    if (mode === 'order_payment') return Number(selectedOrder?.total_price || 0);
+    if (mode === 'order_payment') return Math.max(0, Math.floor(Number(selectedOrder?.total_price_cents || 0)));
     return quickAmountCents;
-  }, [mode, quickAmountCents, selectedOrder?.total_price]);
+  }, [mode, quickAmountCents, selectedOrder?.total_price_cents]);
 
   const amountLabel = useMemo(() => formatPrice(amountCents / 100), [amountCents]);
   const nativeRestaurantId = useMemo(() => {
     const value = restaurantId?.trim();
     return value ? value : null;
   }, [restaurantId]);
-  const isNativeShell = useMemo(() => {
-    if (typeof window === 'undefined') return false;
-    return Boolean((window as CapacitorWindow).Capacitor?.isNativePlatform?.());
-  }, []);
   const quickChargeAttemptDiagnosticsPayload = useMemo(() => {
     if (mode !== 'quick_charge') return null;
     const attemptSummary =
@@ -1971,11 +1962,9 @@ export default function InternalSettlementModule({
     console.info('[payments][contactless_eligibility]', 'terminal_outcome_selected', { entryPoint, outcome: 'success' });
     const timeout = window.setTimeout(() => {
       const target = nativeRestaurantId
-        ? isNativeShell
-          ? source === 'launcher'
-            ? `/pos/${nativeRestaurantId}/payment-entry?source=launcher`
-            : `/pos/${nativeRestaurantId}`
-          : `/pos/${nativeRestaurantId}?stage=paymentComplete&source=${entryPoint === 'pos' ? 'pos-contactless' : 'take-payment'}`
+        ? `/pos/${nativeRestaurantId}?stage=paymentComplete&source=${entryPoint === 'pos' ? 'pos-contactless' : 'take-payment'}${
+            source === 'launcher' ? '&origin=launcher' : ''
+          }`
         : null;
       logCollectionEvent('success_tick_shown', { entryPoint, restaurantId: nativeRestaurantId, target });
       setShowSuccessTick(false);
@@ -2004,7 +1993,7 @@ export default function InternalSettlementModule({
       router.push(target).catch(() => undefined);
     }, 900);
     return () => window.clearTimeout(timeout);
-  }, [entryPoint, isNativeShell, logCollectionEvent, nativeRestaurantId, router, source, state]);
+  }, [entryPoint, logCollectionEvent, nativeRestaurantId, router, source, state]);
 
   useEffect(() => {
     if (state === 'completed') return;
@@ -2221,7 +2210,7 @@ export default function InternalSettlementModule({
   }, [busy, nativeRestaurantId, router, source]);
 
   return (
-    <section className="relative overflow-hidden rounded-3xl border border-gray-200 bg-white shadow-sm">
+    <section className="relative min-h-[calc(100dvh-3.5rem)] overflow-hidden bg-white sm:min-h-0 sm:rounded-3xl sm:border sm:border-gray-200 sm:shadow-sm">
       <NativeTapToPayPreHandoverOverlay
         visible={showTransitionOverlay}
         lines={overlayLines}
@@ -2259,7 +2248,7 @@ export default function InternalSettlementModule({
         </button>
       </header>
 
-      <div className="grid gap-4 p-4 sm:p-5 lg:grid-cols-[1.1fr_0.9fr]">
+      <div className="grid min-h-[calc(100dvh-10rem)] gap-4 px-3 py-4 sm:min-h-0 sm:p-5 lg:grid-cols-[1.1fr_0.9fr]">
         <div className="space-y-4">
           <div className="rounded-3xl bg-gray-900 px-6 py-5 text-white">
             <p className="text-[11px] uppercase tracking-[0.18em] text-gray-300">{toCurrencyCode('gbp')}</p>
@@ -2324,16 +2313,6 @@ export default function InternalSettlementModule({
         </div>
 
         <div className="space-y-3 rounded-2xl border border-gray-200 bg-white p-4">
-          <div className="rounded-2xl border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-700">
-            {!tapAvailabilityLoading && !tapAvailabilityReady ? (
-              <p className="text-xs text-amber-700">{tapAvailabilityReason || 'Tap to Pay is not ready on this account/device.'}</p>
-            ) : null}
-            {!nativeReadinessLoading && !nativeReadinessReady ? (
-              <p className="mt-2 text-xs text-amber-700">{nativeReadinessReason || 'Location permission and location services are required.'}</p>
-            ) : null}
-            {state === 'failed' || state === 'canceled' ? <p className="mt-2 text-xs text-rose-700">{message}</p> : null}
-          </div>
-
           <div className="pt-1">
             {(() => {
               const presentation = contactlessEligibility ? resolveContactlessPresentation(contactlessEligibility) : null;
@@ -2357,6 +2336,13 @@ export default function InternalSettlementModule({
                 </button>
               );
             })()}
+            {!tapAvailabilityLoading && !tapAvailabilityReady ? (
+              <p className="mt-2 text-xs text-amber-700">{tapAvailabilityReason || 'Tap to Pay is not ready on this account/device.'}</p>
+            ) : null}
+            {!nativeReadinessLoading && !nativeReadinessReady ? (
+              <p className="mt-2 text-xs text-amber-700">{nativeReadinessReason || 'Location permission and location services are required.'}</p>
+            ) : null}
+            {state === 'failed' || state === 'canceled' ? <p className="mt-2 text-xs text-rose-700">{message}</p> : null}
             {busy ? (
               <button
                 type="button"
@@ -2405,7 +2391,7 @@ export default function InternalSettlementModule({
                   >
                     <div className="flex items-center justify-between gap-2">
                       <p className="text-sm font-semibold text-gray-900">#{order.short_order_number ?? '—'} · {order.customer_name || 'Guest'}</p>
-                      <p className="text-sm font-semibold text-gray-900">{formatPrice(Number(order.total_price || 0) / 100)}</p>
+                      <p className="text-sm font-semibold text-gray-900">{formatPrice(Number(order.total_price_cents || 0) / 100)}</p>
                     </div>
                     <p className="mt-1 text-xs uppercase tracking-[0.08em] text-gray-500">{order.status}</p>
                   </button>

--- a/lib/server/payments/internalSettlementService.ts
+++ b/lib/server/payments/internalSettlementService.ts
@@ -21,6 +21,7 @@ export type UnpaidOrderSummary = {
   order_type: string | null;
   status: string;
   total_price: number | null;
+  total_price_cents: number;
   created_at: string;
 };
 
@@ -39,6 +40,33 @@ const isCollectionOperationalType = (orderType: string | null | undefined) => {
   return orderType !== 'delivery';
 };
 const QUICK_CHARGE_MINIMUM_CENTS = 50;
+
+const normalizeMoneyToCents = (value: unknown) => {
+  if (value == null) return 0;
+  if (typeof value === 'string') {
+    const sanitized = value.trim().replace(/,/g, '');
+    if (!sanitized) return 0;
+    const parsed = Number(sanitized);
+    if (!Number.isFinite(parsed)) return 0;
+    if (sanitized.includes('.')) {
+      return Math.max(0, Math.round(parsed * 100));
+    }
+    if (Math.abs(parsed) >= 1000 && parsed % 100 !== 0) {
+      return Math.max(0, Math.round(parsed));
+    }
+    return Math.max(0, Math.round(parsed * 100));
+  }
+
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return 0;
+  if (!Number.isInteger(numeric)) {
+    return Math.max(0, Math.round(numeric * 100));
+  }
+  if (Math.abs(numeric) >= 1000 && numeric % 100 !== 0) {
+    return Math.max(0, Math.round(numeric));
+  }
+  return Math.max(0, Math.round(numeric * 100));
+};
 
 const updatePaidOrderWithOptionalStripeIntent = async (input: {
   orderId: string;
@@ -135,7 +163,7 @@ export const listUnpaidOrdersForSettlement = async (restaurantId: string, limit 
   if (error) throw error;
 
   return (data || [])
-    .filter((row: any) => isOrderPaymentUnpaid(row.payment_status) && Number(row.total_price || 0) > 0)
+    .filter((row: any) => isOrderPaymentUnpaid(row.payment_status) && normalizeMoneyToCents(row.total_price) > 0)
     .map((row: any) => ({
       id: String(row.id),
       short_order_number: row.short_order_number == null ? null : Number(row.short_order_number),
@@ -143,6 +171,7 @@ export const listUnpaidOrdersForSettlement = async (restaurantId: string, limit 
       order_type: row.order_type ? String(row.order_type) : null,
       status: String(row.status || 'pending'),
       total_price: row.total_price == null ? null : Number(row.total_price),
+      total_price_cents: normalizeMoneyToCents(row.total_price),
       created_at: String(row.created_at),
     }));
 };
@@ -183,7 +212,7 @@ export const createInternalSettlementSession = async (input: {
     if (!order) throw new Error('Order not found');
     if (!isOrderPaymentUnpaid(order.payment_status)) throw new Error('Order is already settled');
 
-    const orderAmount = Math.max(1, Number(order.total_price || 0));
+    const orderAmount = Math.max(1, normalizeMoneyToCents(order.total_price));
     if (orderAmount <= 0) throw new Error('Order has no outstanding amount');
 
     const pendingPayload: Record<string, unknown> = {

--- a/pages/dashboard/take-payment.tsx
+++ b/pages/dashboard/take-payment.tsx
@@ -4,7 +4,7 @@ import InternalSettlementModule from '@/components/payments/InternalSettlementMo
 export default function DashboardTakePaymentPage() {
   return (
     <DashboardLayout>
-      <div className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6">
+      <div className="w-full px-0 py-0 sm:px-4 sm:py-6">
         <InternalSettlementModule
           entryPoint="take_payment"
         />

--- a/pages/pos/[restaurantId]/index.tsx
+++ b/pages/pos/[restaurantId]/index.tsx
@@ -89,6 +89,8 @@ export default function PosHomePage() {
   const router = useRouter();
   const { restaurantId: routeParam } = router.query;
   const stageParam = Array.isArray(router.query.stage) ? router.query.stage[0] : router.query.stage;
+  const sourceParam = Array.isArray(router.query.source) ? router.query.source[0] : router.query.source;
+  const originParam = Array.isArray(router.query.origin) ? router.query.origin[0] : router.query.origin;
   const restaurantId = Array.isArray(routeParam) ? routeParam[0] : routeParam;
   const storageKey = useMemo(
     () => (restaurantId ? `orderfast_pos_cart_${restaurantId}` : null),
@@ -453,6 +455,22 @@ export default function PosHomePage() {
       window.localStorage.removeItem(storageKey);
     }
   };
+
+  const completeReceiptFlow = useCallback(() => {
+    if (!restaurantId) {
+      startNewOrder();
+      return;
+    }
+    if (stageParam === 'paymentComplete' && (sourceParam === 'take-payment' || sourceParam === 'pos-contactless')) {
+      if (originParam === 'launcher') {
+        router.push(`/dashboard/launcher?restaurant_id=${encodeURIComponent(String(restaurantId))}`).catch(() => undefined);
+        return;
+      }
+      router.push(`/pos/${encodeURIComponent(String(restaurantId))}`).catch(() => undefined);
+      return;
+    }
+    startNewOrder();
+  }, [originParam, restaurantId, router, sourceParam, stageParam]);
 
   const handleSelectOrderType = (selection: OrderType) => {
     setOrderType(selection);
@@ -1244,7 +1262,7 @@ export default function PosHomePage() {
               {receiptChoice ? (
                 <button
                   type="button"
-                  onClick={startNewOrder}
+                  onClick={completeReceiptFlow}
                   className="mt-6 w-full rounded-full bg-teal-600 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-teal-700"
                 >
                   Start new order

--- a/pages/pos/[restaurantId]/payment-entry.tsx
+++ b/pages/pos/[restaurantId]/payment-entry.tsx
@@ -18,8 +18,8 @@ export default function PosPaymentEntryPage() {
   }, [flowActive, router]);
 
   return (
-    <div className="w-full bg-gray-50 text-gray-900">
-      <div className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6">
+    <div className="min-h-screen w-full bg-gray-50 text-gray-900">
+      <div className="w-full px-0 py-0 sm:px-4 sm:py-6">
         <InternalSettlementModule
           restaurantId={restaurantId || null}
           onFlowActivityChange={setFlowActive}


### PR DESCRIPTION
### Motivation

- Remove the stale grey debug/reporting bar that is still mounted above the Collect action and restore a clean, restaurant-facing POS surface.  
- Ensure unpaid/pending order amounts are displayed and used with correct currency scaling (pounds, not pennies) while keeping a single source-of-truth amount owner.  
- Make the Take Payment UI occupy the available in-app page area on mobile so it doesn't look like a small centered card.  
- Restore the post-payment receipt-options step so successful payment routes into receipt selection before returning safely depending on context.

### Description

- Normalize money on the server by adding `normalizeMoneyToCents` and returning a `total_price_cents` field from `listUnpaidOrdersForSettlement`, and use that cents value for filtering and session creation to avoid mixed-unit bugs. (`lib/server/payments/internalSettlementService.ts`)  
- Wire the client to the normalized cents field and use a single `amountCents` owner for both selected-order hero amount and unpaid-order list display (`components/payments/InternalSettlementModule.tsx`).  
- Remove the stale mounted debug/reporting block and keep readiness/error copy inline under the primary collect action so feedback remains without the old grey bar (`components/payments/InternalSettlementModule.tsx`).  
- Adjust layout wrappers so the Take Payment module naturally fills handheld app page space (`components/payments/InternalSettlementModule.tsx`, `pages/dashboard/take-payment.tsx`, `pages/pos/[restaurantId]/payment-entry.tsx`).  
- Restore post-success routing into POS `paymentComplete` and wire a launcher/origin-safe return after receipt selection by adding `completeReceiptFlow` and using it from the POS receipt step, preserving the native-wrapper-safe navigation behavior (`components/payments/InternalSettlementModule.tsx`, `pages/pos/[restaurantId]/index.tsx`).

### Testing

- Ran the production build with `npm run build`; compilation, type checking and lint phases completed successfully but page-data collection failed due to missing server environment (`SUPABASE_URL`) in this execution environment, so full runtime page sampling could not be exercised.  
- No additional automated test suites were executed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e78efcba348325aca93489885c37ba)