### PR TITLE
fix(android-shell): unify non-fullscreen restaurant app shell

### DIFF
--- a/components/layouts/NonFullscreenRestaurantShell.tsx
+++ b/components/layouts/NonFullscreenRestaurantShell.tsx
@@ -1,0 +1,42 @@
+import { type ReactNode } from 'react';
+
+type NonFullscreenRestaurantShellProps = {
+  children: ReactNode;
+  maxWidthClassName?: string;
+  contentClassName?: string;
+};
+
+export default function NonFullscreenRestaurantShell({
+  children,
+  maxWidthClassName = 'max-w-[440px]',
+  contentClassName,
+}: NonFullscreenRestaurantShellProps) {
+  const resolvedContentClassName = ['relative z-10 mx-auto w-full', maxWidthClassName, contentClassName]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className="relative min-h-screen w-full overflow-x-hidden bg-slate-100 text-slate-900">
+      <div
+        aria-hidden
+        className="pointer-events-none fixed inset-x-0 top-0 z-0 bg-slate-950"
+        style={{ height: 'calc(env(safe-area-inset-top, 0px) + 112px)' }}
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none fixed inset-x-0 bottom-0 z-0 bg-slate-950"
+        style={{ height: 'calc(env(safe-area-inset-bottom, 0px) + 82px)' }}
+      />
+
+      <main
+        className="relative min-h-screen px-4"
+        style={{
+          paddingTop: 'calc(env(safe-area-inset-top, 0px) + 14px)',
+          paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 24px)',
+        }}
+      >
+        <div className={resolvedContentClassName}>{children}</div>
+      </main>
+    </div>
+  );
+}

--- a/pages/dashboard/launcher.tsx
+++ b/pages/dashboard/launcher.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import { supabase } from '@/lib/supabaseClient';
+import NonFullscreenRestaurantShell from '@/components/layouts/NonFullscreenRestaurantShell';
 import {
   readLauncherBootstrapSnapshot,
   runLauncherBootstrap,
@@ -336,18 +337,8 @@ export default function DashboardLauncherPage() {
   }, [takePaymentPresentation?.detail, takePaymentUnavailable]);
 
   return (
-    <main
-      style={{
-        minHeight: '100vh',
-        background: 'linear-gradient(180deg, #0f172a 0px, #0f172a 136px, #f8fafc 136px, #f8fafc 100%)',
-        padding: '1rem',
-        paddingTop: 'calc(env(safe-area-inset-top, 0px) + 1rem)',
-        paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 1rem)',
-        display: 'flex',
-        justifyContent: 'center',
-      }}
-    >
-      <div style={{ width: '100%', maxWidth: '420px', display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+    <NonFullscreenRestaurantShell contentClassName="flex flex-col gap-4" maxWidthClassName="max-w-[420px]">
+      <div style={{ width: '100%', display: 'flex', flexDirection: 'column', gap: '1rem' }}>
         <header style={{ marginTop: '0.25rem', paddingTop: '0.25rem' }}>
           <p style={{ margin: 0, fontSize: '0.8rem', color: '#cbd5e1', letterSpacing: '0.08em' }}>ORDERFAST</p>
           <h1 style={{ margin: '0.3rem 0 0', fontSize: '1.5rem', color: '#f8fafc' }}>App launcher</h1>
@@ -507,6 +498,6 @@ export default function DashboardLauncherPage() {
           </>
         ) : null}
       </div>
-    </main>
+    </NonFullscreenRestaurantShell>
   );
 }

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useSupabaseClient } from '@supabase/auth-helpers-react';
 import { useRouter } from 'next/router';
