### PR TITLE
Update Capacitor `server.url` to point to dashboard launcher

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -5,7 +5,7 @@ const config: CapacitorConfig = {
   appName: 'OFtaptest2',
   webDir: 'www',
   server: {
-    url: 'https://orderfast.vercel.app/',
+    url: 'https://orderfast.vercel.app/dashboard/launcher',
   },
 };
 


### PR DESCRIPTION
### Motivation
- Ensure the Capacitor-hosted webview loads the app at the dashboard launcher route instead of the site root so the native wrapper opens the intended entry point.

### Description
- Change `server.url` in `capacitor.config.ts` from `https://orderfast.vercel.app/` to `https://orderfast.vercel.app/dashboard/launcher`.

### Testing
- No automated tests were run for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2ca7b09c8325889f67e6b49f337a)