### PR TITLE
fix(android): neutralize startup URL and tighten fullscreen ownership

### DIFF
--- a/android/app/src/main/java/com/orderfast/app/MainActivity.java
+++ b/android/app/src/main/java/com/orderfast/app/MainActivity.java
@@ -19,6 +19,14 @@ import android.webkit.WebView;
 public class MainActivity extends BridgeActivity {
     private static final String TAG = "OrderfastFullscreen";
     private final Handler immersiveHandler = new Handler(Looper.getMainLooper());
+    private static final long IMMERSIVE_ROUTE_RECHECK_MS = 500L;
+    private final Runnable immersiveRouteMonitor = new Runnable() {
+        @Override
+        public void run() {
+            reevaluateImmersiveMode();
+            immersiveHandler.postDelayed(this, IMMERSIVE_ROUTE_RECHECK_MS);
+        }
+    };
     private static volatile boolean hostActivityWasPaused = false;
     private static volatile boolean hostActivityWasStopped = false;
     private static volatile boolean hostActivityWasDestroyed = false;
@@ -117,7 +125,7 @@ public class MainActivity extends BridgeActivity {
         lastHostLifecycleUpdateAtMs = System.currentTimeMillis();
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
         clearImmersiveMode();
-        immersiveHandler.postDelayed(this::reevaluateImmersiveMode, 220);
+        startImmersiveRouteMonitor(220L);
         configureWebViewPresentation();
     }
 
@@ -150,7 +158,7 @@ public class MainActivity extends BridgeActivity {
         updateHostIntentTelemetry(getIntent());
         hostActivityCurrentOrientation = orientationToName(getResources().getConfiguration().orientation);
         lastHostLifecycleUpdateAtMs = System.currentTimeMillis();
-        immersiveHandler.postDelayed(this::reevaluateImmersiveMode, 120);
+        startImmersiveRouteMonitor(120L);
     }
 
     @Override
@@ -180,7 +188,7 @@ public class MainActivity extends BridgeActivity {
         hostActivityLastPausedAtMs = System.currentTimeMillis();
         immersiveModeActive = false;
         lastHostLifecycleUpdateAtMs = System.currentTimeMillis();
-        immersiveHandler.removeCallbacksAndMessages(null);
+        stopImmersiveRouteMonitor();
         super.onPause();
     }
 
@@ -189,7 +197,7 @@ public class MainActivity extends BridgeActivity {
         hostActivityWasStopped = true;
         hostActivityLastStoppedAtMs = System.currentTimeMillis();
         lastHostLifecycleUpdateAtMs = System.currentTimeMillis();
-        immersiveHandler.removeCallbacksAndMessages(null);
+        stopImmersiveRouteMonitor();
         super.onStop();
     }
 
@@ -199,7 +207,7 @@ public class MainActivity extends BridgeActivity {
         hostActivityLastDestroyedAtMs = System.currentTimeMillis();
         immersiveModeActive = false;
         lastHostLifecycleUpdateAtMs = System.currentTimeMillis();
-        immersiveHandler.removeCallbacksAndMessages(null);
+        stopImmersiveRouteMonitor();
         super.onDestroy();
     }
 
@@ -213,10 +221,10 @@ public class MainActivity extends BridgeActivity {
         }
         if (!hasFocus) {
             immersiveModeActive = false;
-            immersiveHandler.removeCallbacksAndMessages(null);
+            stopImmersiveRouteMonitor();
             return;
         }
-        immersiveHandler.post(this::reevaluateImmersiveMode);
+        startImmersiveRouteMonitor(0L);
     }
 
     @Override
@@ -335,6 +343,9 @@ public class MainActivity extends BridgeActivity {
     }
 
     private boolean shouldEnforceImmersiveForPath(String path) {
+        if (isExplicitNonImmersivePath(path)) {
+            return false;
+        }
         if (path.startsWith("/kiosk")) {
             return true;
         }
@@ -349,6 +360,14 @@ public class MainActivity extends BridgeActivity {
             return hasPosFullscreenOptIn(uri) && !path.contains("/payment-entry");
         }
         return false;
+    }
+
+    private boolean isExplicitNonImmersivePath(String path) {
+        return path.startsWith("/login")
+            || path.startsWith("/dashboard")
+            || path.startsWith("/customer")
+            || path.startsWith("/take-payment")
+            || path.contains("/payment-entry");
     }
 
     private boolean hasPosFullscreenOptIn(Uri uri) {
@@ -404,6 +423,15 @@ public class MainActivity extends BridgeActivity {
 
     private void logImmersiveDecision(String action, String detail) {
         Log.d(TAG, "immersive_decision action=" + action + " detail=" + detail);
+    }
+
+    private void startImmersiveRouteMonitor(long delayMs) {
+        immersiveHandler.removeCallbacks(immersiveRouteMonitor);
+        immersiveHandler.postDelayed(immersiveRouteMonitor, Math.max(delayMs, 0L));
+    }
+
+    private void stopImmersiveRouteMonitor() {
+        immersiveHandler.removeCallbacks(immersiveRouteMonitor);
     }
 
     private void updateHostIdentity() {

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -5,7 +5,7 @@ const config: CapacitorConfig = {
   appName: 'OFtaptest2',
   webDir: 'www',
   server: {
-    url: 'https://orderfast.vercel.app/dashboard/launcher',
+    url: 'https://orderfast.vercel.app/',
   },
 };
 


### PR DESCRIPTION
### Motivation
- Cold-starting the Capacitor Android wrapper into `/dashboard/launcher` made the native app boot into a non-neutral web shell, causing fullscreen ownership to be split and persist incorrectly across routes.  
- The goal is to keep the native host non-immersive by default and only grant immersive ownership to explicit fullscreen owners while preserving existing auth/navigation and avoiding `_app.tsx` changes.  

### Description
- Replaced the hardcoded Capacitor startup URL so the app now launches at the neutral root `https://orderfast.vercel.app/` instead of `https://orderfast.vercel.app/dashboard/launcher`.  
- Added a lightweight route-monitor loop in `MainActivity` to re-evaluate immersive state while the host is focused and to start/stop that monitor on lifecycle and focus changes.  
- Added explicit non-immersive route checks and tightened the immersive decision logic so immersive is only applied for `/kiosk...`, `/kod...`, and `/pos...` only when `?fullscreen=` is explicitly opted-in and never on `/payment-entry`; login, dashboard, customer, take-payment, and payment-entry are explicit non-immersive.  
- Files changed: `capacitor.config.ts` and `android/app/src/main/java/com/orderfast/app/MainActivity.java`.  
- Implementation summary: the hardcoded `/dashboard/launcher` startup URL was part of the root cause; the new Android startup route/context is `https://orderfast.vercel.app/`; changed files are `capacitor.config.ts` and `MainActivity.java`; fullscreen is now owned explicitly by native route decisions (owns: `/kiosk...`, `/kod...`, `/pos...` with opt-in) and no longer implicitly owned by the startup web route or general routes like login/dashboard/take-payment/customer.  

### Testing
- Ran `npx tsc --noEmit` and it passed.  
- Attempted `cd android && ./gradlew :app:compileDebugJavaWithJavac --no-daemon`, which could not complete in this environment due to missing Android SDK configuration (`ANDROID_HOME` / `android/local.properties`) and therefore failed to compile; this is an environment limitation rather than a code failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9f1aa0394832580110f6007bc38bb)