### PR TITLE
fix(take-payment): disable fullscreen on Take Payment receipt flow, restore receipt UX, and enforce £0.50 minimum

### DIFF
--- a/components/layouts/FullscreenAppLayout.tsx
+++ b/components/layouts/FullscreenAppLayout.tsx
@@ -18,13 +18,16 @@ type FullscreenAppLayoutProps = {
   children: ReactNode;
   promptTitle?: string;
   promptDescription?: string;
+  fullscreenBehavior?: 'auto' | 'disabled';
 };
 
 export default function FullscreenAppLayout({
   children,
   promptTitle = 'Tap to enter fullscreen',
   promptDescription = 'Tap below to stay fully immersed in the POS experience.',
+  fullscreenBehavior = 'auto',
 }: FullscreenAppLayoutProps) {
+  const fullscreenEnabled = fullscreenBehavior !== 'disabled';
   const [showFullscreenPrompt, setShowFullscreenPrompt] = useState(false);
   const fullscreenRequestInFlight = useRef(false);
   const [wakeLock, setWakeLock] = useState<WakeLockSentinel | null>(null);
@@ -106,6 +109,10 @@ export default function FullscreenAppLayout({
 
   useEffect(() => {
     if (typeof window === 'undefined' || typeof document === 'undefined') return;
+    if (!fullscreenEnabled) {
+      setShowFullscreenPrompt(false);
+      return;
+    }
 
     const handleFullscreenChange = () => {
       if (isFullscreenActive()) {
@@ -126,10 +133,11 @@ export default function FullscreenAppLayout({
       window.removeEventListener('fullscreenchange', handleFullscreenChange);
       window.removeEventListener('webkitfullscreenchange', handleFullscreenChange as any);
     };
-  }, [attemptFullscreen, isFullscreenActive]);
+  }, [attemptFullscreen, fullscreenEnabled, isFullscreenActive]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
+    if (!fullscreenEnabled) return;
 
     const handleInteraction = async () => {
       await Promise.allSettled([attemptFullscreen({ allowModal: true }), requestWakeLock()]);
@@ -145,7 +153,7 @@ export default function FullscreenAppLayout({
       window.removeEventListener('pointerdown', handleInteraction);
       window.removeEventListener('keydown', handleInteraction);
     };
-  }, [attemptFullscreen, requestWakeLock]);
+  }, [attemptFullscreen, fullscreenEnabled, requestWakeLock]);
 
   useEffect(() => {
     if (typeof document === 'undefined') return;
@@ -188,7 +196,7 @@ export default function FullscreenAppLayout({
   return (
     <div className="min-h-screen w-full bg-gradient-to-b from-[#fafafa] via-white to-white text-neutral-900">
       {children}
-      {showFullscreenPrompt ? (
+      {fullscreenEnabled && showFullscreenPrompt ? (
         <div className="fixed inset-0 z-[70] flex items-center justify-center bg-black/20 px-6 text-center">
           <div className="w-full max-w-sm rounded-3xl border border-neutral-200 bg-white p-6 shadow-2xl shadow-black/10">
             <p className="text-lg font-semibold text-neutral-900">{promptTitle}</p>

--- a/components/payments/InternalSettlementModule.tsx
+++ b/components/payments/InternalSettlementModule.tsx
@@ -238,6 +238,8 @@ export default function InternalSettlementModule({
   }, [mode, quickAmountCents, selectedOrder?.total_price_cents]);
 
   const amountLabel = useMemo(() => formatPrice(amountCents / 100), [amountCents]);
+  const isBelowMinimumAmount = amountCents > 0 && amountCents < QUICK_CHARGE_MINIMUM_CENTS;
+  const minimumAmountMessage = `Minimum payment amount is ${formatPrice(QUICK_CHARGE_MINIMUM_CENTS / 100)}.`;
   const nativeRestaurantId = useMemo(() => {
     const value = restaurantId?.trim();
     return value ? value : null;
@@ -2327,6 +2329,7 @@ export default function InternalSettlementModule({
                     nativeReadinessLoading ||
                     !tapAvailabilityReady ||
                     amountCents <= 0 ||
+                    isBelowMinimumAmount ||
                     (mode === 'order_payment' && !selectedOrderId)
                   }
                   onClick={handleCollectContactless}
@@ -2342,6 +2345,7 @@ export default function InternalSettlementModule({
             {!nativeReadinessLoading && !nativeReadinessReady ? (
               <p className="mt-2 text-xs text-amber-700">{nativeReadinessReason || 'Location permission and location services are required.'}</p>
             ) : null}
+            {isBelowMinimumAmount ? <p className="mt-2 text-xs text-rose-700">{minimumAmountMessage}</p> : null}
             {state === 'failed' || state === 'canceled' ? <p className="mt-2 text-xs text-rose-700">{message}</p> : null}
             {busy ? (
               <button

--- a/pages/pos/[restaurantId]/index.tsx
+++ b/pages/pos/[restaurantId]/index.tsx
@@ -127,6 +127,8 @@ export default function PosHomePage() {
   const [saveError, setSaveError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [menuRefreshKey, setMenuRefreshKey] = useState(0);
+  const isTakePaymentReceiptFlow =
+    stageParam === 'paymentComplete' && (sourceParam === 'take-payment' || sourceParam === 'pos-contactless');
 
   useEffect(() => {
     if (!storageKey || typeof window === 'undefined') return;
@@ -472,6 +474,17 @@ export default function PosHomePage() {
     startNewOrder();
   }, [originParam, restaurantId, router, sourceParam, stageParam]);
 
+  useEffect(() => {
+    if (!isTakePaymentReceiptFlow) return;
+    router.beforePopState(() => {
+      completeReceiptFlow();
+      return false;
+    });
+    return () => {
+      router.beforePopState(() => true);
+    };
+  }, [completeReceiptFlow, isTakePaymentReceiptFlow, router]);
+
   const handleSelectOrderType = (selection: OrderType) => {
     setOrderType(selection);
     if (selection === 'delivery') {
@@ -800,7 +813,7 @@ export default function PosHomePage() {
   }, [canConfirmPayment, isSaving, savePosOrderToSupabase]);
 
   return (
-    <FullscreenAppLayout>
+    <FullscreenAppLayout fullscreenBehavior={isTakePaymentReceiptFlow ? 'disabled' : 'auto'}>
       <div className="flex min-h-screen w-full flex-col">
         <header className="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 bg-white px-6 py-4">
           <div>
@@ -1241,6 +1254,8 @@ export default function PosHomePage() {
                               console.error('[pos] failed to queue invoice print', error);
                               setToastMessage('Could not queue invoice print job.');
                             }
+                          } else {
+                            setToastMessage('Print receipt is not available for this payment.');
                           }
                         }
                         if (choice === 'digital') {
@@ -1265,7 +1280,7 @@ export default function PosHomePage() {
                   onClick={completeReceiptFlow}
                   className="mt-6 w-full rounded-full bg-teal-600 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-teal-700"
                 >
-                  Start new order
+                  {isTakePaymentReceiptFlow ? 'Done' : 'Start new order'}
                 </button>
               ) : null}
             </div>


### PR DESCRIPTION
### Motivation
- Take Payment was still triggering the fullscreen prompt on Android/web and the receipt step was partially broken in wrapper contexts, and amounts below the supported minimum failed silently.
- The change must be narrowly scoped to stop fullscreen prompting from the Take Payment path, restore receipt-step behavior and navigation safety, and add clear minimum-amount validation without touching working contactless logic.

### Description
- Add a `fullscreenBehavior` prop to `FullscreenAppLayout` and gate auto-prompt/request logic behind it so callers can opt out of fullscreen prompting by passing `fullscreenBehavior="disabled"` (keeps kiosk/POS defaults unchanged). (`components/layouts/FullscreenAppLayout.tsx`).
- Detect Take Payment receipt-return flows (`stage=paymentComplete` with `source=take-payment|pos-contactless`) and disable fullscreen prompting for that path by passing `fullscreenBehavior='disabled'`, while preserving native-wrapper-safe back handling via `router.beforePopState`. (`pages/pos/[restaurantId]/index.tsx`).
- Repair receipt interactions by showing an explicit toast when a print receipt is requested but no order-backed receipt exists, and change the post-payment CTA label to `Done` for Take Payment receipt-return flows to match wrapper expectations. (`pages/pos/[restaurantId]/index.tsx`).
- Add explicit minimum-amount validation to `InternalSettlementModule` to block collect when the quick-charge amount is below `QUICK_CHARGE_MINIMUM_CENTS` (50) and surface an immediate on-screen message (`Minimum payment amount is £0.50.`), re-enabling the action once corrected. (`components/payments/InternalSettlementModule.tsx`).

### Testing
- Ran TypeScript typecheck with `npx tsc --noEmit`, which completed successfully.
- No automated UI or unit tests were added; changes are restricted to fullscreen prompting, receipt UX, and client-side amount validation only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e794b9787c8325b297c9a9eb0362d2)