+import NonFullscreenRestaurantShell from '@/components/layouts/NonFullscreenRestaurantShell';
 
 export default function Login() {
   const [email, setEmail] = useState('');
@@ -41,42 +42,39 @@ export default function Login() {
   }, [router, supabase]);
 
   return (
-    <div style={{ padding: '2rem', maxWidth: '400px', margin: 'auto' }}>
-      <h1>Login</h1>
-      <form onSubmit={handleLogin}>
-        <div style={{ marginBottom: '1rem' }}>
-          <input
-            type="email"
-            placeholder="Email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            style={{ width: '100%', padding: '0.5rem' }}
-          />
-        </div>
-        <div style={{ marginBottom: '1rem' }}>
-          <input
-            type="password"
-            placeholder="Password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-            style={{ width: '100%', padding: '0.5rem' }}
-          />
-        </div>
-        <button
-          type="submit"
-          style={{
-            padding: '0.5rem 1rem',
-            backgroundColor: 'black',
-            color: 'white',
-            border: 'none',
-            cursor: 'pointer',
-          }}
-        >
-          Log In
-        </button>
-      </form>
-    </div>
+    <NonFullscreenRestaurantShell contentClassName="flex min-h-[calc(100vh-180px)] items-center" maxWidthClassName="max-w-[420px]">
+      <section className="w-full rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <p className="m-0 text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Orderfast</p>
+        <h1 className="mt-2 text-2xl font-semibold text-slate-900">Login</h1>
+        <form className="mt-5" onSubmit={handleLogin}>
+          <div className="mb-3">
+            <input
+              type="email"
+              placeholder="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="w-full rounded-lg border border-slate-300 px-3 py-2"
+            />
+          </div>
+          <div className="mb-4">
+            <input
+              type="password"
+              placeholder="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              className="w-full rounded-lg border border-slate-300 px-3 py-2"
+            />
+          </div>
+          <button
+            type="submit"
+            className="rounded-lg bg-slate-900 px-4 py-2 font-medium text-white transition hover:bg-black"
+          >
+            Log In
+          </button>
+        </form>
+      </section>
+    </NonFullscreenRestaurantShell>
   );
 }

--- a/pages/pos/[restaurantId]/payment-entry.tsx
+++ b/pages/pos/[restaurantId]/payment-entry.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import InternalSettlementModule from '@/components/payments/InternalSettlementModule';
+import NonFullscreenRestaurantShell from '@/components/layouts/NonFullscreenRestaurantShell';
 
 export default function PosPaymentEntryPage() {
   const router = useRouter();
@@ -18,11 +19,8 @@ export default function PosPaymentEntryPage() {
   }, [flowActive, router]);
 
   return (
-    <div
-      className="min-h-screen w-full bg-gray-900 text-gray-900"
-      style={{ paddingTop: 'env(safe-area-inset-top, 0px)', paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
-    >
-      <div className="w-full px-0 pb-0 pt-2 sm:px-4 sm:py-6">
+    <NonFullscreenRestaurantShell contentClassName="pt-2 sm:pt-6" maxWidthClassName="max-w-none">
+      <div className="w-full px-0 pb-0 sm:px-4">
         <InternalSettlementModule
           restaurantId={restaurantId || null}
           onFlowActivityChange={setFlowActive}
@@ -30,6 +28,6 @@ export default function PosPaymentEntryPage() {
           source={source}
         />
       </div>
-    </div>
+    </NonFullscreenRestaurantShell>
   );
 }


### PR DESCRIPTION
### Motivation
- Android system bars are visible again and multiple non-fullscreen restaurant app pages were bleeding into the status/nav areas, making system icons hard to read and producing inconsistent spacing across login, launcher, and Take Payment.
- Previous fixes were page‑level one-offs; the intent is to introduce a single safe-area-aware non-fullscreen shell to make these surfaces consistent and intentional inside the native wrapper without changing kiosk/fullscreen behavior or payment logic.

### Description
- Add a shared `NonFullscreenRestaurantShell` component that provides top and bottom safe-area padding and fixed dark backdrops behind the status bar and nav bar so system icons remain legible and page content does not bleed into system UI.
- Apply the new shell to the restaurant-facing non-fullscreen surfaces: `pages/login.tsx`, `pages/dashboard/launcher.tsx`, and `pages/pos/[restaurantId]/payment-entry.tsx` (Take Payment entry), removing the duplicated per-page safe-area wrappers in those pages.
- Preserve existing launcher bootstrap / eligibility refresh and focus/pageshow/visibility handlers; no logic changes to launch eligibility, payment execution, kiosk fullscreen ownership, or `_app.tsx` were made.
- Implementation summary: (1) files changed: `components/layouts/NonFullscreenRestaurantShell.tsx`, `pages/login.tsx`, `pages/dashboard/launcher.tsx`, `pages/pos/[restaurantId]/payment-entry.tsx`; (2) shared shell introduced: `NonFullscreenRestaurantShell` with safe-area padding and top/bottom contrast backdrops; (3) screens now using it: Login, Launcher, Take Payment entry; (4) page-specific hacks removed/reduced: inline launcher background/padding and the payment-entry inline safe-area padding were removed in favor of the shared shell; (5) safety: centralizing shell behavior reduces ad-hoc divergence across pages and lowers regression risk compared to continuing page-by-page tweaks.

### Testing
- Ran type check with `npx tsc --noEmit`, which completed successfully.
- Ran `npm run build`, which failed in this environment due to a missing server environment variable (`SUPABASE_URL`) while collecting page data for `/restaurant`, and this failure is unrelated to the UI shell changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea444d73648325bed737103bd40077)