### PR TITLE
fix(android): constrain immersive ownership to trusted fullscreen routes

### DIFF
--- a/android/app/src/main/java/com/orderfast/app/MainActivity.java
+++ b/android/app/src/main/java/com/orderfast/app/MainActivity.java
@@ -7,25 +7,18 @@ import android.app.Application;
 import android.content.res.Configuration;
 import android.content.Intent;
 import android.net.Uri;
+import android.util.Log;
 import android.view.View;
 import android.view.WindowManager;
 import android.view.WindowInsets;
 import android.view.WindowInsetsController;
-import android.webkit.WebBackForwardList;
 
 import com.getcapacitor.BridgeActivity;
 import android.webkit.WebView;
 
 public class MainActivity extends BridgeActivity {
+    private static final String TAG = "OrderfastFullscreen";
     private final Handler immersiveHandler = new Handler(Looper.getMainLooper());
-    private final Runnable immersiveRunnable = this::applyImmersiveMode;
-    private final Runnable immersiveRouteMonitorRunnable = new Runnable() {
-        @Override
-        public void run() {
-            reevaluateImmersiveMode();
-            immersiveHandler.postDelayed(this, 900);
-        }
-    };
     private static volatile boolean hostActivityWasPaused = false;
     private static volatile boolean hostActivityWasStopped = false;
     private static volatile boolean hostActivityWasDestroyed = false;
@@ -125,7 +118,6 @@ public class MainActivity extends BridgeActivity {
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
         clearImmersiveMode();
         immersiveHandler.postDelayed(this::reevaluateImmersiveMode, 220);
-        immersiveHandler.postDelayed(immersiveRouteMonitorRunnable, 400);
         configureWebViewPresentation();
     }
 
@@ -159,7 +151,6 @@ public class MainActivity extends BridgeActivity {
         hostActivityCurrentOrientation = orientationToName(getResources().getConfiguration().orientation);
         lastHostLifecycleUpdateAtMs = System.currentTimeMillis();
         immersiveHandler.postDelayed(this::reevaluateImmersiveMode, 120);
-        immersiveHandler.postDelayed(immersiveRouteMonitorRunnable, 400);
     }
 
     @Override
@@ -189,8 +180,7 @@ public class MainActivity extends BridgeActivity {
         hostActivityLastPausedAtMs = System.currentTimeMillis();
         immersiveModeActive = false;
         lastHostLifecycleUpdateAtMs = System.currentTimeMillis();
-        immersiveHandler.removeCallbacks(immersiveRunnable);
-        immersiveHandler.removeCallbacks(immersiveRouteMonitorRunnable);
+        immersiveHandler.removeCallbacksAndMessages(null);
         super.onPause();
     }
 
@@ -199,8 +189,7 @@ public class MainActivity extends BridgeActivity {
         hostActivityWasStopped = true;
         hostActivityLastStoppedAtMs = System.currentTimeMillis();
         lastHostLifecycleUpdateAtMs = System.currentTimeMillis();
-        immersiveHandler.removeCallbacks(immersiveRunnable);
-        immersiveHandler.removeCallbacks(immersiveRouteMonitorRunnable);
+        immersiveHandler.removeCallbacksAndMessages(null);
         super.onStop();
     }
 
@@ -210,8 +199,7 @@ public class MainActivity extends BridgeActivity {
         hostActivityLastDestroyedAtMs = System.currentTimeMillis();
         immersiveModeActive = false;
         lastHostLifecycleUpdateAtMs = System.currentTimeMillis();
-        immersiveHandler.removeCallbacks(immersiveRunnable);
-        immersiveHandler.removeCallbacks(immersiveRouteMonitorRunnable);
+        immersiveHandler.removeCallbacksAndMessages(null);
         super.onDestroy();
     }
 
@@ -225,12 +213,10 @@ public class MainActivity extends BridgeActivity {
         }
         if (!hasFocus) {
             immersiveModeActive = false;
-            immersiveHandler.removeCallbacks(immersiveRunnable);
-            immersiveHandler.removeCallbacks(immersiveRouteMonitorRunnable);
+            immersiveHandler.removeCallbacksAndMessages(null);
             return;
         }
         immersiveHandler.post(this::reevaluateImmersiveMode);
-        immersiveHandler.postDelayed(immersiveRouteMonitorRunnable, 300);
     }
 
     @Override
