### PR TITLE
fix(fullscreen): rollback broken route-bridge fullscreen pass

### DIFF
--- a/android/app/src/main/java/com/orderfast/app/MainActivity.java
+++ b/android/app/src/main/java/com/orderfast/app/MainActivity.java
@@ -7,21 +7,25 @@ import android.app.Application;
 import android.content.res.Configuration;
 import android.content.Intent;
 import android.net.Uri;
-import android.util.Log;
 import android.view.View;
 import android.view.WindowManager;
 import android.view.WindowInsets;
 import android.view.WindowInsetsController;
-import android.webkit.JavascriptInterface;
+import android.webkit.WebBackForwardList;
 
 import com.getcapacitor.BridgeActivity;
 import android.webkit.WebView;
 
 public class MainActivity extends BridgeActivity {
-    private static final String IMMERSIVE_LOG_TAG = "OrderfastImmersive";
-
     private final Handler immersiveHandler = new Handler(Looper.getMainLooper());
-    private final Runnable immersiveRunnable = this::reevaluateImmersiveMode;
+    private final Runnable immersiveRunnable = this::applyImmersiveMode;
+    private final Runnable immersiveRouteMonitorRunnable = new Runnable() {
+        @Override
+        public void run() {
+            reevaluateImmersiveMode();
+            immersiveHandler.postDelayed(this, 900);
+        }
+    };
     private static volatile boolean hostActivityWasPaused = false;
     private static volatile boolean hostActivityWasStopped = false;
     private static volatile boolean hostActivityWasDestroyed = false;
@@ -48,7 +52,6 @@ public class MainActivity extends BridgeActivity {
     private static volatile int hostActivityResumeCount = 0;
     private static volatile int hostActivityNewIntentCount = 0;
     private static volatile int lastKnownOrientationValue = Configuration.ORIENTATION_UNDEFINED;
-    private static volatile String lastSignaledRoute = null;
 
     public static boolean getHostActivityWasPaused() { return hostActivityWasPaused; }
     public static boolean getHostActivityWasStopped() { return hostActivityWasStopped; }
@@ -96,20 +99,7 @@ public class MainActivity extends BridgeActivity {
         hostActivityLastNewIntentAtMs = 0L;
         hostActivityResumeCount = 0;
         hostActivityNewIntentCount = 0;
-        lastSignaledRoute = null;
         lastHostLifecycleUpdateAtMs = System.currentTimeMillis();
-    }
-
-    private final class AndroidRouteBridge {
-        @JavascriptInterface
-        public void setCurrentRoute(String route) {
-            String normalized = normalizeRouteSignal(route);
-            runOnUiThread(() -> {
-                lastSignaledRoute = normalized;
-                Log.d(IMMERSIVE_LOG_TAG, "route signal received route=" + normalized);
-                reevaluateImmersiveMode();
-            });
-        }
     }
 
     private boolean shouldSuppressHostUiChurn() {
@@ -119,7 +109,8 @@ public class MainActivity extends BridgeActivity {
         if (OrderfastTapToPayPlugin.isNativeTapToPayProcessInFlight()) {
             return true;
         }
-        return isPosPaymentEntryRoute(lastSignaledRoute);
+        WebView webView = bridge != null ? bridge.getWebView() : null;
+        return isPosPaymentEntryRoute(webView);
     }
 
     @Override
@@ -132,22 +123,20 @@ public class MainActivity extends BridgeActivity {
         lastKnownOrientationValue = getResources().getConfiguration().orientation;
         lastHostLifecycleUpdateAtMs = System.currentTimeMillis();
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-        lastSignaledRoute = null;
-        clearImmersiveMode("cold_launch_default_non_immersive");
+        clearImmersiveMode();
+        immersiveHandler.postDelayed(this::reevaluateImmersiveMode, 220);
+        immersiveHandler.postDelayed(immersiveRouteMonitorRunnable, 400);
         configureWebViewPresentation();
-        immersiveHandler.postDelayed(immersiveRunnable, 180);
     }
 
     @Override
     public void onBackPressed() {
         WebView webView = bridge != null ? bridge.getWebView() : null;
-        if (isKioskRoute(lastSignaledRoute)) {
-            if (webView != null) {
-                webView.evaluateJavascript(
-                    "window.dispatchEvent(new CustomEvent('orderfast:kiosk-back-blocked'));",
-                    null
-                );
-            }
+        if (isKioskRoute(webView)) {
+            webView.evaluateJavascript(
+                "window.dispatchEvent(new CustomEvent('orderfast:kiosk-back-blocked'));",
+                null
+            );
             return;
         }
 
@@ -169,7 +158,8 @@ public class MainActivity extends BridgeActivity {
         updateHostIntentTelemetry(getIntent());
         hostActivityCurrentOrientation = orientationToName(getResources().getConfiguration().orientation);
         lastHostLifecycleUpdateAtMs = System.currentTimeMillis();
-        immersiveHandler.post(immersiveRunnable);
+        immersiveHandler.postDelayed(this::reevaluateImmersiveMode, 120);
+        immersiveHandler.postDelayed(immersiveRouteMonitorRunnable, 400);
     }
 
     @Override
@@ -200,6 +190,7 @@ public class MainActivity extends BridgeActivity {
         immersiveModeActive = false;
         lastHostLifecycleUpdateAtMs = System.currentTimeMillis();
         immersiveHandler.removeCallbacks(immersiveRunnable);
+        immersiveHandler.removeCallbacks(immersiveRouteMonitorRunnable);
         super.onPause();
     }
 
@@ -209,6 +200,7 @@ public class MainActivity extends BridgeActivity {
         hostActivityLastStoppedAtMs = System.currentTimeMillis();
         lastHostLifecycleUpdateAtMs = System.currentTimeMillis();
         immersiveHandler.removeCallbacks(immersiveRunnable);
+        immersiveHandler.removeCallbacks(immersiveRouteMonitorRunnable);
         super.onStop();
     }
 
@@ -219,6 +211,7 @@ public class MainActivity extends BridgeActivity {
         immersiveModeActive = false;
         lastHostLifecycleUpdateAtMs = System.currentTimeMillis();
         immersiveHandler.removeCallbacks(immersiveRunnable);
+        immersiveHandler.removeCallbacks(immersiveRouteMonitorRunnable);
         super.onDestroy();
     }
 
@@ -231,10 +224,13 @@ public class MainActivity extends BridgeActivity {
             windowFocusChangedDuringPayment = true;
         }
         if (!hasFocus) {
+            immersiveModeActive = false;
             immersiveHandler.removeCallbacks(immersiveRunnable);
+            immersiveHandler.removeCallbacks(immersiveRouteMonitorRunnable);
             return;
         }
-        immersiveHandler.post(immersiveRunnable);
+        immersiveHandler.post(this::reevaluateImmersiveMode);
+        immersiveHandler.postDelayed(immersiveRouteMonitorRunnable, 300);
     }
 
     @Override
@@ -251,7 +247,7 @@ public class MainActivity extends BridgeActivity {
         lastHostLifecycleUpdateAtMs = System.currentTimeMillis();
     }
 
-    private void applyImmersiveMode(String reason, String route) {
+    private void applyImmersiveMode() {
         if (getWindow() == null || getWindow().getDecorView() == null) {
             return;
         }
@@ -260,7 +256,6 @@ public class MainActivity extends BridgeActivity {
             immersiveReappliedDuringPayment = true;
         }
         lastHostLifecycleUpdateAtMs = System.currentTimeMillis();
-        Log.d(IMMERSIVE_LOG_TAG, "apply immersive reason=" + reason + " route=" + route);
 
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
             getWindow().setDecorFitsSystemWindows(false);
@@ -283,13 +278,12 @@ public class MainActivity extends BridgeActivity {
         getWindow().getDecorView().setSystemUiVisibility(flags);
     }
 
-    private void clearImmersiveMode(String reason) {
+    private void clearImmersiveMode() {
         if (getWindow() == null || getWindow().getDecorView() == null) {
             return;
         }
         immersiveModeActive = false;
         lastHostLifecycleUpdateAtMs = System.currentTimeMillis();
-        Log.d(IMMERSIVE_LOG_TAG, "clear immersive reason=" + reason + " route=" + lastSignaledRoute);
 
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
             getWindow().setDecorFitsSystemWindows(true);
@@ -305,20 +299,15 @@ public class MainActivity extends BridgeActivity {
     }
 
     private void reevaluateImmersiveMode() {
-        String activeRoute = resolveActiveRouteFromSignal();
-        if (activeRoute == null) {
-            clearImmersiveMode("route_unknown_default_clear");
-            return;
-        }
         if (shouldSuppressHostUiChurn()) {
-            clearImmersiveMode("payment_guard_active");
+            clearImmersiveMode();
             return;
         }
-        if (shouldEnforceImmersiveForRoute(activeRoute)) {
-            applyImmersiveMode("route_owner_confirmed", activeRoute);
+        if (shouldEnforceImmersiveForRoute()) {
+            applyImmersiveMode();
             return;
         }
-        clearImmersiveMode("route_non_owner");
+        clearImmersiveMode();
     }
 
     private String orientationToName(int orientation) {
@@ -335,48 +324,70 @@ public class MainActivity extends BridgeActivity {
             return;
         }
 
-        webView.addJavascriptInterface(new AndroidRouteBridge(), "OrderfastAndroidRouteBridge");
         webView.setVerticalScrollBarEnabled(false);
         webView.setHorizontalScrollBarEnabled(false);
         webView.setOverScrollMode(View.OVER_SCROLL_NEVER);
     }
 
-    private boolean isKioskRoute(String route) {
-        Uri uri = parseRouteUri(route);
-        if (uri == null) {
+    private boolean isKioskRoute(WebView webView) {
+        if (webView == null) {
             return false;
         }
-        String path = uri.getPath();
-        return path != null && path.startsWith("/kiosk");
+
+        String currentUrl = webView.getUrl();
+        if (currentUrl != null && currentUrl.contains("/kiosk/")) {
+            return true;
+        }
+
+        WebBackForwardList history = webView.copyBackForwardList();
+        if (history == null) {
+            return false;
+        }
+
+        int currentIndex = history.getCurrentIndex();
+        if (currentIndex < 0) {
+            return false;
+        }
+
+        String historyUrl = history.getItemAtIndex(currentIndex).getUrl();
+        return historyUrl != null && historyUrl.contains("/kiosk/");
     }
 
-    private boolean isPosPaymentEntryRoute(String route) {
-        Uri uri = parseRouteUri(route);
-        if (uri == null) {
+    private boolean isPosPaymentEntryRoute(WebView webView) {
+        if (webView == null) {
             return false;
         }
+
+        String currentUrl = webView.getUrl();
+        if (currentUrl != null && currentUrl.contains("/payment-entry")) {
+            return true;
+        }
+
+        WebBackForwardList history = webView.copyBackForwardList();
+        if (history == null) {
+            return false;
+        }
+
+        int currentIndex = history.getCurrentIndex();
+        if (currentIndex < 0) {
+            return false;
+        }
+
+        String historyUrl = history.getItemAtIndex(currentIndex).getUrl();
+        return historyUrl != null && historyUrl.contains("/payment-entry");
+    }
+
+    private boolean shouldEnforceImmersiveForRoute() {
+        WebView webView = bridge != null ? bridge.getWebView() : null;
+        String routeUrl = resolveCurrentRouteUrl(webView);
+        if (routeUrl == null || routeUrl.isEmpty()) {
+            return false;
+        }
+        Uri uri = Uri.parse(routeUrl);
         String path = uri.getPath();
         if (path == null) {
             return false;
         }
-        return path.startsWith("/payment-entry") || path.contains("/payment-entry");
-    }
-
-    private boolean shouldEnforceImmersiveForRoute(String route) {
-        Uri uri = parseRouteUri(route);
-        if (uri == null) {
-            return false;
-        }
-
-        String path = uri.getPath();
-        if (path == null || path.isEmpty()) {
-            return false;
-        }
-
-        if (path.startsWith("/payment-entry")) {
-            return false;
-        }
-
         if (path.startsWith("/kiosk")) {
             return true;
         }
@@ -399,45 +410,23 @@ public class MainActivity extends BridgeActivity {
             || normalized.equals("on");
     }
 
-    private String resolveActiveRouteFromSignal() {
-        String normalized = normalizeRouteSignal(lastSignaledRoute);
-        if (normalized == null) {
-            Log.d(IMMERSIVE_LOG_TAG, "route unresolved (no signal)");
+    private String resolveCurrentRouteUrl(WebView webView) {
+        if (webView == null) {
             return null;
         }
-        Log.d(IMMERSIVE_LOG_TAG, "route resolved route=" + normalized);
-        return normalized;
-    }
-
-    private String normalizeRouteSignal(String route) {
-        if (route == null) {
+        String currentUrl = webView.getUrl();
+        if (currentUrl != null && !currentUrl.isEmpty()) {
+            return currentUrl;
+        }
+        WebBackForwardList history = webView.copyBackForwardList();
+        if (history == null) {
             return null;
         }
-        String trimmed = route.trim();
-        if (trimmed.isEmpty()) {
+        int currentIndex = history.getCurrentIndex();
+        if (currentIndex < 0) {
             return null;
         }
-        return trimmed;
-    }
-
-    private Uri parseRouteUri(String route) {
-        String normalized = normalizeRouteSignal(route);
-        if (normalized == null) {
-            return null;
-        }
-
-        try {
-            if (normalized.startsWith("http://") || normalized.startsWith("https://")) {
-                return Uri.parse(normalized);
-            }
-            if (normalized.startsWith("/")) {
-                return Uri.parse("https://orderfast.local" + normalized);
-            }
-            return Uri.parse("https://orderfast.local/" + normalized);
-        } catch (Exception ignored) {
-            Log.d(IMMERSIVE_LOG_TAG, "route parse failed route=" + normalized);
-            return null;
-        }
+        return history.getItemAtIndex(currentIndex).getUrl();
     }
 
     private void updateHostIdentity() {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -14,28 +14,11 @@ import { supabase } from '../utils/supabaseClient';
 import { RestaurantProvider } from '@/lib/restaurant-context';
 import { exitDocumentFullscreen } from '@/lib/fullscreen';
 
-
-type AndroidRouteBridgeWindow = Window & {
-  OrderfastAndroidRouteBridge?: {
-    setCurrentRoute?: (route: string) => void;
-  };
-};
-
 export default function App({ Component, pageProps }: AppProps) {
   const router = useRouter();
   const isRestaurantRoute = router.pathname.startsWith('/restaurant');
   const isKioskRoute = router.pathname.startsWith('/kiosk') || router.asPath.startsWith('/kiosk');
   const manifestHref = isKioskRoute ? '/kiosk.webmanifest' : '/site.webmanifest';
-
-
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const bridge = (window as AndroidRouteBridgeWindow).OrderfastAndroidRouteBridge;
-    const setCurrentRoute = bridge?.setCurrentRoute;
-    if (typeof setCurrentRoute !== 'function') return;
-    setCurrentRoute(router.asPath || router.pathname || '/');
-  }, [router.asPath, router.pathname]);
 
   useEffect(() => {
     const currentPath = router.asPath.split('?')[0] || '';


### PR DESCRIPTION
### Motivation
- Restore app bootability by reverting the last fullscreen pass that introduced a client-side exception screen. 
- Limit rollback to the two affected files so recovery is surgical and other work is unaffected. 
- Determine whether the crash originated from the web runtime changes or the native Android changes before attempting a safer follow-up.

### Description
- Reverted the Android route-bridge signaling and related changes from `pages/_app.tsx`, restoring the prior app-level fullscreen exit behavior. 
- Restored `android/app/src/main/java/com/orderfast/app/MainActivity.java` to the previous immersive-mode lifecycle and WebView route-resolution behavior (WebView URL/history based) and re-enabled the prior scheduling/teardown of immersive checks. 
- Changes were strictly limited to those two files and removed the bridge-based route signaling that could surface web runtime exceptions. 
- Assessment: the `_app.tsx` route-bridge web runtime changes are the most likely direct cause of the client-side exception, while the Android native adjustments were part of the same fullscreen pass and were reverted for safety; both files are now returned to their last working state.

### Testing
- Attempted production build with `npm run build`, which failed due to a pre-existing missing server env (`SUPABASE_URL`) during page data collection and is unrelated to this rollback. 
- Verified development server startup and responsiveness by running `next dev` and performing an HTTP request to `http://localhost:3000`, which returned HTTP 200 and showed successful compile/start. 
- Confirmed automated type checks that run during build were invoked (build failure was due to env), and no new runtime web exception is observed in the dev startup verification for the reverted state.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e906d892e88325bcce8c437f22efd5)