### PR TITLE
fix(fullscreen): route-aware ownership and cleanup across kiosk/kod/pos

### DIFF
--- a/android/app/src/main/java/com/orderfast/app/MainActivity.java
+++ b/android/app/src/main/java/com/orderfast/app/MainActivity.java
@@ -393,6 +393,9 @@ public class MainActivity extends BridgeActivity {
         if (path.startsWith("/kiosk")) {
             return true;
         }
+        if (path.startsWith("/kod")) {
+            return true;
+        }
         if (path.startsWith("/pos")) {
             return hasPosFullscreenOptIn(uri) && !path.contains("/payment-entry");
         }

--- a/components/layouts/FullscreenAppLayout.tsx
+++ b/components/layouts/FullscreenAppLayout.tsx
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import KioskActionButton from '@/components/kiosk/KioskActionButton';
+import {
+  exitDocumentFullscreen,
+  isDocumentFullscreenActive,
+  requestDocumentFullscreen,
+} from '@/lib/fullscreen';
 
 interface WakeLockSentinel {
   released: boolean;
@@ -19,6 +24,7 @@ type FullscreenAppLayoutProps = {
   promptTitle?: string;
   promptDescription?: string;
   fullscreenBehavior?: 'auto' | 'disabled' | 'manual';
+  exitFullscreenOnUnmount?: boolean;
 };
 
 export default function FullscreenAppLayout({
@@ -26,6 +32,7 @@ export default function FullscreenAppLayout({
   promptTitle = 'Tap to enter fullscreen',
   promptDescription = 'Tap below to stay fully immersed in the POS experience.',
   fullscreenBehavior = 'auto',
+  exitFullscreenOnUnmount = true,
 }: FullscreenAppLayoutProps) {
   const fullscreenEnabled = fullscreenBehavior !== 'disabled';
   const autoFullscreen = fullscreenBehavior === 'auto';
@@ -33,40 +40,31 @@ export default function FullscreenAppLayout({
   const fullscreenRequestInFlight = useRef(false);
   const [wakeLock, setWakeLock] = useState<WakeLockSentinel | null>(null);
 
-  const isFullscreenActive = useCallback(() => {
-    if (typeof document === 'undefined') return false;
-    const anyDoc = document as Document & { webkitFullscreenElement?: Element | null };
-    return Boolean(document.fullscreenElement || anyDoc.webkitFullscreenElement);
-  }, []);
-
   const attemptFullscreen = useCallback(
     async (options: { allowModal?: boolean } = {}) => {
       if (typeof document === 'undefined') return false;
-      const el = document.documentElement as HTMLElement & { webkitRequestFullscreen?: () => Promise<void> };
-      if (!el) return false;
       if (fullscreenRequestInFlight.current) {
-        return isFullscreenActive();
+        return isDocumentFullscreenActive();
       }
       fullscreenRequestInFlight.current = true;
       let success = false;
       try {
-        if (isFullscreenActive()) {
+        if (isDocumentFullscreenActive()) {
           setShowFullscreenPrompt(false);
           success = true;
         } else {
-          const request = el.requestFullscreen?.bind(el) || el.webkitRequestFullscreen?.bind(el);
-          if (!request) {
+          const requested = await requestDocumentFullscreen();
+          if (!requested) {
             if (options.allowModal) {
               setShowFullscreenPrompt(true);
             }
           } else {
-            await Promise.resolve(request());
             setShowFullscreenPrompt(false);
             success = true;
           }
         }
       } catch (err) {
-        console.debug('[pos] fullscreen request failed', err);
+        console.debug('[fullscreen] fullscreen request failed', err);
         if (options.allowModal) {
           setShowFullscreenPrompt(true);
         }
@@ -75,7 +73,7 @@ export default function FullscreenAppLayout({
       }
       return success;
     },
-    [isFullscreenActive]
+    []
   );
 
   const requestWakeLock = useCallback(async () => {
@@ -88,7 +86,7 @@ export default function FullscreenAppLayout({
       }
       return sentinel;
     } catch (err) {
-      console.debug('[pos] wake lock unavailable', err);
+      console.debug('[fullscreen] wake lock unavailable', err);
       return null;
     }
   }, []);
@@ -105,24 +103,28 @@ export default function FullscreenAppLayout({
     return () => {
       html.style.colorScheme = previousColorScheme;
       html.classList.remove('kiosk-mode');
+      if (exitFullscreenOnUnmount) {
+        void exitDocumentFullscreen();
+      }
     };
-  }, []);
+  }, [exitFullscreenOnUnmount]);
 
   useEffect(() => {
     if (typeof window === 'undefined' || typeof document === 'undefined') return;
     if (!fullscreenEnabled) {
       setShowFullscreenPrompt(false);
+      void exitDocumentFullscreen();
       return;
     }
 
     const handleFullscreenChange = () => {
-      if (isFullscreenActive()) {
+      if (isDocumentFullscreenActive()) {
         setShowFullscreenPrompt(false);
         return;
       }
-      setTimeout(() => {
-        attemptFullscreen({ allowModal: true });
-      }, 150);
+      if (autoFullscreen) {
+        setShowFullscreenPrompt(true);
+      }
     };
 
     if (autoFullscreen) {
@@ -136,7 +138,7 @@ export default function FullscreenAppLayout({
       window.removeEventListener('fullscreenchange', handleFullscreenChange);
       window.removeEventListener('webkitfullscreenchange', handleFullscreenChange as any);
     };
-  }, [attemptFullscreen, autoFullscreen, fullscreenEnabled, isFullscreenActive]);
+  }, [attemptFullscreen, autoFullscreen, fullscreenEnabled]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -170,7 +172,7 @@ export default function FullscreenAppLayout({
           await requestWakeLock();
         }
       } catch (err) {
-        console.debug('[pos] wake lock renewal failed', err);
+        console.debug('[fullscreen] wake lock renewal failed', err);
       }
     };
 

--- a/components/layouts/KioskLayout.tsx
+++ b/components/layouts/KioskLayout.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/utils/kiosk/debug';
 import { getExpressSession } from '@/utils/express/session';
 import { useCustomerAvailability } from '@/hooks/useCustomerAvailability';
+import { exitDocumentFullscreen, isDocumentFullscreenActive, requestDocumentFullscreen } from '@/lib/fullscreen';
 
 export const FULL_HEADER_HEIGHT = 136;
 export const COLLAPSED_HEADER_HEIGHT = 88;
@@ -184,11 +185,9 @@ export default function KioskLayout({
     };
   }, [showOperatorUnlock]);
 
-  const isFullscreenActive = useCallback(() => {
-    if (typeof document === 'undefined') return false;
-    const anyDoc = document as Document & { webkitFullscreenElement?: Element | null };
-    return Boolean(document.fullscreenElement || anyDoc.webkitFullscreenElement);
-  }, []);
+  const [isKioskFullscreenActive, setIsKioskFullscreenActive] = useState(false);
+
+  const isFullscreenActive = useCallback(() => isDocumentFullscreenActive(), []);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -272,8 +271,6 @@ export default function KioskLayout({
         setShowFullscreenPrompt(false);
         return false;
       }
-      const el = document.documentElement as HTMLElement & { webkitRequestFullscreen?: () => Promise<void> };
-      if (!el) return false;
       if (fullscreenRequestInFlight.current) {
         return isFullscreenActive();
       }
@@ -284,13 +281,12 @@ export default function KioskLayout({
           setShowFullscreenPrompt(false);
           success = true;
         } else {
-          const request = el.requestFullscreen?.bind(el) || el.webkitRequestFullscreen?.bind(el);
-          if (!request) {
+          const requested = await requestDocumentFullscreen();
+          if (!requested) {
             if (options.allowModal) {
               setShowFullscreenPrompt(true);
             }
           } else {
-            await Promise.resolve(request());
             setShowFullscreenPrompt(false);
             success = true;
           }
@@ -374,24 +370,19 @@ export default function KioskLayout({
     };
 
     const handleFullscreenChange = () => {
-      if (isFullscreenActive()) {
+      const active = isFullscreenActive();
+      setIsKioskFullscreenActive(active);
+      if (active || shouldSuppressFullscreen || !shouldAutoFullscreen) {
         setShowFullscreenPrompt(false);
         return;
       }
-      if (shouldSuppressFullscreen || !shouldAutoFullscreen) {
-        setShowFullscreenPrompt(false);
-        return;
-      }
-      setTimeout(() => {
-        if (!shouldSuppressFullscreen) {
-          attemptFullscreen({ allowModal: true });
-        }
-      }, 150);
+      setShowFullscreenPrompt(true);
     };
 
     const media = window.matchMedia?.('(display-mode: standalone)');
 
     evaluateDisplayMode();
+    setIsKioskFullscreenActive(isFullscreenActive());
     if (!shouldSuppressFullscreen) {
       attemptFullscreen({ allowModal: true });
     }
@@ -764,7 +755,9 @@ export default function KioskLayout({
     if (!restaurantId) return;
     resetOperatorUnlock();
     setShowOperatorUnlock(false);
-    await router.push(`/dashboard/launcher?restaurant_id=${encodeURIComponent(restaurantId)}`);
+    setShowFullscreenPrompt(false);
+    await exitDocumentFullscreen();
+    await router.push(`/dashboard?restaurant_id=${encodeURIComponent(restaurantId)}`);
   }, [resetOperatorUnlock, restaurantId, router]);
 
   const handleOperatorUnlockSubmit = useCallback(
@@ -865,23 +858,25 @@ export default function KioskLayout({
     );
     console.info('[kiosk-debug] force open menu requested', { targetPath, resolvedRestaurantId });
     if (!targetPath || router.asPath === targetPath) return;
-    router.push(targetPath).catch((error) => {
-      const message = error instanceof Error ? error.message : String(error);
-      patchKioskDebugState(
-        {
-          lastNavigationTarget: targetPath,
-          navigationStatus: 'error',
-          navigationError: message,
-        },
-        'debug-force-open-menu-error'
-      );
-      console.error('[kiosk-debug] force open menu failed', { error, targetPath });
+    exitDocumentFullscreen().finally(() => {
+      router.push(targetPath).catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        patchKioskDebugState(
+          {
+            lastNavigationTarget: targetPath,
+            navigationStatus: 'error',
+            navigationError: message,
+          },
+          'debug-force-open-menu-error'
+        );
+        console.error('[kiosk-debug] force open menu failed', { error, targetPath });
+      });
     });
   }, [isExpressActive, menuPath, resolveRestaurantIdForNavigation, router]);
 
   const handleExitDebug = useCallback(() => {
     if (!restaurantId) return;
-    const targetPath = `/dashboard/launcher?restaurant_id=${encodeURIComponent(restaurantId)}`;
+    const targetPath = `/dashboard?restaurant_id=${encodeURIComponent(restaurantId)}`;
     patchKioskDebugState(
       {
         lastNavigationTarget: targetPath,
@@ -891,19 +886,47 @@ export default function KioskLayout({
       'debug-exit-kiosk'
     );
     console.info('[kiosk-debug] debug exit requested', { targetPath });
-    router.push(targetPath).catch((error) => {
-      const message = error instanceof Error ? error.message : String(error);
-      patchKioskDebugState(
-        {
-          lastNavigationTarget: targetPath,
-          navigationStatus: 'error',
-          navigationError: message,
-        },
-        'debug-exit-kiosk-error'
-      );
-      console.error('[kiosk-debug] debug exit failed', { error, targetPath });
+    exitDocumentFullscreen().finally(() => {
+      router.push(targetPath).catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        patchKioskDebugState(
+          {
+            lastNavigationTarget: targetPath,
+            navigationStatus: 'error',
+            navigationError: message,
+          },
+          'debug-exit-kiosk-error'
+        );
+        console.error('[kiosk-debug] debug exit failed', { error, targetPath });
+      });
     });
   }, [restaurantId, router]);
+
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || shouldSuppressFullscreen || isExpressActive || !restaurantId) return;
+
+    const preventBackEscape = () => {
+      window.history.pushState({ orderfastKioskLock: true }, '', window.location.href);
+    };
+
+    const handlePopState = () => {
+      setShowLockedNavigationNotice(true);
+      if (operatorNoticeTimerRef.current) {
+        window.clearTimeout(operatorNoticeTimerRef.current);
+      }
+      operatorNoticeTimerRef.current = window.setTimeout(() => {
+        setShowLockedNavigationNotice(false);
+      }, 2600);
+      preventBackEscape();
+    };
+
+    preventBackEscape();
+    window.addEventListener('popstate', handlePopState);
+    return () => {
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, [isExpressActive, restaurantId, shouldSuppressFullscreen]);
 
   const headerTitle = restaurant?.website_title || restaurant?.name || 'Restaurant';
   const logoUrl = restaurant?.logo_url || null;
@@ -1112,11 +1135,11 @@ export default function KioskLayout({
           </button>
         </div>
       ) : null}
-      {!shouldSuppressFullscreen && showFullscreenPrompt ? (
+      {!shouldSuppressFullscreen && shouldAutoFullscreen && (!isKioskFullscreenActive || showFullscreenPrompt) ? (
         <div className="fixed inset-0 z-[70] flex items-center justify-center bg-black/20 px-6 text-center">
           <div className="w-full max-w-sm rounded-3xl border border-neutral-200 bg-white p-6 shadow-2xl shadow-black/10">
-            <p className="text-lg font-semibold text-neutral-900">Tap to enter kiosk mode</p>
-            <p className="mt-2 text-sm text-neutral-600">Tap below to stay fully immersed in the kiosk experience.</p>
+            <p className="text-lg font-semibold text-neutral-900">Tap to continue kiosk</p>
+            <p className="mt-2 text-sm text-neutral-600">Kiosk is locked until fullscreen is restored.</p>
             <KioskActionButton onClick={handleFullscreenPromptClick} className="mt-6 w-full justify-center text-base">
               Enter fullscreen
             </KioskActionButton>
@@ -1158,7 +1181,7 @@ export default function KioskLayout({
         <div className="fixed inset-0 z-[85] flex items-center justify-center bg-black/30 px-6">
           <div className="w-full max-w-sm rounded-3xl border border-neutral-200 bg-white p-6 shadow-2xl shadow-black/20">
             <p className="text-lg font-semibold text-neutral-900">Staff unlock required</p>
-            <p className="mt-2 text-sm text-neutral-600">Enter staff PIN to exit kiosk and return to launcher.</p>
+            <p className="mt-2 text-sm text-neutral-600">Enter staff PIN to exit kiosk and return to dashboard.</p>
             <form className="mt-5 space-y-4" onSubmit={handleOperatorUnlockSubmit}>
               <input
                 ref={operatorPinInputRef}

--- a/lib/fullscreen.ts
+++ b/lib/fullscreen.ts
@@ -1,0 +1,30 @@
+export const isDocumentFullscreenActive = () => {
+  if (typeof document === 'undefined') return false;
+  const anyDoc = document as Document & {
+    webkitFullscreenElement?: Element | null;
+  };
+  return Boolean(document.fullscreenElement || anyDoc.webkitFullscreenElement);
+};
+
+export const requestDocumentFullscreen = async () => {
+  if (typeof document === 'undefined') return false;
+  const el = document.documentElement as HTMLElement & {
+    webkitRequestFullscreen?: () => Promise<void>;
+  };
+  if (!el) return false;
+  const request = el.requestFullscreen?.bind(el) || el.webkitRequestFullscreen?.bind(el);
+  if (!request) return false;
+  await Promise.resolve(request());
+  return true;
+};
+
+export const exitDocumentFullscreen = async () => {
+  if (typeof document === 'undefined') return;
+  const anyDoc = document as Document & {
+    webkitExitFullscreen?: () => Promise<void>;
+  };
+  if (!isDocumentFullscreenActive()) return;
+  const exit = document.exitFullscreen?.bind(document) || anyDoc.webkitExitFullscreen?.bind(document);
+  if (!exit) return;
+  await Promise.resolve(exit()).catch(() => undefined);
+};

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,18 +5,30 @@ import '@/src/styles/webpage-builder.css';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 import { BrandProvider } from '@/components/branding/BrandProvider';
 import { SessionContextProvider } from '@supabase/auth-helpers-react';
 import { CartProvider } from '../context/CartContext';
 import { OrderTypeProvider } from '../context/OrderTypeContext';
 import { supabase } from '../utils/supabaseClient';
 import { RestaurantProvider } from '@/lib/restaurant-context';
+import { exitDocumentFullscreen } from '@/lib/fullscreen';
 
 export default function App({ Component, pageProps }: AppProps) {
   const router = useRouter();
   const isRestaurantRoute = router.pathname.startsWith('/restaurant');
   const isKioskRoute = router.pathname.startsWith('/kiosk') || router.asPath.startsWith('/kiosk');
   const manifestHref = isKioskRoute ? '/kiosk.webmanifest' : '/site.webmanifest';
+
+  useEffect(() => {
+    const currentPath = router.asPath.split('?')[0] || '';
+    const allowsFullscreenOwnership =
+      currentPath.startsWith('/kiosk/') || currentPath.startsWith('/kod/') || currentPath.startsWith('/pos/');
+    if (!allowsFullscreenOwnership) {
+      void exitDocumentFullscreen();
+    }
+  }, [router.asPath]);
+
   const page = <Component {...pageProps} />;
   const content = isRestaurantRoute ? (
     <BrandProvider initialBrand={pageProps.initialBrand}>{page}</BrandProvider>

--- a/pages/pos/[restaurantId]/index.tsx
+++ b/pages/pos/[restaurantId]/index.tsx
@@ -19,6 +19,7 @@ import { isInStockAddonOption, isOutOfStockEntity } from '@/lib/stockAvailabilit
 import Toast from '@/components/Toast';
 import { requestPrintJobCreation } from '@/lib/print-jobs/request';
 import { buildPosPaymentEntryPath } from '@/lib/payment-entry/routes';
+import { exitDocumentFullscreen } from '@/lib/fullscreen';
 
 type OrderType = 'walk-in' | 'collection' | 'delivery';
 type PaymentMethod = 'cash' | 'card';
@@ -490,6 +491,14 @@ export default function PosHomePage() {
     }
   };
 
+  const navigateAfterFullscreenExit = useCallback(
+    async (target: string) => {
+      await exitDocumentFullscreen();
+      await router.push(target);
+    },
+    [router]
+  );
+
   const completeReceiptFlow = useCallback(() => {
     if (!restaurantId) {
       startNewOrder();
@@ -497,14 +506,16 @@ export default function PosHomePage() {
     }
     if (stageParam === 'paymentComplete' && (sourceParam === 'take-payment' || sourceParam === 'pos-contactless')) {
       if (originParam === 'launcher') {
-        router.push(`/dashboard/launcher?restaurant_id=${encodeURIComponent(String(restaurantId))}`).catch(() => undefined);
+        navigateAfterFullscreenExit(`/dashboard/launcher?restaurant_id=${encodeURIComponent(String(restaurantId))}`).catch(
+          () => undefined
+        );
         return;
       }
       router.push(`/pos/${encodeURIComponent(String(restaurantId))}`).catch(() => undefined);
       return;
     }
     startNewOrder();
-  }, [originParam, restaurantId, router, sourceParam, stageParam]);
+  }, [navigateAfterFullscreenExit, originParam, restaurantId, router, sourceParam, stageParam]);
 
   useEffect(() => {
     if (!isTakePaymentReceiptFlow) return;
@@ -873,7 +884,9 @@ export default function PosHomePage() {
             ) : null}
             <button
               type="button"
-              onClick={() => router.push('/dashboard')}
+              onClick={() => {
+                navigateAfterFullscreenExit('/dashboard').catch(() => undefined);
+              }}
               className="rounded-full border border-gray-200 bg-white px-4 py-2 text-xs font-semibold text-gray-700 shadow-sm transition hover:bg-gray-50"
             >
               Exit to Dashboard
@@ -1151,7 +1164,7 @@ export default function PosHomePage() {
                   <button
                     type="button"
                     onClick={() => {
-                      router.push(buildPosPaymentEntryPath(restaurantId)).catch(() => undefined);
+                      navigateAfterFullscreenExit(buildPosPaymentEntryPath(restaurantId)).catch(() => undefined);
                     }}
                     className="mt-2 text-xs font-medium text-gray-500 underline decoration-gray-300 underline-offset-2 hover:text-gray-700"
                   >


### PR DESCRIPTION
### Motivation
- Centralise fullscreen/immersive ownership and fix leaking behaviours across web/PWA and the Android wrapper so dashboard, take-payment, customer app, POS, KOD and kiosk follow explicit ownership rules. 
- Previous ad-hoc fullscreen calls and per-screen re-entry logic caused stale fullscreen to persist across route transitions and inconsistent back/exit flows that this change aims to eliminate.

### Description
- Core change: add a shared fullscreen helper (`lib/fullscreen.ts`) and move all fullscreen enter/exit calls to route- and surface-aware paths (updated `FullscreenAppLayout`, `KioskLayout`, POS pages, and app shell) and tightened native ownership in `MainActivity` on Android. 
- Implementation summary — old fullscreen owners found: `FullscreenAppLayout` aggressive auto-reentry/prompt, `KioskLayout` reattempt-on-loss flow, and Android `MainActivity` native immersive logic (plus scattered ad-hoc `document` fullscreen calls). 
- Implementation summary — route leaks removed: explicit `exitDocumentFullscreen()` before navigating away from POS/take-payment/launcher, kiosk admin exit now exits fullscreen and routes to dashboard, kiosk popstate/back escape is locked while kiosk is active, and app-shell now clears fullscreen on entry to non-owner routes. 
- Implementation summary — final fullscreen rule per surface and web/Android differences: Dashboard and Customer app never force fullscreen; Take Payment never forces fullscreen; POS is optional fullscreen only (respect user exit) on web and Android; Kiosk remains fullscreen while active and on web shows a blocking tap-to-reenter overlay when fullscreen is lost; KOD is treated as fullscreen-capable and is now included in Android immersive ownership; web requires user activation so the site shows a blocking overlay rather than silently re-entering fullscreen while Android re-applies immersive natively. 

### Testing
- Type-check: ran `npx tsc --noEmit` and it completed successfully. 
- Build: ran `npm run build` which completed compilation but page-data collection failed during the build due to a missing server env (`SUPABASE_URL`) in this environment, so compile/time-of-build verification passed but full static page-data collection could not complete here. 
- Runtime/manual E2E flows (Android immersive behavior, browser fullscreen/back flows and kiosk tap-to-reenter) require device/browser interaction and were not executed in this CI environment, so those acceptance scenarios should be validated in a browser and on an Android device as part of QA.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8edf2ec6483258793e583eae92ed0)