### PR TITLE
fix(android): correct global system bar insets and contrast handling

### DIFF
--- a/android/app/src/main/java/com/orderfast/app/MainActivity.java
+++ b/android/app/src/main/java/com/orderfast/app/MainActivity.java
@@ -7,6 +7,7 @@ import android.app.Application;
 import android.content.res.Configuration;
 import android.content.Intent;
 import android.net.Uri;
+import android.graphics.Color;
 import android.util.Log;
 import android.view.View;
 import android.view.WindowManager;
@@ -287,6 +288,9 @@ public class MainActivity extends BridgeActivity {
         }
         immersiveModeActive = false;
         lastHostLifecycleUpdateAtMs = System.currentTimeMillis();
+        final int systemBarColor = Color.parseColor("#F8FAFC");
+        getWindow().setStatusBarColor(systemBarColor);
+        getWindow().setNavigationBarColor(systemBarColor);
 
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
             getWindow().setDecorFitsSystemWindows(true);
@@ -294,6 +298,12 @@ public class MainActivity extends BridgeActivity {
             if (controller != null) {
                 controller.show(WindowInsets.Type.statusBars() | WindowInsets.Type.navigationBars());
                 controller.setSystemBarsBehavior(WindowInsetsController.BEHAVIOR_DEFAULT);
+                controller.setSystemBarsAppearance(
+                    WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS
+                        | WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS,
+                    WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS
+                        | WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS
+                );
             }
             getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
             getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
@@ -301,7 +311,14 @@ public class MainActivity extends BridgeActivity {
         }
 
         getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-        getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
+        int flags = View.SYSTEM_UI_FLAG_VISIBLE;
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+            flags |= View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
+        }
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+            flags |= View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR;
+        }
+        getWindow().getDecorView().setSystemUiVisibility(flags);
     }
 
     private void reevaluateImmersiveMode() {

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="#F8FAFC"
     tools:context=".MainActivity">
 
     <WebView

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -13,6 +13,12 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="android:background">@null</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:statusBarColor">#F8FAFC</item>
+        <item name="android:navigationBarColor">#F8FAFC</item>
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowLightNavigationBar">true</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
     </style>
 
 


### PR DESCRIPTION
### Motivation
- Regular app screens were rendering too close to or underneath the Android status and navigation bars because the native host did not fully restore a non-edge-to-edge system UI state on modern Android (targetSdk 35).
- The route-based immersive logic left non-immersive routes without explicit system-bar colors/appearance and decor fitting, causing content to visually overlap system bars.
- The smallest safe fix is to adjust the native host/theme so all non-immersive routes render inside the system-safe area with readable bar contrast, rather than hacking individual pages.

### Description
- Restored explicit non-immersive behavior in the host activity by updating `MainActivity.clearImmersiveMode()` to set status/navigation bar colors, and to apply light-bar appearances on modern APIs (`android/app/src/main/java/com/orderfast/app/MainActivity.java`).
- Added system-bar related theme attributes to the app theme so the host activity draws system bar backgrounds and opts out of Android 15 edge-to-edge enforcement (`android/app/src/main/res/values/styles.xml`).
- Set the activity root background color to match the app surface to avoid visual seams around system bars (`android/app/src/main/res/layout/activity_main.xml`).
- This change is global and limited to the native shell because the problem originates in the Capacitor host activity + theme which affects all web routes; immersive/owner fullscreen behavior for kiosk/KOD/POS routes is preserved.
- How to manually verify on device/emulator: install the build and check a normal route (e.g. `/login` or dashboard) that content no longer sits under the top status bar or bottom navigation bar, confirm bar icons remain readable, then navigate into immersive owner routes (`/kiosk`, `/kod`, or opt-in `/pos`) and confirm full-screen immersive still works and that returning to normal routes restores the non-immersive safe layout; test with both gesture navigation and 3-button navigation modes.

### Testing
- Attempted automated build: ran `./gradlew :app:assembleDebug` (Android build attempted in CI/dev environment) and it failed due to environment constraints (SDK location not configured; missing `ANDROID_HOME` / `local.properties`), so a local/device build is required to produce an APK.
- No other automated JS unit tests were modified or run as part of this change; code-level inspection confirms only native host files were changed and TypeScript/Next code was not altered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef1ab4e8488325b3aa43c03ffe3341)