@@ -300,13 +286,22 @@ public class MainActivity extends BridgeActivity {
 
     private void reevaluateImmersiveMode() {
         if (shouldSuppressHostUiChurn()) {
+            logImmersiveDecision("clear", "suppressed_for_tap_to_pay_or_payment_entry");
             clearImmersiveMode();
             return;
         }
-        if (shouldEnforceImmersiveForRoute()) {
+        String routePath = resolveCurrentRoutePath();
+        if (routePath == null) {
+            logImmersiveDecision("clear", "route_unknown");
+            clearImmersiveMode();
+            return;
+        }
+        if (shouldEnforceImmersiveForPath(routePath)) {
+            logImmersiveDecision("apply", routePath);
             applyImmersiveMode();
             return;
         }
+        logImmersiveDecision("clear", routePath);
         clearImmersiveMode();
     }
 
@@ -330,64 +325,16 @@ public class MainActivity extends BridgeActivity {
     }
 
     private boolean isKioskRoute(WebView webView) {
-        if (webView == null) {
-            return false;
-        }
-
-        String currentUrl = webView.getUrl();
-        if (currentUrl != null && currentUrl.contains("/kiosk/")) {
-            return true;
-        }
-
-        WebBackForwardList history = webView.copyBackForwardList();
-        if (history == null) {
-            return false;
-        }
-
-        int currentIndex = history.getCurrentIndex();
-        if (currentIndex < 0) {
-            return false;
-        }
-
-        String historyUrl = history.getItemAtIndex(currentIndex).getUrl();
-        return historyUrl != null && historyUrl.contains("/kiosk/");
+        String path = resolvePathFromWebView(webView);
+        return path != null && path.startsWith("/kiosk");
     }
 
     private boolean isPosPaymentEntryRoute(WebView webView) {
-        if (webView == null) {
-            return false;
-        }
-
-        String currentUrl = webView.getUrl();
-        if (currentUrl != null && currentUrl.contains("/payment-entry")) {
-            return true;
-        }
-
-        WebBackForwardList history = webView.copyBackForwardList();
-        if (history == null) {
-            return false;
-        }
-
-        int currentIndex = history.getCurrentIndex();
-        if (currentIndex < 0) {
-            return false;
-        }
-
-        String historyUrl = history.getItemAtIndex(currentIndex).getUrl();
-        return historyUrl != null && historyUrl.contains("/payment-entry");
+        String path = resolvePathFromWebView(webView);
+        return path != null && path.contains("/payment-entry");
     }
 
-    private boolean shouldEnforceImmersiveForRoute() {
-        WebView webView = bridge != null ? bridge.getWebView() : null;
-        String routeUrl = resolveCurrentRouteUrl(webView);
-        if (routeUrl == null || routeUrl.isEmpty()) {
-            return false;
-        }
-        Uri uri = Uri.parse(routeUrl);
-        String path = uri.getPath();
-        if (path == null) {
-            return false;
-        }
+    private boolean shouldEnforceImmersiveForPath(String path) {
         if (path.startsWith("/kiosk")) {
             return true;
         }
@@ -395,6 +342,10 @@ public class MainActivity extends BridgeActivity {
             return true;
         }
         if (path.startsWith("/pos")) {
+            Uri uri = resolveCurrentRouteUri();
+            if (uri == null) {
+                return false;
+            }
             return hasPosFullscreenOptIn(uri) && !path.contains("/payment-entry");
         }
         return false;
@@ -410,23 +361,49 @@ public class MainActivity extends BridgeActivity {
             || normalized.equals("on");
     }
 
-    private String resolveCurrentRouteUrl(WebView webView) {
+    private Uri resolveCurrentRouteUri() {
+        WebView webView = bridge != null ? bridge.getWebView() : null;
         if (webView == null) {
             return null;
         }
         String currentUrl = webView.getUrl();
-        if (currentUrl != null && !currentUrl.isEmpty()) {
-            return currentUrl;
-        }
-        WebBackForwardList history = webView.copyBackForwardList();
-        if (history == null) {
+        if (currentUrl == null || currentUrl.isEmpty()) {
             return null;
         }
-        int currentIndex = history.getCurrentIndex();
-        if (currentIndex < 0) {
+        try {
+            return Uri.parse(currentUrl);
+        } catch (Exception ignored) {
             return null;
         }
-        return history.getItemAtIndex(currentIndex).getUrl();
+    }
+
+    private String resolveCurrentRoutePath() {
+        WebView webView = bridge != null ? bridge.getWebView() : null;
+        return resolvePathFromWebView(webView);
+    }
+
+    private String resolvePathFromWebView(WebView webView) {
+        if (webView == null) {
+            return null;
+        }
+        String currentUrl = webView.getUrl();
+        if (currentUrl == null || currentUrl.isEmpty()) {
+            return null;
+        }
+        try {
+            Uri uri = Uri.parse(currentUrl);
+            String path = uri.getPath();
+            if (path == null || path.isEmpty()) {
+                return null;
+            }
+            return path;
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private void logImmersiveDecision(String action, String detail) {
+        Log.d(TAG, "immersive_decision action=" + action + " detail=" + detail);
     }
 
     private void updateHostIdentity() {


### PR DESCRIPTION
### Motivation
- The Android app was repeatedly entering immersive fullscreen from login onward due to overly aggressive native ownership and a repeating monitor loop in `MainActivity`, causing non-owner surfaces to hide system UI.
- This change must be Android-native only, avoid touching `pages/_app.tsx`, and preserve existing web fullscreen/kiosk/logout/POS exit/route-cleanup behavior.

### Description
- Modified only `android/app/src/main/java/com/orderfast/app/MainActivity.java` to tighten native fullscreen ownership and add minimal diagnostic logging.
- Removed the repeating immersive monitor loop and reduced reevaluation to one-shot lifecycle checks (`onCreate`, `onResume`, `onWindowFocusChanged`), using `Handler` one-shots and `removeCallbacksAndMessages(null)` to prevent sticky reapplication.
- Made cold-start explicitly non-immersive by calling `clearImmersiveMode()` in `onCreate`, and defaulted unknown/stale route state to clearing immersive rather than applying it.
- Switched route detection to parse the current `WebView.getUrl()` path via `resolvePathFromWebView(...)` (no history fallback and no web-to-native bridge), and enforced ownership only for trusted paths: `/kiosk*` => immersive, `/kod*` => immersive, `/pos*` => immersive only with explicit `?fullscreen=` opt-in (and never on `/payment-entry`), and all other routes => immersive off; added `logImmersiveDecision` for safe diagnostics.

### Testing
- Attempted an automated Java compile with `./gradlew :app:compileDebugJavaWithJavac`, which could not complete in this environment due to missing Android SDK configuration (`ANDROID_HOME` / `android/local.properties`), so no APK was produced.
- No other automated tests were run in this environment; the change is limited to a single native file and preserves Tap-to-Pay suppression logic while avoiding any `_app.tsx` or bridge modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9dd8a800c8325a461b236ead86c7c)